### PR TITLE
[skip ci] Bug reproducer for incorrect data shape

### DIFF
--- a/prototypes/digitalmicrograph/components.py
+++ b/prototypes/digitalmicrograph/components.py
@@ -1,30 +1,20 @@
-import inspect
-
 import numpy as np
 
-changed = False
 
 class EventHandler(DM.Py_ScriptObject):
 
-        
-    def HandleComponentChangedEvent(self, img_disp_event_flags, img_disp, component_change_flag, component_disp_change_flags, component):
-        changed = True
-        print(changed)
+    def HandleComponentChangedEvent(self, img_disp_event_flags, img_disp, 
+            component_change_flag, component_disp_change_flags, component):
+        print("changed")
+
 
 z = np.zeros((100, 100))
 
 image = DM.CreateImage(z)
 
 doc = DM.NewImageDocument("test document")
-
-
-
-r = doc.GetRootComponent()
-
 d = doc.AddImageDisplay(image, 1)
-
 c = d.AddNewComponent(5, 40, 40, 60, 60)
-
 c.SetForegroundColor(1, 0, 0)
 
 listener = EventHandler()

--- a/prototypes/digitalmicrograph/datashape.py
+++ b/prototypes/digitalmicrograph/datashape.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+data = np.array(((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12)))
+
+image = DM.CreateImage(data)
+image.ShowImage()
+
+buffer = image.GetNumArray()
+
+if (buffer == data):
+    print("original data and image buffer are the same")
+else:
+    print("original data and image buffer are different")
+    print("Shape of data: ", data.shape)
+    print("Shape of buffer: ", buffer.shape)
+    print("Data:")
+    print(data)
+    print("Buffer:")
+    print(buffer)

--- a/prototypes/digitalmicrograph/digital-micrograph-async.py
+++ b/prototypes/digitalmicrograph/digital-micrograph-async.py
@@ -77,11 +77,20 @@ async def async_main(address):
     
     executor = await AsyncDaskJobExecutor.connect(address)
 
+    #ds = load(
+    #    "blo",
+    #    path=("C:/Users/weber/Nextcloud/Projects/Open Pixelated STEM framework/"
+    #    "Data/3rd-Party Datasets/Glasgow/10 um 110.blo"),
+    #    tileshape=(1,8,144,144)
+    #)
+
     ds = load(
-        "blo",
-        path=("C:/Users/weber/Nextcloud/Projects/Open Pixelated STEM framework/"
-        "Data/3rd-Party Datasets/Glasgow/10 um 110.blo"),
-        tileshape=(1,8,144,144)
+        "raw",
+        path = '/data/users/weber/scan_11_x256_y256.raw',
+        dtype = "float32",
+        scan_size = (256, 256),
+        detector_size_raw = (130, 128),
+        crop_detector_to = (128, 128)
     )
 
     sum_job = SumFramesJob(dataset=ds)
@@ -149,17 +158,17 @@ def main():
         "n_workers": cores
     }
 
-    cluster = dd.LocalCluster(**cluster_kwargs)
+    #cluster = dd.LocalCluster(**cluster_kwargs)
     loop = asyncio.get_event_loop()
-
+    address = 'tcp://localhost:31313'
     try:
         # (can be replaced with asyncio.run(coro) in Python 3.7)
-        loop.run_until_complete(async_main(cluster.scheduler_address))
+        loop.run_until_complete(async_main(address))
         
     finally:
         # loop.close()
         print("Close cluster")
-        cluster.close()
+        #cluster.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Somewhere somehow the dimensions are mixed up when Digital Micrograph
constructs the image buffer numpy array.

Current workaround is a reshape of the data when writing into the buffer

This will likely change in the future when this is corrected.