### PR TITLE
Fix broken links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,5 +196,8 @@ intersphinx_mapping = {
 # Sphinx' link checker.
 linkcheck_ignore = [
     # Local URLs:
-    r'^http://localhost.*'
+    r'^http://localhost.*',
+    # Temporary workaround for user agent filtering at fz-juelich.de
+    # FIXME check if this persists and remove if possible
+    r'^http://.*.fz-juelich.de.*'
 ]

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -56,7 +56,7 @@ Using conda
 If you are already using conda, or if you don't have a system-wide Python 3.6 installation,
 you can create a conda environment for LiberTEM.
 
-This section assumes that you have `installed conda <https://conda.io/docs/user-guide/install/index.html#regular-installation>`_
+This section assumes that you have `installed conda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html#regular-installation>`_
 and that your installation is working.
 
 You can create a new conda environment to install LiberTEM with the following command:
@@ -80,7 +80,7 @@ Afterwards, your shell prompt should be prefixed with `(libertem)` to indicate t
 Now the environment is ready to install LiberTEM.
     
 For more information about conda, see their `documentation about 
-creating and managing environments <https://conda.io/docs/user-guide/tasks/manage-environments.html>`_.
+creating and managing environments <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_.
 
 Installing from PyPi
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Conda documentation has moved

fz-juelich.de filters the user agent string since recently. I asked them to stop filtering. Until then, fz-juelich.de is on the ignore list of the link checker as a workaround.

Refs #243 