### PR TITLE
Experimental subprocess launch method for cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - pip install tox
 
 env:
-  - LT_RUN_FUNCTIONAL=1
+  global:
+    - LT_RUN_FUNCTIONAL=1
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ script:
 install:
   - pip install tox
 
+env:
+  - LT_RUN_FUNCTIONAL=1
+
 jobs:
   include:
     - stage: test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 build: false
 environment:
+  LT_RUN_FUNCTIONAL: "1"
   matrix:
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.5"

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -30,6 +30,22 @@ Or specify a specific environment you want to run:
 
     $ tox -e py36
 
+Long-running tests such as starting a real local dask cluster are only executed if the environment variable `LT_RUN_FUNCTIONAL` is set. This 
+
+With bash:
+
+.. code-block:: shell
+
+    $ LT_RUN_FUNCTIONAL=1 tox
+
+With Windows cmd:
+
+.. code-block:: shell
+
+    > set LT_RUN_FUNCTIONAL=1
+    > tox
+
+
 On Windows
 ~~~~~~~~~~
 

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -753,12 +753,14 @@ class LocalFSBrowseHandler(tornado.web.RequestHandler):
                 # this can happen either because of a TOCTOU-like race condition
                 # or for example for things like broken softlinks
                 continue
+
             try:
                 owner = get_owner_name(full_path, s)
-            except IOError:  # only from win_tweaks.py version
-                owner = "<Unknown>"
             except FileNotFoundError:  # only from win_tweaks.py version
                 continue
+            except IOError:  # only from win_tweaks.py version
+                owner = "<Unknown>"
+
             res = {"name": name, "stat": s, "owner": owner}
             if stat.S_ISDIR(s.st_mode):
                 dirs.append(res)

--- a/tests/io/test_detect.py
+++ b/tests/io/test_detect.py
@@ -1,8 +1,8 @@
 from libertem.io.dataset import detect
 
 
-def test_detection_empty_hdf5(hdf5):
-    fn = hdf5.filename
+def test_detection_empty_hdf5(empty_hdf5):
+    fn = empty_hdf5.filename
     params = detect(fn)
     assert params != {}
     assert list(params.keys()) == ["path", "type"]

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -1,0 +1,44 @@
+import os
+
+import numpy as np
+import pytest
+
+from libertem import api
+from utils import _naive_mask_apply
+
+@pytest.mark.skipif('LT_RUN_FUNCTIONAL' not in os.environ, reason="Takes a long time")
+def test_start_local(hdf5_ds_1):
+    mask = np.random.choice(a=[0, 1], size=(16, 16))
+    with hdf5_ds_1.get_h5ds() as h5ds:
+        data = h5ds[:]
+        expected = _naive_mask_apply([mask], data)
+
+    with api.Context() as ctx:
+        analysis = ctx.create_mask_analysis(
+            dataset=hdf5_ds_1, factories=[lambda: mask]
+        )
+        results = ctx.run(analysis)
+
+    assert np.allclose(
+        results.mask_0.raw_data,
+        expected
+    )
+
+@pytest.mark.skipif('LT_RUN_FUNCTIONAL' not in os.environ, reason="Takes a long time")
+def test_subprocess_start_local(lt_ctx, hdf5_ds_1):
+    mask = np.random.choice(a=[0, 1], size=(16, 16))
+    with hdf5_ds_1.get_h5ds() as h5ds:
+        data = h5ds[:]
+        expected = _naive_mask_apply([mask], data)
+
+    with api.subprocess_create_executor() as ex:
+        ctx = api.Context(ex)
+        analysis = ctx.create_mask_analysis(
+            dataset=hdf5_ds_1, factories=[lambda: mask]
+        )
+        results = ctx.run(analysis)
+
+    assert np.allclose(
+        results.mask_0.raw_data,
+        expected
+    )

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -5,6 +5,7 @@ import pytest
 
 from libertem import api
 from utils import _naive_mask_apply
+from libertem.executor.dask import DaskJobExecutor
 
 @pytest.mark.skipif('LT_RUN_FUNCTIONAL' not in os.environ, reason="Takes a long time")
 def test_start_local(hdf5_ds_1):
@@ -25,7 +26,7 @@ def test_start_local(hdf5_ds_1):
     )
 
 @pytest.mark.skipif('LT_RUN_FUNCTIONAL' not in os.environ, reason="Takes a long time")
-def test_subprocess_start_local(lt_ctx, hdf5_ds_1):
+def test_subprocess_start_local(hdf5_ds_1):
     mask = np.random.choice(a=[0, 1], size=(16, 16))
     with hdf5_ds_1.get_h5ds() as h5ds:
         data = h5ds[:]
@@ -42,3 +43,21 @@ def test_subprocess_start_local(lt_ctx, hdf5_ds_1):
         results.mask_0.raw_data,
         expected
     )
+
+@pytest.mark.skipif('LT_RUN_FUNCTIONAL' not in os.environ, reason="Takes a long time")
+def test_subprocess_errorhandling():
+    # Include an argument that makes dask LocalCluster trip
+    cluster_kwargs = {
+        "threads_per_worker": 1,
+        "n_workers": 2,
+        "breakme": "die die die"
+    }
+    try:
+        with DaskJobExecutor.subprocess_make_local(cluster_kwargs=cluster_kwargs) as ex:
+            # This should not be reached
+            ctx = api.Context(ex)
+    except Exception as e:
+        text = e.args[0]
+
+    # We make sure we get the expected error message
+    assert "Starting subprocess failed." in text

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ commands=
     pytest --cov=libertem --cov-report=term --cov-report=html --cov-report=xml {posargs:tests/}
 deps=
     -rrequirements.txt
+passenv=
+    LT_RUN_FUNCTIONAL
 
 [testenv:flake8]
 changedir={toxinidir}


### PR DESCRIPTION
The regular startup method for a local dask cluster doesn't work
from within Digital Micrograph 3.40 beta. The new code introduces an
alternative launch method via the subprocess module.

In order to make it safe and convenient to use, include support for
context manager. Within Digital Micrograph 3.40 beta it is important to
tidy up after a script because the embedded interpreter continues to run.
A running dask cluster subprocess would block Digital Micrograph.

TODO Verify handling of all possible error states in launcher
TODO Unix compatibility: Existence of "pythonw" vs "python"
TODO Raise issue with dask/distributed if dask should use a different
launch method for local clusters that works from within embedded interpreters
TODO Proper example, tests and documentation