### PR TITLE
Use '/' as universal path separator.

### DIFF
--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -518,7 +518,8 @@ class SharedData(object):
             "revision": libertem.revision,
             "localCores": self.get_local_cores(),
             "cwd": os.getcwd(),
-            "separator": os.sep,
+            # '/' works on Windows, too.
+            "separator": '/'
         }
 
     def get_executor(self):


### PR DESCRIPTION
Allow mixing Linux and Windows for dask cluster and libertem-server, fixes #210

With Python, '/' works on Windows as a path separator, too.

Question: Should one do some kind of logic with [os.altsep](https://docs.python.org/3/library/os.html#os.altsep) and/or asking the cluster, or do '/' and be done with it? I'd favor '/' until we have a specific case where that breaks.