### PR TITLE
Example for performance effect of tiling numpy operations

### DIFF
--- a/prototypes/map-reduce-comparison/tiled-performance.ipynb
+++ b/prototypes/map-reduce-comparison/tiled-performance.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = 64\n",
+    "f = 128\n",
+    "\n",
+    "data = np.random.rand(s, s, f, f).astype(np.float32)\n",
+    "\n",
+    "mask_1 = np.zeros(shape=(f, f), dtype=np.float32)\n",
+    "mask_1[(f * 5) // 10:(f * 6) // 10, (f * 2) // 10:(f * 3)// 10] = 1\n",
+    "boolean_mask_1 = mask_1 == 1\n",
+    "\n",
+    "mask_2 = np.zeros(shape=(f, f), dtype=np.float32)\n",
+    "mask_2[(f * 2) // 10:(f * 7) // 10, (f * 1) // 10:(f * 8)// 10] = 1\n",
+    "boolean_mask_2 = mask_2 == 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_1 = np.zeros(shape=(s*s), dtype=np.float32)\n",
+    "result_2 = np.zeros(shape=(s*s), dtype=np.float32)\n",
+    "\n",
+    "data_list = data.reshape((-1, f, f))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "29.2 ms ± 1.17 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "1.07 s ± 42.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit result_1[:] = data_list[:, boolean_mask_1].std(axis=1)\n",
+    "\n",
+    "%timeit result_2[:] = data_list[:, boolean_mask_2].std(axis=1)\n",
+    "\n",
+    "true_result_1 = result_1.copy()\n",
+    "true_result_2 = result_2.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "503 ms ± 32.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n",
+      "814 ms ± 33.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def single(result, data_list, boolean_mask):\n",
+    "    for i in range(len(result)):\n",
+    "        view = data_list[i, boolean_mask]\n",
+    "        result[i] = view.std()\n",
+    "\n",
+    "result_1[:] = np.zeros(shape=(s*s), dtype=np.float32)\n",
+    "result_2[:] = np.zeros(shape=(s*s), dtype=np.float32)\n",
+    "        \n",
+    "%timeit single(result_1, data_list, boolean_mask_1)\n",
+    "%timeit single(result_2, data_list, boolean_mask_2)\n",
+    "\n",
+    "assert np.allclose(result_1, true_result_1)\n",
+    "assert np.allclose(result_2, true_result_2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "28.6 ms ± 1.42 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "519 ms ± 52.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def tiled(result, data_list, boolean_mask, tilesize):\n",
+    "    repeats = len(result) // tilesize\n",
+    "    tail = len(result) % tilesize\n",
+    "    for i in range(repeats):\n",
+    "        result[i*tilesize:(i+1)*tilesize] = data_list[i*tilesize:(i+1)*tilesize, boolean_mask].std(axis=1)\n",
+    "    if tail != 0:\n",
+    "        result[-tail:] = data_list[-tail:, boolean_mask].std(axis=1)\n",
+    "\n",
+    "result_1[:] = np.zeros(shape=(s*s), dtype=np.float32)\n",
+    "result_2[:] = np.zeros(shape=(s*s), dtype=np.float32)\n",
+    "        \n",
+    "%timeit tiled(result_1, data_list, boolean_mask_1, 32)\n",
+    "%timeit tiled(result_2, data_list, boolean_mask_2, 32)\n",
+    "\n",
+    "assert np.allclose(result_1, true_result_1)\n",
+    "assert np.allclose(result_2, true_result_2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The difference is a result of balancing overheads from
fine-grained loops with gains from working on data that fits
the L3 cache.

Fancy indexing with the boolean mask creates a copy. If the
copy fits the L3 cache, the subsequent calculation of std()
can use the data from the L3 cache, which is much faster.

This example shows how we should implement per-tile UDFs #310 in
order to reap the benefits of this, in particular for operations
that are limited by memory transfer. std() is such an operation.