### PR TITLE
Portable way to determine file owner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy
 distributed
 numba
 psutil
+pypiwin32;sys_platform == 'Windows'
 
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ setup(
         "h5py",
         "psutil",
         "numba",
+        'pypiwin32;platform_system=="Windows"'
     ],
     extras_require={
         'hdfs': 'hfds3',

--- a/src/libertem/io/utils.py
+++ b/src/libertem/io/utils.py
@@ -1,0 +1,9 @@
+try:
+    import pwd
+
+    def get_owner_name(full_path, stat):
+        return pwd.getpwuid(stat.st_uid).pw_name
+# Assume that we are on Windows
+# TODO do a proper abstraction layer if this simple solution doesn't work anymore
+except ModuleNotFoundError:
+    from libertem.win_tweaks import get_owner_name  # noqa: F401

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -22,7 +22,7 @@ from libertem.analysis import (
     DiskMaskAnalysis, RingMaskAnalysis, PointMaskAnalysis,
     COMAnalysis, SumAnalysis, PickFrameAnalysis
 )
-from libertem.win_tweaks import get_owner_name
+from libertem.io.utils import get_owner_name
 
 
 log = logging.getLogger(__name__)

--- a/src/libertem/win_tweaks.py
+++ b/src/libertem/win_tweaks.py
@@ -3,19 +3,14 @@ import msvcrt
 import ctypes
 from ctypes import windll, wintypes, byref
 
-try:
-    import pwd
+import win32security
 
-    def get_owner_name(full_path, stat):
-        return pwd.getpwuid(stat.st_uid).pwname
-except ModuleNotFoundError:
-    import win32security
 
-    def get_owner_name(full_path, stat):
-        s = win32security.GetFileSecurity(full_path, win32security.OWNER_SECURITY_INFORMATION)
-        sid = s.GetSecurityDescriptorOwner()
-        (name, domain, t) = win32security.LookupAccountSid(None, sid)
-        return "%s\\%s" % (domain, name)
+def get_owner_name(full_path, stat):
+    s = win32security.GetFileSecurity(full_path, win32security.OWNER_SECURITY_INFORMATION)
+    sid = s.GetSecurityDescriptorOwner()
+    (name, domain, t) = win32security.LookupAccountSid(None, sid)
+    return "%s\\%s" % (domain, name)
 
 
 ENABLE_QUICK_EDIT = 0x0040

--- a/src/libertem/win_tweaks.py
+++ b/src/libertem/win_tweaks.py
@@ -3,6 +3,20 @@ import msvcrt
 import ctypes
 from ctypes import windll, wintypes, byref
 
+try:
+    import pwd
+
+    def get_owner_name(full_path, stat):
+        return pwd.getpwuid(stat.st_uid).pwname
+except ModuleNotFoundError:
+    import win32security
+
+    def get_owner_name(full_path, stat):
+        s = win32security.GetFileSecurity(full_path, win32security.OWNER_SECURITY_INFORMATION)
+        sid = s.GetSecurityDescriptorOwner()
+        (name, domain, t) = win32security.LookupAccountSid(None, sid)
+        return "%s\\%s" % (domain, name)
+
 
 ENABLE_QUICK_EDIT = 0x0040
 ENABLE_EXTENDED_FLAGS = 0x0080

--- a/tests/test_fileowner.py
+++ b/tests/test_fileowner.py
@@ -1,6 +1,6 @@
 import os
 
-from libertem.win_tweaks import get_owner_name
+from libertem.io.utils import get_owner_name
 
 
 def test_get_owner_name():

--- a/tests/test_fileowner.py
+++ b/tests/test_fileowner.py
@@ -1,0 +1,9 @@
+import os
+
+from libertem.win_tweaks import get_owner_name
+
+
+def test_get_owner_name():
+    owner = get_owner_name(__file__, os.stat(__file__))
+    assert isinstance(owner, str)
+    assert len(owner) > 0


### PR DESCRIPTION
The pwd module is not available on Windows and uid and gid are 0 in
stat. Implement a platform-independent function in win_tweaks.py and
restructure the listing code since we need the full path to determine
an owner on Windows.

Make pypywin32 a platform-dependent dependency for Windows to support
listing the owner.