### PR TITLE
Catch an exception on Windows and handle it gracefully

### DIFF
--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -719,10 +719,15 @@ class LocalFSBrowseHandler(tornado.web.RequestHandler):
             full_path = os.path.join(path, name)
             try:
                 s = os.stat(full_path)
-                owner = get_owner_name(full_path, s)
             except FileNotFoundError:
                 # this can happen either because of a TOCTOU-like race condition
                 # or for example for things like broken softlinks
+                continue
+            try:
+                owner = get_owner_name(full_path, s)
+            except IOError:  # only from win_tweaks.py version
+                owner = "<Unknown>"
+            except FileNotFoundError:  # only from win_tweaks.py version
                 continue
             res = {"name": name, "stat": s, "owner": owner}
             if stat.S_ISDIR(s.st_mode):

--- a/src/libertem/win_tweaks.py
+++ b/src/libertem/win_tweaks.py
@@ -4,13 +4,17 @@ import ctypes
 from ctypes import windll, wintypes, byref
 
 import win32security
+import pywintypes
 
 
 def get_owner_name(full_path, stat):
-    s = win32security.GetFileSecurity(full_path, win32security.OWNER_SECURITY_INFORMATION)
-    sid = s.GetSecurityDescriptorOwner()
-    (name, domain, t) = win32security.LookupAccountSid(None, sid)
-    return "%s\\%s" % (domain, name)
+    try:
+        s = win32security.GetFileSecurity(full_path, win32security.OWNER_SECURITY_INFORMATION)
+        sid = s.GetSecurityDescriptorOwner()
+        (name, domain, t) = win32security.LookupAccountSid(None, sid)
+        return "%s\\%s" % (domain, name)
+    except pywintypes.error as e:
+        raise IOError(e)
 
 
 ENABLE_QUICK_EDIT = 0x0040


### PR DESCRIPTION
Attempting to determine the owner of files like C:\pagefile.sys
on Windows triggers an "Access is denied" error.

* Transform the specific Windows exception to a general IOError
in win_tweaks.py
* Handle the IOError gracefully in web/server.py