### PR TITLE
Include workaround for sys.argv issue

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -126,7 +126,17 @@ For a full API reference, please see :doc:`Reference <reference>`.
 From an embedded interpreter
 ----------------------------
 
-If LiberTEM is run from within an embedded interpreter, the `correct executable for spawning subprocesses <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_executable>`_ has to be set. This is necessary for Python scripting in Digital Micrograph, for example.
+If LiberTEM is run from within an embedded interpreter, the following steps should be taken. This is necessary for Python scripting in Digital Micrograph, for example.
+
+The variable :code:`sys.argv` `may not be set in embedded interpreters <https://bugs.python.org/issue32573>`_, but it is expected by the :code:`multiprocessing` module when spawning new processes. This workaround guarantees that :code:`sys.argv` is set `until this is fixed upstream <https://github.com/python/cpython/pull/12463>`_:
+
+.. code-block:: python
+    
+    if not hasattr(sys, 'argv'):
+        sys.argv  = []
+
+
+Furthermore, the `correct executable for spawning subprocesses <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_executable>`_ has to be set. 
 
 .. code-block:: python
     


### PR DESCRIPTION
sys.argv is not set in embedded interpreters https://bugs.python.org/issue32573

This workaround avoids trouble in the multiprocessing module. https://github.com/python/cpython/pull/12463