### PR TITLE
Update Python version used for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,17 @@ jobs:
       dist: xenial
       sudo: true
     - stage: test
-      python: 3.6
+      python: 3.7
       env: TOXENV=flake8
+      sudo: true
     - stage: test
-      python: 3.6
+      python: 3.7
       env: TOXENV=qa
+      sudo: true
     - stage: test
-      python: 3.6
-      env: TOXENV=docs-deploy
+      python: 3.7
+      env: TOXENV=docs-check
+      sudo: true
     - stage: test
       language: node_js
       node_js:
@@ -41,6 +44,11 @@ jobs:
       script:
         - (cd client && npm run build)
         - (cd client && npm test -- --coverage)
+
+    - stage: packaging
+      python: 3.7
+      env: TOXENV=docs-deploy
+      sudo: true
 
     - stage: packaging
       sudo: require

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,27 @@ after_success:
 jobs:
   include:
     - stage: test
-      python: 3.6
       env: TOXENV=py36
+      python: 3.6
     - stage: test
-      python: 3.7
       env: TOXENV=py37
+      python: 3.7
       dist: xenial
       sudo: true
     - stage: test
-      python: 3.7
       env: TOXENV=flake8
+      python: 3.7
+      dist: xenial
       sudo: true
     - stage: test
-      python: 3.7
       env: TOXENV=qa
+      dist: xenial
+      python: 3.7
       sudo: true
     - stage: test
-      python: 3.7
       env: TOXENV=docs-check
+      python: 3.7
+      dist: xenial
       sudo: true
     - stage: test
       language: node_js
@@ -46,8 +49,9 @@ jobs:
         - (cd client && npm test -- --coverage)
 
     - stage: packaging
-      python: 3.7
       env: TOXENV=docs-deploy
+      python: 3.7
+      dist: xenial
       sudo: true
 
     - stage: packaging

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands=
 
 [testenv:docs]
 changedir={toxinidir}
-basepython=python3.6
+basepython=python3.7
 whitelist_externals=
     make
 setenv=
@@ -53,11 +53,10 @@ skipsdist=True
 
 [testenv:docs-deploy]
 changedir={toxinidir}
-basepython=python3.6
+basepython=python3.7
 setenv=
     PYTHONPATH={toxinidir}
 commands=
-    sphinx-build -b linkcheck "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
     travis-sphinx build
     travis-sphinx deploy
 deps=
@@ -67,3 +66,18 @@ skipsdist=True
 passenv=
     GH_*
     TRAVIS_*
+
+[testenv:docs-check]
+changedir={toxinidir}
+basepython=python3.7
+setenv=
+    PYTHONPATH={toxinidir}
+commands=
+    sphinx-build -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
+    sphinx-build -b linkcheck "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
+    cat docs/build/html/output.txt
+deps=
+    sphinx
+skipsdist=True
+whitelist_externals=
+    cat


### PR DESCRIPTION
flake8, qa, doc building etc. should also work with Python 3.7. This is a draft PR to check if CI goes through without breaking the master build again...