### PR TITLE
Support using an external local dask cluster

### DIFF
--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -17,8 +17,10 @@ class CommonDaskMixin(object):
         futures = []
         for task in job.get_tasks():
             submit_kwargs = {}
-            if not self.is_local:
-                submit_kwargs['workers'] = task.get_locations()
+            locations = task.get_locations()
+            if locations is not None and len(locations) == 0:
+                raise ValueError("no workers found for task")
+            submit_kwargs['workers'] = locations
             futures.append(
                 self.client.submit(task, **submit_kwargs)
             )

--- a/src/libertem/io/dataset/base.py
+++ b/src/libertem/io/dataset/base.py
@@ -80,7 +80,8 @@ class Partition(object):
         raise NotImplementedError()
 
     def get_locations(self):
-        raise NotImplementedError()
+        # Allow using any worker by default
+        return None
 
 
 class DataTile(object):

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -140,6 +140,3 @@ class BloPartition(Partition):
                     data=data[tile_slice.get()],
                     tile_slice=tile_slice
                 )
-
-    def get_locations(self):
-        return "127.0.1.1"  # FIXME

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -147,6 +147,3 @@ class H5Partition(Partition):
                     # reuse buffer
                     dataset.read_direct(data, source_sel=tile_slice.get())
                     yield DataTile(data=data, tile_slice=tile_slice)
-
-    def get_locations(self):
-        return "127.0.1.1"  # FIXME

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -612,9 +612,6 @@ class K2ISPartition(Partition):
         finally:
             s.close()
 
-    def get_locations(self):
-        return "127.0.1.1"  # FIXME
-
     def __repr__(self):
         return "<K2ISPartition: sector %d, start_frame=%d, num_frames=%d>" % (
             self._get_sector().idx, self._start_frame, self._num_frames,

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -251,6 +251,3 @@ class MIBPartition(Partition):
                     continue
             self.partfile.read_frames(num=stackheight, offset=t * stackheight, out=data)
             yield DataTile(data=data, tile_slice=tile_slice)
-
-    def get_locations(self):
-        return "127.0.1.1"  # FIXME

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -83,6 +83,3 @@ class RawFilePartition(Partition):
                 data=f[tile_slice.get()],
                 tile_slice=tile_slice
             )
-
-    def get_locations(self):
-        return "127.0.1.1"  # FIXME


### PR DESCRIPTION
Change the default behavior of `get_location()` to return `None`.
dask interprets this as "any worker".

Use `get_location()` independent of `is_local`. Verify that it is either
"None" or not empty. (thx @sk1p!)

Remove the non-functional get_locations() implementations from the
subclasses. "127.0.0.1" doesn't always work as a default identifier.

The remaining purpose of is_local is to determine if we should tidy
up the cluster or leave it running.