### PR TITLE
COM analysis: Handle no mask radius correctly

### DIFF
--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -65,10 +65,10 @@ class COMAnalysis(BaseMasksAnalysis):
                 imageSizeX=frame_size[1],
                 imageSizeY=frame_size[0],
                 dtype=self.dtype,
-            ) * (np.ones(frame_size) * disk_mask()),
+            ) * disk_mask(),
             lambda: masks.gradient_y(
                 imageSizeX=frame_size[1],
                 imageSizeY=frame_size[0],
                 dtype=self.dtype,
-            ) * (np.ones(frame_size) * disk_mask()),
+            ) * disk_mask(),
         ]

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -141,7 +141,7 @@ class Context:
             mask out intensity outside of mask_radius from (cy, cx)
         """
         if mask_radius is None:
-            mask_radius = max(dataset.shape[2:])
+            mask_radius = float('inf')
         analysis = COMAnalysis(
             dataset=dataset,
             parameters={


### PR DESCRIPTION
The mask radius should be set to float('inf') if it is not given
to handle any specified center point point correctly and never cut
off any part of the frame.

Additionally, remove the unnecessary multiplication with ones
when generating the COM masks.