### PR TITLE
Preloading for some modules

### DIFF
--- a/src/libertem/preload.py
+++ b/src/libertem/preload.py
@@ -1,0 +1,19 @@
+# This module pre-loads modules that can have a long load time.
+# To be used to avoid https://github.com/LiberTEM/LiberTEM/issues/218
+# where loading modules makes workers unresponsive for too long.
+# Usage: dask-worker [...] --preload libertem.preload [...]
+
+# Disable flake8 because we import a lot of modules without using them.
+
+# flake8: noqa
+
+import numpy
+import scipy.sparse
+from matplotlib import colors, cm
+
+try:
+    import torch
+except ImportError:
+    pass
+
+import libertem

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,6 +14,7 @@ import libertem.job.sum
 import libertem.web.server
 import libertem.web.cli
 import libertem.api
+import libertem.preload
 
 
 def test_stuff():


### PR DESCRIPTION
Loading modules as part of job execution can make dask workers
unresponsive for too long. This module allows pre-loading any offenders
at the time a worker starts up.

Usage:
dask-worker [...] --preload libertem.preload [...]

Fixes #218