### PR TITLE
Set log level to WARNING in example

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 
 from libertem import api
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.WARNING)
 
 
 # Protect the entry point.


### PR DESCRIPTION
The DEBUG output is too verbose as a default setting.