### PR TITLE
Use sparse.pydata.org

### DIFF
--- a/prototypes/sparse-comparison/performance-recompilation.ipynb
+++ b/prototypes/sparse-comparison/performance-recompilation.ipynb
@@ -1,0 +1,515 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sparse\n",
+    "import numba\n",
+    "import numpy as np\n",
+    "import dask.distributed as dd\n",
+    "import libertem.api as lt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = dd.Client(n_workers=2, threads_per_worker=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def do_numpy():\n",
+    "    a = np.arange(1024*1024, dtype=np.float32)\n",
+    "    return np.dot(a, a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@numba.njit\n",
+    "def do_numba():\n",
+    "    result = 0.\n",
+    "    for i in range(1024*1024):\n",
+    "        result += i**2\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def do_sparse():\n",
+    "    a = sparse.COO.from_numpy(np.arange(1024*1024, dtype=np.float32))\n",
+    "    return sparse.dot(a, a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%time do_numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%time do_numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%time do_numba()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%time do_numba()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%time do_sparse()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%time do_sparse()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 296 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f = client.submit(do_numpy)\n",
+    "%time f.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 23 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f = client.submit(do_numpy)\n",
+    "%time f.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 1.37 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066184463922e+17"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f = client.submit(do_numba)\n",
+    "%time f.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 27 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066184463922e+17"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f = client.submit(do_numba)\n",
+    "%time f.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 9.26 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f = client.submit(do_sparse)\n",
+    "%time f.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 70 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f = client.submit(do_sparse)\n",
+    "%time f.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctx = lt.Context()\n",
+    "ds = ctx.load(\n",
+    "    \"blo\",\n",
+    "    path='C:/Users/weber/Nextcloud/Projects/Open Pixelated STEM framework/Data/3rd-party Datasets/Glasgow/10 um 110.blo',\n",
+    "    tileshape=(1,8,144,144)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis_sparse_1 = ctx.create_disk_analysis(dataset=ds, r=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 6.15 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(analysis_sparse_1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 1.61 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(analysis_sparse_1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis_sparse_2 = ctx.create_disk_analysis(dataset=ds, r=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 1.6 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(analysis_sparse_2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 1.61 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(analysis_sparse_2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis_dense = ctx.create_disk_analysis(dataset=ds, r=256)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 2.06 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(analysis_dense)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 2.53 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(analysis_dense)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/prototypes/sparse-comparison/performance-recompilation.ipynb
+++ b/prototypes/sparse-comparison/performance-recompilation.ipynb
@@ -10,7 +10,8 @@
     "import numba\n",
     "import numpy as np\n",
     "import dask.distributed as dd\n",
-    "import libertem.api as lt"
+    "import libertem.api as lt\n",
+    "import libertem.masks as masks"
    ]
   },
   {
@@ -62,54 +63,162 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 8 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#%time do_numpy()"
+    "%time do_numpy()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 12 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#%time do_numpy()"
+    "%time do_numpy()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 568 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066184463922e+17"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#%time do_numba()"
+    "%time do_numba()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 0 ns\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066184463922e+17"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#%time do_numba()"
+    "%time do_numba()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 7.24 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#%time do_sparse()"
+    "%time do_sparse()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 780 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3.843066e+17"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#%time do_sparse()"
+    "%time do_sparse()"
    ]
   },
   {
@@ -121,7 +230,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 296 ms\n"
+      "Wall time: 256 ms\n"
      ]
     },
     {
@@ -149,7 +258,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 23 ms\n"
+      "Wall time: 28 ms\n"
      ]
     },
     {
@@ -177,7 +286,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 1.37 s\n"
+      "Wall time: 952 ms\n"
      ]
     },
     {
@@ -205,7 +314,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 27 ms\n"
+      "Wall time: 28 ms\n"
      ]
     },
     {
@@ -233,7 +342,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 9.26 s\n"
+      "Wall time: 6.48 s\n"
      ]
     },
     {
@@ -261,7 +370,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 70 ms\n"
+      "Wall time: 32 ms\n"
      ]
     },
     {
@@ -312,7 +421,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 6.15 s\n"
+      "Wall time: 4.07 s\n"
      ]
     },
     {
@@ -339,7 +448,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 1.61 s\n"
+      "Wall time: 1.09 s\n"
      ]
     },
     {
@@ -375,7 +484,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 1.6 s\n"
+      "Wall time: 1.16 s\n"
      ]
     },
     {
@@ -402,7 +511,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 1.61 s\n"
+      "Wall time: 1.06 s\n"
      ]
     },
     {
@@ -438,7 +547,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 2.06 s\n"
+      "Wall time: 1.45 s\n"
      ]
     },
     {
@@ -465,7 +574,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 2.53 s\n"
+      "Wall time: 1.1 s\n"
      ]
     },
     {
@@ -485,10 +594,90 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "fy, fx = ds.shape.sig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_stack = [\n",
+    "    lambda: masks.circular(centerY=(i%fy), centerX=i%fx, imageSizeY=fy, imageSizeX=fx, radius=2)\n",
+    "    for i in range(1000)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_analysis_sparse = ctx.create_mask_analysis(dataset=ds, factories=mask_stack, use_sparse=True)\n",
+    "multi_analysis_dense = ctx.create_mask_analysis(dataset=ds, factories=mask_stack, use_sparse=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 14.1 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: mask_0>, <AnalysisResult: mask_1>, <AnalysisResult: mask_2>, <AnalysisResult: mask_3>, <AnalysisResult: mask_4>, <AnalysisResult: mask_5>, <AnalysisResult: mask_6>, <AnalysisResult: mask_7>, <AnalysisResult: mask_8>, <AnalysisResult: mask_9>, <AnalysisResult: mask_10>, <AnalysisResult: mask_11>, <AnalysisResult: mask_12>, <AnalysisResult: mask_13>, <AnalysisResult: mask_14>, <AnalysisResult: mask_15>, <AnalysisResult: mask_16>, <AnalysisResult: mask_17>, <AnalysisResult: mask_18>, <AnalysisResult: mask_19>, <AnalysisResult: mask_20>, <AnalysisResult: mask_21>, <AnalysisResult: mask_22>, <AnalysisResult: mask_23>, <AnalysisResult: mask_24>, <AnalysisResult: mask_25>, <AnalysisResult: mask_26>, <AnalysisResult: mask_27>, <AnalysisResult: mask_28>, <AnalysisResult: mask_29>, <AnalysisResult: mask_30>, <AnalysisResult: mask_31>, <AnalysisResult: mask_32>, <AnalysisResult: mask_33>, <AnalysisResult: mask_34>, <AnalysisResult: mask_35>, <AnalysisResult: mask_36>, <AnalysisResult: mask_37>, <AnalysisResult: mask_38>, <AnalysisResult: mask_39>, <AnalysisResult: mask_40>, <AnalysisResult: mask_41>, <AnalysisResult: mask_42>, <AnalysisResult: mask_43>, <AnalysisResult: mask_44>, <AnalysisResult: mask_45>, <AnalysisResult: mask_46>, <AnalysisResult: mask_47>, <AnalysisResult: mask_48>, <AnalysisResult: mask_49>, <AnalysisResult: mask_50>, <AnalysisResult: mask_51>, <AnalysisResult: mask_52>, <AnalysisResult: mask_53>, <AnalysisResult: mask_54>, <AnalysisResult: mask_55>, <AnalysisResult: mask_56>, <AnalysisResult: mask_57>, <AnalysisResult: mask_58>, <AnalysisResult: mask_59>, <AnalysisResult: mask_60>, <AnalysisResult: mask_61>, <AnalysisResult: mask_62>, <AnalysisResult: mask_63>, <AnalysisResult: mask_64>, <AnalysisResult: mask_65>, <AnalysisResult: mask_66>, <AnalysisResult: mask_67>, <AnalysisResult: mask_68>, <AnalysisResult: mask_69>, <AnalysisResult: mask_70>, <AnalysisResult: mask_71>, <AnalysisResult: mask_72>, <AnalysisResult: mask_73>, <AnalysisResult: mask_74>, <AnalysisResult: mask_75>, <AnalysisResult: mask_76>, <AnalysisResult: mask_77>, <AnalysisResult: mask_78>, <AnalysisResult: mask_79>, <AnalysisResult: mask_80>, <AnalysisResult: mask_81>, <AnalysisResult: mask_82>, <AnalysisResult: mask_83>, <AnalysisResult: mask_84>, <AnalysisResult: mask_85>, <AnalysisResult: mask_86>, <AnalysisResult: mask_87>, <AnalysisResult: mask_88>, <AnalysisResult: mask_89>, <AnalysisResult: mask_90>, <AnalysisResult: mask_91>, <AnalysisResult: mask_92>, <AnalysisResult: mask_93>, <AnalysisResult: mask_94>, <AnalysisResult: mask_95>, <AnalysisResult: mask_96>, <AnalysisResult: mask_97>, <AnalysisResult: mask_98>, <AnalysisResult: mask_99>, <AnalysisResult: mask_100>, <AnalysisResult: mask_101>, <AnalysisResult: mask_102>, <AnalysisResult: mask_103>, <AnalysisResult: mask_104>, <AnalysisResult: mask_105>, <AnalysisResult: mask_106>, <AnalysisResult: mask_107>, <AnalysisResult: mask_108>, <AnalysisResult: mask_109>, <AnalysisResult: mask_110>, <AnalysisResult: mask_111>, <AnalysisResult: mask_112>, <AnalysisResult: mask_113>, <AnalysisResult: mask_114>, <AnalysisResult: mask_115>, <AnalysisResult: mask_116>, <AnalysisResult: mask_117>, <AnalysisResult: mask_118>, <AnalysisResult: mask_119>, <AnalysisResult: mask_120>, <AnalysisResult: mask_121>, <AnalysisResult: mask_122>, <AnalysisResult: mask_123>, <AnalysisResult: mask_124>, <AnalysisResult: mask_125>, <AnalysisResult: mask_126>, <AnalysisResult: mask_127>, <AnalysisResult: mask_128>, <AnalysisResult: mask_129>, <AnalysisResult: mask_130>, <AnalysisResult: mask_131>, <AnalysisResult: mask_132>, <AnalysisResult: mask_133>, <AnalysisResult: mask_134>, <AnalysisResult: mask_135>, <AnalysisResult: mask_136>, <AnalysisResult: mask_137>, <AnalysisResult: mask_138>, <AnalysisResult: mask_139>, <AnalysisResult: mask_140>, <AnalysisResult: mask_141>, <AnalysisResult: mask_142>, <AnalysisResult: mask_143>, <AnalysisResult: mask_144>, <AnalysisResult: mask_145>, <AnalysisResult: mask_146>, <AnalysisResult: mask_147>, <AnalysisResult: mask_148>, <AnalysisResult: mask_149>, <AnalysisResult: mask_150>, <AnalysisResult: mask_151>, <AnalysisResult: mask_152>, <AnalysisResult: mask_153>, <AnalysisResult: mask_154>, <AnalysisResult: mask_155>, <AnalysisResult: mask_156>, <AnalysisResult: mask_157>, <AnalysisResult: mask_158>, <AnalysisResult: mask_159>, <AnalysisResult: mask_160>, <AnalysisResult: mask_161>, <AnalysisResult: mask_162>, <AnalysisResult: mask_163>, <AnalysisResult: mask_164>, <AnalysisResult: mask_165>, <AnalysisResult: mask_166>, <AnalysisResult: mask_167>, <AnalysisResult: mask_168>, <AnalysisResult: mask_169>, <AnalysisResult: mask_170>, <AnalysisResult: mask_171>, <AnalysisResult: mask_172>, <AnalysisResult: mask_173>, <AnalysisResult: mask_174>, <AnalysisResult: mask_175>, <AnalysisResult: mask_176>, <AnalysisResult: mask_177>, <AnalysisResult: mask_178>, <AnalysisResult: mask_179>, <AnalysisResult: mask_180>, <AnalysisResult: mask_181>, <AnalysisResult: mask_182>, <AnalysisResult: mask_183>, <AnalysisResult: mask_184>, <AnalysisResult: mask_185>, <AnalysisResult: mask_186>, <AnalysisResult: mask_187>, <AnalysisResult: mask_188>, <AnalysisResult: mask_189>, <AnalysisResult: mask_190>, <AnalysisResult: mask_191>, <AnalysisResult: mask_192>, <AnalysisResult: mask_193>, <AnalysisResult: mask_194>, <AnalysisResult: mask_195>, <AnalysisResult: mask_196>, <AnalysisResult: mask_197>, <AnalysisResult: mask_198>, <AnalysisResult: mask_199>, <AnalysisResult: mask_200>, <AnalysisResult: mask_201>, <AnalysisResult: mask_202>, <AnalysisResult: mask_203>, <AnalysisResult: mask_204>, <AnalysisResult: mask_205>, <AnalysisResult: mask_206>, <AnalysisResult: mask_207>, <AnalysisResult: mask_208>, <AnalysisResult: mask_209>, <AnalysisResult: mask_210>, <AnalysisResult: mask_211>, <AnalysisResult: mask_212>, <AnalysisResult: mask_213>, <AnalysisResult: mask_214>, <AnalysisResult: mask_215>, <AnalysisResult: mask_216>, <AnalysisResult: mask_217>, <AnalysisResult: mask_218>, <AnalysisResult: mask_219>, <AnalysisResult: mask_220>, <AnalysisResult: mask_221>, <AnalysisResult: mask_222>, <AnalysisResult: mask_223>, <AnalysisResult: mask_224>, <AnalysisResult: mask_225>, <AnalysisResult: mask_226>, <AnalysisResult: mask_227>, <AnalysisResult: mask_228>, <AnalysisResult: mask_229>, <AnalysisResult: mask_230>, <AnalysisResult: mask_231>, <AnalysisResult: mask_232>, <AnalysisResult: mask_233>, <AnalysisResult: mask_234>, <AnalysisResult: mask_235>, <AnalysisResult: mask_236>, <AnalysisResult: mask_237>, <AnalysisResult: mask_238>, <AnalysisResult: mask_239>, <AnalysisResult: mask_240>, <AnalysisResult: mask_241>, <AnalysisResult: mask_242>, <AnalysisResult: mask_243>, <AnalysisResult: mask_244>, <AnalysisResult: mask_245>, <AnalysisResult: mask_246>, <AnalysisResult: mask_247>, <AnalysisResult: mask_248>, <AnalysisResult: mask_249>, <AnalysisResult: mask_250>, <AnalysisResult: mask_251>, <AnalysisResult: mask_252>, <AnalysisResult: mask_253>, <AnalysisResult: mask_254>, <AnalysisResult: mask_255>, <AnalysisResult: mask_256>, <AnalysisResult: mask_257>, <AnalysisResult: mask_258>, <AnalysisResult: mask_259>, <AnalysisResult: mask_260>, <AnalysisResult: mask_261>, <AnalysisResult: mask_262>, <AnalysisResult: mask_263>, <AnalysisResult: mask_264>, <AnalysisResult: mask_265>, <AnalysisResult: mask_266>, <AnalysisResult: mask_267>, <AnalysisResult: mask_268>, <AnalysisResult: mask_269>, <AnalysisResult: mask_270>, <AnalysisResult: mask_271>, <AnalysisResult: mask_272>, <AnalysisResult: mask_273>, <AnalysisResult: mask_274>, <AnalysisResult: mask_275>, <AnalysisResult: mask_276>, <AnalysisResult: mask_277>, <AnalysisResult: mask_278>, <AnalysisResult: mask_279>, <AnalysisResult: mask_280>, <AnalysisResult: mask_281>, <AnalysisResult: mask_282>, <AnalysisResult: mask_283>, <AnalysisResult: mask_284>, <AnalysisResult: mask_285>, <AnalysisResult: mask_286>, <AnalysisResult: mask_287>, <AnalysisResult: mask_288>, <AnalysisResult: mask_289>, <AnalysisResult: mask_290>, <AnalysisResult: mask_291>, <AnalysisResult: mask_292>, <AnalysisResult: mask_293>, <AnalysisResult: mask_294>, <AnalysisResult: mask_295>, <AnalysisResult: mask_296>, <AnalysisResult: mask_297>, <AnalysisResult: mask_298>, <AnalysisResult: mask_299>, <AnalysisResult: mask_300>, <AnalysisResult: mask_301>, <AnalysisResult: mask_302>, <AnalysisResult: mask_303>, <AnalysisResult: mask_304>, <AnalysisResult: mask_305>, <AnalysisResult: mask_306>, <AnalysisResult: mask_307>, <AnalysisResult: mask_308>, <AnalysisResult: mask_309>, <AnalysisResult: mask_310>, <AnalysisResult: mask_311>, <AnalysisResult: mask_312>, <AnalysisResult: mask_313>, <AnalysisResult: mask_314>, <AnalysisResult: mask_315>, <AnalysisResult: mask_316>, <AnalysisResult: mask_317>, <AnalysisResult: mask_318>, <AnalysisResult: mask_319>, <AnalysisResult: mask_320>, <AnalysisResult: mask_321>, <AnalysisResult: mask_322>, <AnalysisResult: mask_323>, <AnalysisResult: mask_324>, <AnalysisResult: mask_325>, <AnalysisResult: mask_326>, <AnalysisResult: mask_327>, <AnalysisResult: mask_328>, <AnalysisResult: mask_329>, <AnalysisResult: mask_330>, <AnalysisResult: mask_331>, <AnalysisResult: mask_332>, <AnalysisResult: mask_333>, <AnalysisResult: mask_334>, <AnalysisResult: mask_335>, <AnalysisResult: mask_336>, <AnalysisResult: mask_337>, <AnalysisResult: mask_338>, <AnalysisResult: mask_339>, <AnalysisResult: mask_340>, <AnalysisResult: mask_341>, <AnalysisResult: mask_342>, <AnalysisResult: mask_343>, <AnalysisResult: mask_344>, <AnalysisResult: mask_345>, <AnalysisResult: mask_346>, <AnalysisResult: mask_347>, <AnalysisResult: mask_348>, <AnalysisResult: mask_349>, <AnalysisResult: mask_350>, <AnalysisResult: mask_351>, <AnalysisResult: mask_352>, <AnalysisResult: mask_353>, <AnalysisResult: mask_354>, <AnalysisResult: mask_355>, <AnalysisResult: mask_356>, <AnalysisResult: mask_357>, <AnalysisResult: mask_358>, <AnalysisResult: mask_359>, <AnalysisResult: mask_360>, <AnalysisResult: mask_361>, <AnalysisResult: mask_362>, <AnalysisResult: mask_363>, <AnalysisResult: mask_364>, <AnalysisResult: mask_365>, <AnalysisResult: mask_366>, <AnalysisResult: mask_367>, <AnalysisResult: mask_368>, <AnalysisResult: mask_369>, <AnalysisResult: mask_370>, <AnalysisResult: mask_371>, <AnalysisResult: mask_372>, <AnalysisResult: mask_373>, <AnalysisResult: mask_374>, <AnalysisResult: mask_375>, <AnalysisResult: mask_376>, <AnalysisResult: mask_377>, <AnalysisResult: mask_378>, <AnalysisResult: mask_379>, <AnalysisResult: mask_380>, <AnalysisResult: mask_381>, <AnalysisResult: mask_382>, <AnalysisResult: mask_383>, <AnalysisResult: mask_384>, <AnalysisResult: mask_385>, <AnalysisResult: mask_386>, <AnalysisResult: mask_387>, <AnalysisResult: mask_388>, <AnalysisResult: mask_389>, <AnalysisResult: mask_390>, <AnalysisResult: mask_391>, <AnalysisResult: mask_392>, <AnalysisResult: mask_393>, <AnalysisResult: mask_394>, <AnalysisResult: mask_395>, <AnalysisResult: mask_396>, <AnalysisResult: mask_397>, <AnalysisResult: mask_398>, <AnalysisResult: mask_399>, <AnalysisResult: mask_400>, <AnalysisResult: mask_401>, <AnalysisResult: mask_402>, <AnalysisResult: mask_403>, <AnalysisResult: mask_404>, <AnalysisResult: mask_405>, <AnalysisResult: mask_406>, <AnalysisResult: mask_407>, <AnalysisResult: mask_408>, <AnalysisResult: mask_409>, <AnalysisResult: mask_410>, <AnalysisResult: mask_411>, <AnalysisResult: mask_412>, <AnalysisResult: mask_413>, <AnalysisResult: mask_414>, <AnalysisResult: mask_415>, <AnalysisResult: mask_416>, <AnalysisResult: mask_417>, <AnalysisResult: mask_418>, <AnalysisResult: mask_419>, <AnalysisResult: mask_420>, <AnalysisResult: mask_421>, <AnalysisResult: mask_422>, <AnalysisResult: mask_423>, <AnalysisResult: mask_424>, <AnalysisResult: mask_425>, <AnalysisResult: mask_426>, <AnalysisResult: mask_427>, <AnalysisResult: mask_428>, <AnalysisResult: mask_429>, <AnalysisResult: mask_430>, <AnalysisResult: mask_431>, <AnalysisResult: mask_432>, <AnalysisResult: mask_433>, <AnalysisResult: mask_434>, <AnalysisResult: mask_435>, <AnalysisResult: mask_436>, <AnalysisResult: mask_437>, <AnalysisResult: mask_438>, <AnalysisResult: mask_439>, <AnalysisResult: mask_440>, <AnalysisResult: mask_441>, <AnalysisResult: mask_442>, <AnalysisResult: mask_443>, <AnalysisResult: mask_444>, <AnalysisResult: mask_445>, <AnalysisResult: mask_446>, <AnalysisResult: mask_447>, <AnalysisResult: mask_448>, <AnalysisResult: mask_449>, <AnalysisResult: mask_450>, <AnalysisResult: mask_451>, <AnalysisResult: mask_452>, <AnalysisResult: mask_453>, <AnalysisResult: mask_454>, <AnalysisResult: mask_455>, <AnalysisResult: mask_456>, <AnalysisResult: mask_457>, <AnalysisResult: mask_458>, <AnalysisResult: mask_459>, <AnalysisResult: mask_460>, <AnalysisResult: mask_461>, <AnalysisResult: mask_462>, <AnalysisResult: mask_463>, <AnalysisResult: mask_464>, <AnalysisResult: mask_465>, <AnalysisResult: mask_466>, <AnalysisResult: mask_467>, <AnalysisResult: mask_468>, <AnalysisResult: mask_469>, <AnalysisResult: mask_470>, <AnalysisResult: mask_471>, <AnalysisResult: mask_472>, <AnalysisResult: mask_473>, <AnalysisResult: mask_474>, <AnalysisResult: mask_475>, <AnalysisResult: mask_476>, <AnalysisResult: mask_477>, <AnalysisResult: mask_478>, <AnalysisResult: mask_479>, <AnalysisResult: mask_480>, <AnalysisResult: mask_481>, <AnalysisResult: mask_482>, <AnalysisResult: mask_483>, <AnalysisResult: mask_484>, <AnalysisResult: mask_485>, <AnalysisResult: mask_486>, <AnalysisResult: mask_487>, <AnalysisResult: mask_488>, <AnalysisResult: mask_489>, <AnalysisResult: mask_490>, <AnalysisResult: mask_491>, <AnalysisResult: mask_492>, <AnalysisResult: mask_493>, <AnalysisResult: mask_494>, <AnalysisResult: mask_495>, <AnalysisResult: mask_496>, <AnalysisResult: mask_497>, <AnalysisResult: mask_498>, <AnalysisResult: mask_499>, <AnalysisResult: mask_500>, <AnalysisResult: mask_501>, <AnalysisResult: mask_502>, <AnalysisResult: mask_503>, <AnalysisResult: mask_504>, <AnalysisResult: mask_505>, <AnalysisResult: mask_506>, <AnalysisResult: mask_507>, <AnalysisResult: mask_508>, <AnalysisResult: mask_509>, <AnalysisResult: mask_510>, <AnalysisResult: mask_511>, <AnalysisResult: mask_512>, <AnalysisResult: mask_513>, <AnalysisResult: mask_514>, <AnalysisResult: mask_515>, <AnalysisResult: mask_516>, <AnalysisResult: mask_517>, <AnalysisResult: mask_518>, <AnalysisResult: mask_519>, <AnalysisResult: mask_520>, <AnalysisResult: mask_521>, <AnalysisResult: mask_522>, <AnalysisResult: mask_523>, <AnalysisResult: mask_524>, <AnalysisResult: mask_525>, <AnalysisResult: mask_526>, <AnalysisResult: mask_527>, <AnalysisResult: mask_528>, <AnalysisResult: mask_529>, <AnalysisResult: mask_530>, <AnalysisResult: mask_531>, <AnalysisResult: mask_532>, <AnalysisResult: mask_533>, <AnalysisResult: mask_534>, <AnalysisResult: mask_535>, <AnalysisResult: mask_536>, <AnalysisResult: mask_537>, <AnalysisResult: mask_538>, <AnalysisResult: mask_539>, <AnalysisResult: mask_540>, <AnalysisResult: mask_541>, <AnalysisResult: mask_542>, <AnalysisResult: mask_543>, <AnalysisResult: mask_544>, <AnalysisResult: mask_545>, <AnalysisResult: mask_546>, <AnalysisResult: mask_547>, <AnalysisResult: mask_548>, <AnalysisResult: mask_549>, <AnalysisResult: mask_550>, <AnalysisResult: mask_551>, <AnalysisResult: mask_552>, <AnalysisResult: mask_553>, <AnalysisResult: mask_554>, <AnalysisResult: mask_555>, <AnalysisResult: mask_556>, <AnalysisResult: mask_557>, <AnalysisResult: mask_558>, <AnalysisResult: mask_559>, <AnalysisResult: mask_560>, <AnalysisResult: mask_561>, <AnalysisResult: mask_562>, <AnalysisResult: mask_563>, <AnalysisResult: mask_564>, <AnalysisResult: mask_565>, <AnalysisResult: mask_566>, <AnalysisResult: mask_567>, <AnalysisResult: mask_568>, <AnalysisResult: mask_569>, <AnalysisResult: mask_570>, <AnalysisResult: mask_571>, <AnalysisResult: mask_572>, <AnalysisResult: mask_573>, <AnalysisResult: mask_574>, <AnalysisResult: mask_575>, <AnalysisResult: mask_576>, <AnalysisResult: mask_577>, <AnalysisResult: mask_578>, <AnalysisResult: mask_579>, <AnalysisResult: mask_580>, <AnalysisResult: mask_581>, <AnalysisResult: mask_582>, <AnalysisResult: mask_583>, <AnalysisResult: mask_584>, <AnalysisResult: mask_585>, <AnalysisResult: mask_586>, <AnalysisResult: mask_587>, <AnalysisResult: mask_588>, <AnalysisResult: mask_589>, <AnalysisResult: mask_590>, <AnalysisResult: mask_591>, <AnalysisResult: mask_592>, <AnalysisResult: mask_593>, <AnalysisResult: mask_594>, <AnalysisResult: mask_595>, <AnalysisResult: mask_596>, <AnalysisResult: mask_597>, <AnalysisResult: mask_598>, <AnalysisResult: mask_599>, <AnalysisResult: mask_600>, <AnalysisResult: mask_601>, <AnalysisResult: mask_602>, <AnalysisResult: mask_603>, <AnalysisResult: mask_604>, <AnalysisResult: mask_605>, <AnalysisResult: mask_606>, <AnalysisResult: mask_607>, <AnalysisResult: mask_608>, <AnalysisResult: mask_609>, <AnalysisResult: mask_610>, <AnalysisResult: mask_611>, <AnalysisResult: mask_612>, <AnalysisResult: mask_613>, <AnalysisResult: mask_614>, <AnalysisResult: mask_615>, <AnalysisResult: mask_616>, <AnalysisResult: mask_617>, <AnalysisResult: mask_618>, <AnalysisResult: mask_619>, <AnalysisResult: mask_620>, <AnalysisResult: mask_621>, <AnalysisResult: mask_622>, <AnalysisResult: mask_623>, <AnalysisResult: mask_624>, <AnalysisResult: mask_625>, <AnalysisResult: mask_626>, <AnalysisResult: mask_627>, <AnalysisResult: mask_628>, <AnalysisResult: mask_629>, <AnalysisResult: mask_630>, <AnalysisResult: mask_631>, <AnalysisResult: mask_632>, <AnalysisResult: mask_633>, <AnalysisResult: mask_634>, <AnalysisResult: mask_635>, <AnalysisResult: mask_636>, <AnalysisResult: mask_637>, <AnalysisResult: mask_638>, <AnalysisResult: mask_639>, <AnalysisResult: mask_640>, <AnalysisResult: mask_641>, <AnalysisResult: mask_642>, <AnalysisResult: mask_643>, <AnalysisResult: mask_644>, <AnalysisResult: mask_645>, <AnalysisResult: mask_646>, <AnalysisResult: mask_647>, <AnalysisResult: mask_648>, <AnalysisResult: mask_649>, <AnalysisResult: mask_650>, <AnalysisResult: mask_651>, <AnalysisResult: mask_652>, <AnalysisResult: mask_653>, <AnalysisResult: mask_654>, <AnalysisResult: mask_655>, <AnalysisResult: mask_656>, <AnalysisResult: mask_657>, <AnalysisResult: mask_658>, <AnalysisResult: mask_659>, <AnalysisResult: mask_660>, <AnalysisResult: mask_661>, <AnalysisResult: mask_662>, <AnalysisResult: mask_663>, <AnalysisResult: mask_664>, <AnalysisResult: mask_665>, <AnalysisResult: mask_666>, <AnalysisResult: mask_667>, <AnalysisResult: mask_668>, <AnalysisResult: mask_669>, <AnalysisResult: mask_670>, <AnalysisResult: mask_671>, <AnalysisResult: mask_672>, <AnalysisResult: mask_673>, <AnalysisResult: mask_674>, <AnalysisResult: mask_675>, <AnalysisResult: mask_676>, <AnalysisResult: mask_677>, <AnalysisResult: mask_678>, <AnalysisResult: mask_679>, <AnalysisResult: mask_680>, <AnalysisResult: mask_681>, <AnalysisResult: mask_682>, <AnalysisResult: mask_683>, <AnalysisResult: mask_684>, <AnalysisResult: mask_685>, <AnalysisResult: mask_686>, <AnalysisResult: mask_687>, <AnalysisResult: mask_688>, <AnalysisResult: mask_689>, <AnalysisResult: mask_690>, <AnalysisResult: mask_691>, <AnalysisResult: mask_692>, <AnalysisResult: mask_693>, <AnalysisResult: mask_694>, <AnalysisResult: mask_695>, <AnalysisResult: mask_696>, <AnalysisResult: mask_697>, <AnalysisResult: mask_698>, <AnalysisResult: mask_699>, <AnalysisResult: mask_700>, <AnalysisResult: mask_701>, <AnalysisResult: mask_702>, <AnalysisResult: mask_703>, <AnalysisResult: mask_704>, <AnalysisResult: mask_705>, <AnalysisResult: mask_706>, <AnalysisResult: mask_707>, <AnalysisResult: mask_708>, <AnalysisResult: mask_709>, <AnalysisResult: mask_710>, <AnalysisResult: mask_711>, <AnalysisResult: mask_712>, <AnalysisResult: mask_713>, <AnalysisResult: mask_714>, <AnalysisResult: mask_715>, <AnalysisResult: mask_716>, <AnalysisResult: mask_717>, <AnalysisResult: mask_718>, <AnalysisResult: mask_719>, <AnalysisResult: mask_720>, <AnalysisResult: mask_721>, <AnalysisResult: mask_722>, <AnalysisResult: mask_723>, <AnalysisResult: mask_724>, <AnalysisResult: mask_725>, <AnalysisResult: mask_726>, <AnalysisResult: mask_727>, <AnalysisResult: mask_728>, <AnalysisResult: mask_729>, <AnalysisResult: mask_730>, <AnalysisResult: mask_731>, <AnalysisResult: mask_732>, <AnalysisResult: mask_733>, <AnalysisResult: mask_734>, <AnalysisResult: mask_735>, <AnalysisResult: mask_736>, <AnalysisResult: mask_737>, <AnalysisResult: mask_738>, <AnalysisResult: mask_739>, <AnalysisResult: mask_740>, <AnalysisResult: mask_741>, <AnalysisResult: mask_742>, <AnalysisResult: mask_743>, <AnalysisResult: mask_744>, <AnalysisResult: mask_745>, <AnalysisResult: mask_746>, <AnalysisResult: mask_747>, <AnalysisResult: mask_748>, <AnalysisResult: mask_749>, <AnalysisResult: mask_750>, <AnalysisResult: mask_751>, <AnalysisResult: mask_752>, <AnalysisResult: mask_753>, <AnalysisResult: mask_754>, <AnalysisResult: mask_755>, <AnalysisResult: mask_756>, <AnalysisResult: mask_757>, <AnalysisResult: mask_758>, <AnalysisResult: mask_759>, <AnalysisResult: mask_760>, <AnalysisResult: mask_761>, <AnalysisResult: mask_762>, <AnalysisResult: mask_763>, <AnalysisResult: mask_764>, <AnalysisResult: mask_765>, <AnalysisResult: mask_766>, <AnalysisResult: mask_767>, <AnalysisResult: mask_768>, <AnalysisResult: mask_769>, <AnalysisResult: mask_770>, <AnalysisResult: mask_771>, <AnalysisResult: mask_772>, <AnalysisResult: mask_773>, <AnalysisResult: mask_774>, <AnalysisResult: mask_775>, <AnalysisResult: mask_776>, <AnalysisResult: mask_777>, <AnalysisResult: mask_778>, <AnalysisResult: mask_779>, <AnalysisResult: mask_780>, <AnalysisResult: mask_781>, <AnalysisResult: mask_782>, <AnalysisResult: mask_783>, <AnalysisResult: mask_784>, <AnalysisResult: mask_785>, <AnalysisResult: mask_786>, <AnalysisResult: mask_787>, <AnalysisResult: mask_788>, <AnalysisResult: mask_789>, <AnalysisResult: mask_790>, <AnalysisResult: mask_791>, <AnalysisResult: mask_792>, <AnalysisResult: mask_793>, <AnalysisResult: mask_794>, <AnalysisResult: mask_795>, <AnalysisResult: mask_796>, <AnalysisResult: mask_797>, <AnalysisResult: mask_798>, <AnalysisResult: mask_799>, <AnalysisResult: mask_800>, <AnalysisResult: mask_801>, <AnalysisResult: mask_802>, <AnalysisResult: mask_803>, <AnalysisResult: mask_804>, <AnalysisResult: mask_805>, <AnalysisResult: mask_806>, <AnalysisResult: mask_807>, <AnalysisResult: mask_808>, <AnalysisResult: mask_809>, <AnalysisResult: mask_810>, <AnalysisResult: mask_811>, <AnalysisResult: mask_812>, <AnalysisResult: mask_813>, <AnalysisResult: mask_814>, <AnalysisResult: mask_815>, <AnalysisResult: mask_816>, <AnalysisResult: mask_817>, <AnalysisResult: mask_818>, <AnalysisResult: mask_819>, <AnalysisResult: mask_820>, <AnalysisResult: mask_821>, <AnalysisResult: mask_822>, <AnalysisResult: mask_823>, <AnalysisResult: mask_824>, <AnalysisResult: mask_825>, <AnalysisResult: mask_826>, <AnalysisResult: mask_827>, <AnalysisResult: mask_828>, <AnalysisResult: mask_829>, <AnalysisResult: mask_830>, <AnalysisResult: mask_831>, <AnalysisResult: mask_832>, <AnalysisResult: mask_833>, <AnalysisResult: mask_834>, <AnalysisResult: mask_835>, <AnalysisResult: mask_836>, <AnalysisResult: mask_837>, <AnalysisResult: mask_838>, <AnalysisResult: mask_839>, <AnalysisResult: mask_840>, <AnalysisResult: mask_841>, <AnalysisResult: mask_842>, <AnalysisResult: mask_843>, <AnalysisResult: mask_844>, <AnalysisResult: mask_845>, <AnalysisResult: mask_846>, <AnalysisResult: mask_847>, <AnalysisResult: mask_848>, <AnalysisResult: mask_849>, <AnalysisResult: mask_850>, <AnalysisResult: mask_851>, <AnalysisResult: mask_852>, <AnalysisResult: mask_853>, <AnalysisResult: mask_854>, <AnalysisResult: mask_855>, <AnalysisResult: mask_856>, <AnalysisResult: mask_857>, <AnalysisResult: mask_858>, <AnalysisResult: mask_859>, <AnalysisResult: mask_860>, <AnalysisResult: mask_861>, <AnalysisResult: mask_862>, <AnalysisResult: mask_863>, <AnalysisResult: mask_864>, <AnalysisResult: mask_865>, <AnalysisResult: mask_866>, <AnalysisResult: mask_867>, <AnalysisResult: mask_868>, <AnalysisResult: mask_869>, <AnalysisResult: mask_870>, <AnalysisResult: mask_871>, <AnalysisResult: mask_872>, <AnalysisResult: mask_873>, <AnalysisResult: mask_874>, <AnalysisResult: mask_875>, <AnalysisResult: mask_876>, <AnalysisResult: mask_877>, <AnalysisResult: mask_878>, <AnalysisResult: mask_879>, <AnalysisResult: mask_880>, <AnalysisResult: mask_881>, <AnalysisResult: mask_882>, <AnalysisResult: mask_883>, <AnalysisResult: mask_884>, <AnalysisResult: mask_885>, <AnalysisResult: mask_886>, <AnalysisResult: mask_887>, <AnalysisResult: mask_888>, <AnalysisResult: mask_889>, <AnalysisResult: mask_890>, <AnalysisResult: mask_891>, <AnalysisResult: mask_892>, <AnalysisResult: mask_893>, <AnalysisResult: mask_894>, <AnalysisResult: mask_895>, <AnalysisResult: mask_896>, <AnalysisResult: mask_897>, <AnalysisResult: mask_898>, <AnalysisResult: mask_899>, <AnalysisResult: mask_900>, <AnalysisResult: mask_901>, <AnalysisResult: mask_902>, <AnalysisResult: mask_903>, <AnalysisResult: mask_904>, <AnalysisResult: mask_905>, <AnalysisResult: mask_906>, <AnalysisResult: mask_907>, <AnalysisResult: mask_908>, <AnalysisResult: mask_909>, <AnalysisResult: mask_910>, <AnalysisResult: mask_911>, <AnalysisResult: mask_912>, <AnalysisResult: mask_913>, <AnalysisResult: mask_914>, <AnalysisResult: mask_915>, <AnalysisResult: mask_916>, <AnalysisResult: mask_917>, <AnalysisResult: mask_918>, <AnalysisResult: mask_919>, <AnalysisResult: mask_920>, <AnalysisResult: mask_921>, <AnalysisResult: mask_922>, <AnalysisResult: mask_923>, <AnalysisResult: mask_924>, <AnalysisResult: mask_925>, <AnalysisResult: mask_926>, <AnalysisResult: mask_927>, <AnalysisResult: mask_928>, <AnalysisResult: mask_929>, <AnalysisResult: mask_930>, <AnalysisResult: mask_931>, <AnalysisResult: mask_932>, <AnalysisResult: mask_933>, <AnalysisResult: mask_934>, <AnalysisResult: mask_935>, <AnalysisResult: mask_936>, <AnalysisResult: mask_937>, <AnalysisResult: mask_938>, <AnalysisResult: mask_939>, <AnalysisResult: mask_940>, <AnalysisResult: mask_941>, <AnalysisResult: mask_942>, <AnalysisResult: mask_943>, <AnalysisResult: mask_944>, <AnalysisResult: mask_945>, <AnalysisResult: mask_946>, <AnalysisResult: mask_947>, <AnalysisResult: mask_948>, <AnalysisResult: mask_949>, <AnalysisResult: mask_950>, <AnalysisResult: mask_951>, <AnalysisResult: mask_952>, <AnalysisResult: mask_953>, <AnalysisResult: mask_954>, <AnalysisResult: mask_955>, <AnalysisResult: mask_956>, <AnalysisResult: mask_957>, <AnalysisResult: mask_958>, <AnalysisResult: mask_959>, <AnalysisResult: mask_960>, <AnalysisResult: mask_961>, <AnalysisResult: mask_962>, <AnalysisResult: mask_963>, <AnalysisResult: mask_964>, <AnalysisResult: mask_965>, <AnalysisResult: mask_966>, <AnalysisResult: mask_967>, <AnalysisResult: mask_968>, <AnalysisResult: mask_969>, <AnalysisResult: mask_970>, <AnalysisResult: mask_971>, <AnalysisResult: mask_972>, <AnalysisResult: mask_973>, <AnalysisResult: mask_974>, <AnalysisResult: mask_975>, <AnalysisResult: mask_976>, <AnalysisResult: mask_977>, <AnalysisResult: mask_978>, <AnalysisResult: mask_979>, <AnalysisResult: mask_980>, <AnalysisResult: mask_981>, <AnalysisResult: mask_982>, <AnalysisResult: mask_983>, <AnalysisResult: mask_984>, <AnalysisResult: mask_985>, <AnalysisResult: mask_986>, <AnalysisResult: mask_987>, <AnalysisResult: mask_988>, <AnalysisResult: mask_989>, <AnalysisResult: mask_990>, <AnalysisResult: mask_991>, <AnalysisResult: mask_992>, <AnalysisResult: mask_993>, <AnalysisResult: mask_994>, <AnalysisResult: mask_995>, <AnalysisResult: mask_996>, <AnalysisResult: mask_997>, <AnalysisResult: mask_998>, <AnalysisResult: mask_999>]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(multi_analysis_sparse)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 36.5 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: mask_0>, <AnalysisResult: mask_1>, <AnalysisResult: mask_2>, <AnalysisResult: mask_3>, <AnalysisResult: mask_4>, <AnalysisResult: mask_5>, <AnalysisResult: mask_6>, <AnalysisResult: mask_7>, <AnalysisResult: mask_8>, <AnalysisResult: mask_9>, <AnalysisResult: mask_10>, <AnalysisResult: mask_11>, <AnalysisResult: mask_12>, <AnalysisResult: mask_13>, <AnalysisResult: mask_14>, <AnalysisResult: mask_15>, <AnalysisResult: mask_16>, <AnalysisResult: mask_17>, <AnalysisResult: mask_18>, <AnalysisResult: mask_19>, <AnalysisResult: mask_20>, <AnalysisResult: mask_21>, <AnalysisResult: mask_22>, <AnalysisResult: mask_23>, <AnalysisResult: mask_24>, <AnalysisResult: mask_25>, <AnalysisResult: mask_26>, <AnalysisResult: mask_27>, <AnalysisResult: mask_28>, <AnalysisResult: mask_29>, <AnalysisResult: mask_30>, <AnalysisResult: mask_31>, <AnalysisResult: mask_32>, <AnalysisResult: mask_33>, <AnalysisResult: mask_34>, <AnalysisResult: mask_35>, <AnalysisResult: mask_36>, <AnalysisResult: mask_37>, <AnalysisResult: mask_38>, <AnalysisResult: mask_39>, <AnalysisResult: mask_40>, <AnalysisResult: mask_41>, <AnalysisResult: mask_42>, <AnalysisResult: mask_43>, <AnalysisResult: mask_44>, <AnalysisResult: mask_45>, <AnalysisResult: mask_46>, <AnalysisResult: mask_47>, <AnalysisResult: mask_48>, <AnalysisResult: mask_49>, <AnalysisResult: mask_50>, <AnalysisResult: mask_51>, <AnalysisResult: mask_52>, <AnalysisResult: mask_53>, <AnalysisResult: mask_54>, <AnalysisResult: mask_55>, <AnalysisResult: mask_56>, <AnalysisResult: mask_57>, <AnalysisResult: mask_58>, <AnalysisResult: mask_59>, <AnalysisResult: mask_60>, <AnalysisResult: mask_61>, <AnalysisResult: mask_62>, <AnalysisResult: mask_63>, <AnalysisResult: mask_64>, <AnalysisResult: mask_65>, <AnalysisResult: mask_66>, <AnalysisResult: mask_67>, <AnalysisResult: mask_68>, <AnalysisResult: mask_69>, <AnalysisResult: mask_70>, <AnalysisResult: mask_71>, <AnalysisResult: mask_72>, <AnalysisResult: mask_73>, <AnalysisResult: mask_74>, <AnalysisResult: mask_75>, <AnalysisResult: mask_76>, <AnalysisResult: mask_77>, <AnalysisResult: mask_78>, <AnalysisResult: mask_79>, <AnalysisResult: mask_80>, <AnalysisResult: mask_81>, <AnalysisResult: mask_82>, <AnalysisResult: mask_83>, <AnalysisResult: mask_84>, <AnalysisResult: mask_85>, <AnalysisResult: mask_86>, <AnalysisResult: mask_87>, <AnalysisResult: mask_88>, <AnalysisResult: mask_89>, <AnalysisResult: mask_90>, <AnalysisResult: mask_91>, <AnalysisResult: mask_92>, <AnalysisResult: mask_93>, <AnalysisResult: mask_94>, <AnalysisResult: mask_95>, <AnalysisResult: mask_96>, <AnalysisResult: mask_97>, <AnalysisResult: mask_98>, <AnalysisResult: mask_99>, <AnalysisResult: mask_100>, <AnalysisResult: mask_101>, <AnalysisResult: mask_102>, <AnalysisResult: mask_103>, <AnalysisResult: mask_104>, <AnalysisResult: mask_105>, <AnalysisResult: mask_106>, <AnalysisResult: mask_107>, <AnalysisResult: mask_108>, <AnalysisResult: mask_109>, <AnalysisResult: mask_110>, <AnalysisResult: mask_111>, <AnalysisResult: mask_112>, <AnalysisResult: mask_113>, <AnalysisResult: mask_114>, <AnalysisResult: mask_115>, <AnalysisResult: mask_116>, <AnalysisResult: mask_117>, <AnalysisResult: mask_118>, <AnalysisResult: mask_119>, <AnalysisResult: mask_120>, <AnalysisResult: mask_121>, <AnalysisResult: mask_122>, <AnalysisResult: mask_123>, <AnalysisResult: mask_124>, <AnalysisResult: mask_125>, <AnalysisResult: mask_126>, <AnalysisResult: mask_127>, <AnalysisResult: mask_128>, <AnalysisResult: mask_129>, <AnalysisResult: mask_130>, <AnalysisResult: mask_131>, <AnalysisResult: mask_132>, <AnalysisResult: mask_133>, <AnalysisResult: mask_134>, <AnalysisResult: mask_135>, <AnalysisResult: mask_136>, <AnalysisResult: mask_137>, <AnalysisResult: mask_138>, <AnalysisResult: mask_139>, <AnalysisResult: mask_140>, <AnalysisResult: mask_141>, <AnalysisResult: mask_142>, <AnalysisResult: mask_143>, <AnalysisResult: mask_144>, <AnalysisResult: mask_145>, <AnalysisResult: mask_146>, <AnalysisResult: mask_147>, <AnalysisResult: mask_148>, <AnalysisResult: mask_149>, <AnalysisResult: mask_150>, <AnalysisResult: mask_151>, <AnalysisResult: mask_152>, <AnalysisResult: mask_153>, <AnalysisResult: mask_154>, <AnalysisResult: mask_155>, <AnalysisResult: mask_156>, <AnalysisResult: mask_157>, <AnalysisResult: mask_158>, <AnalysisResult: mask_159>, <AnalysisResult: mask_160>, <AnalysisResult: mask_161>, <AnalysisResult: mask_162>, <AnalysisResult: mask_163>, <AnalysisResult: mask_164>, <AnalysisResult: mask_165>, <AnalysisResult: mask_166>, <AnalysisResult: mask_167>, <AnalysisResult: mask_168>, <AnalysisResult: mask_169>, <AnalysisResult: mask_170>, <AnalysisResult: mask_171>, <AnalysisResult: mask_172>, <AnalysisResult: mask_173>, <AnalysisResult: mask_174>, <AnalysisResult: mask_175>, <AnalysisResult: mask_176>, <AnalysisResult: mask_177>, <AnalysisResult: mask_178>, <AnalysisResult: mask_179>, <AnalysisResult: mask_180>, <AnalysisResult: mask_181>, <AnalysisResult: mask_182>, <AnalysisResult: mask_183>, <AnalysisResult: mask_184>, <AnalysisResult: mask_185>, <AnalysisResult: mask_186>, <AnalysisResult: mask_187>, <AnalysisResult: mask_188>, <AnalysisResult: mask_189>, <AnalysisResult: mask_190>, <AnalysisResult: mask_191>, <AnalysisResult: mask_192>, <AnalysisResult: mask_193>, <AnalysisResult: mask_194>, <AnalysisResult: mask_195>, <AnalysisResult: mask_196>, <AnalysisResult: mask_197>, <AnalysisResult: mask_198>, <AnalysisResult: mask_199>, <AnalysisResult: mask_200>, <AnalysisResult: mask_201>, <AnalysisResult: mask_202>, <AnalysisResult: mask_203>, <AnalysisResult: mask_204>, <AnalysisResult: mask_205>, <AnalysisResult: mask_206>, <AnalysisResult: mask_207>, <AnalysisResult: mask_208>, <AnalysisResult: mask_209>, <AnalysisResult: mask_210>, <AnalysisResult: mask_211>, <AnalysisResult: mask_212>, <AnalysisResult: mask_213>, <AnalysisResult: mask_214>, <AnalysisResult: mask_215>, <AnalysisResult: mask_216>, <AnalysisResult: mask_217>, <AnalysisResult: mask_218>, <AnalysisResult: mask_219>, <AnalysisResult: mask_220>, <AnalysisResult: mask_221>, <AnalysisResult: mask_222>, <AnalysisResult: mask_223>, <AnalysisResult: mask_224>, <AnalysisResult: mask_225>, <AnalysisResult: mask_226>, <AnalysisResult: mask_227>, <AnalysisResult: mask_228>, <AnalysisResult: mask_229>, <AnalysisResult: mask_230>, <AnalysisResult: mask_231>, <AnalysisResult: mask_232>, <AnalysisResult: mask_233>, <AnalysisResult: mask_234>, <AnalysisResult: mask_235>, <AnalysisResult: mask_236>, <AnalysisResult: mask_237>, <AnalysisResult: mask_238>, <AnalysisResult: mask_239>, <AnalysisResult: mask_240>, <AnalysisResult: mask_241>, <AnalysisResult: mask_242>, <AnalysisResult: mask_243>, <AnalysisResult: mask_244>, <AnalysisResult: mask_245>, <AnalysisResult: mask_246>, <AnalysisResult: mask_247>, <AnalysisResult: mask_248>, <AnalysisResult: mask_249>, <AnalysisResult: mask_250>, <AnalysisResult: mask_251>, <AnalysisResult: mask_252>, <AnalysisResult: mask_253>, <AnalysisResult: mask_254>, <AnalysisResult: mask_255>, <AnalysisResult: mask_256>, <AnalysisResult: mask_257>, <AnalysisResult: mask_258>, <AnalysisResult: mask_259>, <AnalysisResult: mask_260>, <AnalysisResult: mask_261>, <AnalysisResult: mask_262>, <AnalysisResult: mask_263>, <AnalysisResult: mask_264>, <AnalysisResult: mask_265>, <AnalysisResult: mask_266>, <AnalysisResult: mask_267>, <AnalysisResult: mask_268>, <AnalysisResult: mask_269>, <AnalysisResult: mask_270>, <AnalysisResult: mask_271>, <AnalysisResult: mask_272>, <AnalysisResult: mask_273>, <AnalysisResult: mask_274>, <AnalysisResult: mask_275>, <AnalysisResult: mask_276>, <AnalysisResult: mask_277>, <AnalysisResult: mask_278>, <AnalysisResult: mask_279>, <AnalysisResult: mask_280>, <AnalysisResult: mask_281>, <AnalysisResult: mask_282>, <AnalysisResult: mask_283>, <AnalysisResult: mask_284>, <AnalysisResult: mask_285>, <AnalysisResult: mask_286>, <AnalysisResult: mask_287>, <AnalysisResult: mask_288>, <AnalysisResult: mask_289>, <AnalysisResult: mask_290>, <AnalysisResult: mask_291>, <AnalysisResult: mask_292>, <AnalysisResult: mask_293>, <AnalysisResult: mask_294>, <AnalysisResult: mask_295>, <AnalysisResult: mask_296>, <AnalysisResult: mask_297>, <AnalysisResult: mask_298>, <AnalysisResult: mask_299>, <AnalysisResult: mask_300>, <AnalysisResult: mask_301>, <AnalysisResult: mask_302>, <AnalysisResult: mask_303>, <AnalysisResult: mask_304>, <AnalysisResult: mask_305>, <AnalysisResult: mask_306>, <AnalysisResult: mask_307>, <AnalysisResult: mask_308>, <AnalysisResult: mask_309>, <AnalysisResult: mask_310>, <AnalysisResult: mask_311>, <AnalysisResult: mask_312>, <AnalysisResult: mask_313>, <AnalysisResult: mask_314>, <AnalysisResult: mask_315>, <AnalysisResult: mask_316>, <AnalysisResult: mask_317>, <AnalysisResult: mask_318>, <AnalysisResult: mask_319>, <AnalysisResult: mask_320>, <AnalysisResult: mask_321>, <AnalysisResult: mask_322>, <AnalysisResult: mask_323>, <AnalysisResult: mask_324>, <AnalysisResult: mask_325>, <AnalysisResult: mask_326>, <AnalysisResult: mask_327>, <AnalysisResult: mask_328>, <AnalysisResult: mask_329>, <AnalysisResult: mask_330>, <AnalysisResult: mask_331>, <AnalysisResult: mask_332>, <AnalysisResult: mask_333>, <AnalysisResult: mask_334>, <AnalysisResult: mask_335>, <AnalysisResult: mask_336>, <AnalysisResult: mask_337>, <AnalysisResult: mask_338>, <AnalysisResult: mask_339>, <AnalysisResult: mask_340>, <AnalysisResult: mask_341>, <AnalysisResult: mask_342>, <AnalysisResult: mask_343>, <AnalysisResult: mask_344>, <AnalysisResult: mask_345>, <AnalysisResult: mask_346>, <AnalysisResult: mask_347>, <AnalysisResult: mask_348>, <AnalysisResult: mask_349>, <AnalysisResult: mask_350>, <AnalysisResult: mask_351>, <AnalysisResult: mask_352>, <AnalysisResult: mask_353>, <AnalysisResult: mask_354>, <AnalysisResult: mask_355>, <AnalysisResult: mask_356>, <AnalysisResult: mask_357>, <AnalysisResult: mask_358>, <AnalysisResult: mask_359>, <AnalysisResult: mask_360>, <AnalysisResult: mask_361>, <AnalysisResult: mask_362>, <AnalysisResult: mask_363>, <AnalysisResult: mask_364>, <AnalysisResult: mask_365>, <AnalysisResult: mask_366>, <AnalysisResult: mask_367>, <AnalysisResult: mask_368>, <AnalysisResult: mask_369>, <AnalysisResult: mask_370>, <AnalysisResult: mask_371>, <AnalysisResult: mask_372>, <AnalysisResult: mask_373>, <AnalysisResult: mask_374>, <AnalysisResult: mask_375>, <AnalysisResult: mask_376>, <AnalysisResult: mask_377>, <AnalysisResult: mask_378>, <AnalysisResult: mask_379>, <AnalysisResult: mask_380>, <AnalysisResult: mask_381>, <AnalysisResult: mask_382>, <AnalysisResult: mask_383>, <AnalysisResult: mask_384>, <AnalysisResult: mask_385>, <AnalysisResult: mask_386>, <AnalysisResult: mask_387>, <AnalysisResult: mask_388>, <AnalysisResult: mask_389>, <AnalysisResult: mask_390>, <AnalysisResult: mask_391>, <AnalysisResult: mask_392>, <AnalysisResult: mask_393>, <AnalysisResult: mask_394>, <AnalysisResult: mask_395>, <AnalysisResult: mask_396>, <AnalysisResult: mask_397>, <AnalysisResult: mask_398>, <AnalysisResult: mask_399>, <AnalysisResult: mask_400>, <AnalysisResult: mask_401>, <AnalysisResult: mask_402>, <AnalysisResult: mask_403>, <AnalysisResult: mask_404>, <AnalysisResult: mask_405>, <AnalysisResult: mask_406>, <AnalysisResult: mask_407>, <AnalysisResult: mask_408>, <AnalysisResult: mask_409>, <AnalysisResult: mask_410>, <AnalysisResult: mask_411>, <AnalysisResult: mask_412>, <AnalysisResult: mask_413>, <AnalysisResult: mask_414>, <AnalysisResult: mask_415>, <AnalysisResult: mask_416>, <AnalysisResult: mask_417>, <AnalysisResult: mask_418>, <AnalysisResult: mask_419>, <AnalysisResult: mask_420>, <AnalysisResult: mask_421>, <AnalysisResult: mask_422>, <AnalysisResult: mask_423>, <AnalysisResult: mask_424>, <AnalysisResult: mask_425>, <AnalysisResult: mask_426>, <AnalysisResult: mask_427>, <AnalysisResult: mask_428>, <AnalysisResult: mask_429>, <AnalysisResult: mask_430>, <AnalysisResult: mask_431>, <AnalysisResult: mask_432>, <AnalysisResult: mask_433>, <AnalysisResult: mask_434>, <AnalysisResult: mask_435>, <AnalysisResult: mask_436>, <AnalysisResult: mask_437>, <AnalysisResult: mask_438>, <AnalysisResult: mask_439>, <AnalysisResult: mask_440>, <AnalysisResult: mask_441>, <AnalysisResult: mask_442>, <AnalysisResult: mask_443>, <AnalysisResult: mask_444>, <AnalysisResult: mask_445>, <AnalysisResult: mask_446>, <AnalysisResult: mask_447>, <AnalysisResult: mask_448>, <AnalysisResult: mask_449>, <AnalysisResult: mask_450>, <AnalysisResult: mask_451>, <AnalysisResult: mask_452>, <AnalysisResult: mask_453>, <AnalysisResult: mask_454>, <AnalysisResult: mask_455>, <AnalysisResult: mask_456>, <AnalysisResult: mask_457>, <AnalysisResult: mask_458>, <AnalysisResult: mask_459>, <AnalysisResult: mask_460>, <AnalysisResult: mask_461>, <AnalysisResult: mask_462>, <AnalysisResult: mask_463>, <AnalysisResult: mask_464>, <AnalysisResult: mask_465>, <AnalysisResult: mask_466>, <AnalysisResult: mask_467>, <AnalysisResult: mask_468>, <AnalysisResult: mask_469>, <AnalysisResult: mask_470>, <AnalysisResult: mask_471>, <AnalysisResult: mask_472>, <AnalysisResult: mask_473>, <AnalysisResult: mask_474>, <AnalysisResult: mask_475>, <AnalysisResult: mask_476>, <AnalysisResult: mask_477>, <AnalysisResult: mask_478>, <AnalysisResult: mask_479>, <AnalysisResult: mask_480>, <AnalysisResult: mask_481>, <AnalysisResult: mask_482>, <AnalysisResult: mask_483>, <AnalysisResult: mask_484>, <AnalysisResult: mask_485>, <AnalysisResult: mask_486>, <AnalysisResult: mask_487>, <AnalysisResult: mask_488>, <AnalysisResult: mask_489>, <AnalysisResult: mask_490>, <AnalysisResult: mask_491>, <AnalysisResult: mask_492>, <AnalysisResult: mask_493>, <AnalysisResult: mask_494>, <AnalysisResult: mask_495>, <AnalysisResult: mask_496>, <AnalysisResult: mask_497>, <AnalysisResult: mask_498>, <AnalysisResult: mask_499>, <AnalysisResult: mask_500>, <AnalysisResult: mask_501>, <AnalysisResult: mask_502>, <AnalysisResult: mask_503>, <AnalysisResult: mask_504>, <AnalysisResult: mask_505>, <AnalysisResult: mask_506>, <AnalysisResult: mask_507>, <AnalysisResult: mask_508>, <AnalysisResult: mask_509>, <AnalysisResult: mask_510>, <AnalysisResult: mask_511>, <AnalysisResult: mask_512>, <AnalysisResult: mask_513>, <AnalysisResult: mask_514>, <AnalysisResult: mask_515>, <AnalysisResult: mask_516>, <AnalysisResult: mask_517>, <AnalysisResult: mask_518>, <AnalysisResult: mask_519>, <AnalysisResult: mask_520>, <AnalysisResult: mask_521>, <AnalysisResult: mask_522>, <AnalysisResult: mask_523>, <AnalysisResult: mask_524>, <AnalysisResult: mask_525>, <AnalysisResult: mask_526>, <AnalysisResult: mask_527>, <AnalysisResult: mask_528>, <AnalysisResult: mask_529>, <AnalysisResult: mask_530>, <AnalysisResult: mask_531>, <AnalysisResult: mask_532>, <AnalysisResult: mask_533>, <AnalysisResult: mask_534>, <AnalysisResult: mask_535>, <AnalysisResult: mask_536>, <AnalysisResult: mask_537>, <AnalysisResult: mask_538>, <AnalysisResult: mask_539>, <AnalysisResult: mask_540>, <AnalysisResult: mask_541>, <AnalysisResult: mask_542>, <AnalysisResult: mask_543>, <AnalysisResult: mask_544>, <AnalysisResult: mask_545>, <AnalysisResult: mask_546>, <AnalysisResult: mask_547>, <AnalysisResult: mask_548>, <AnalysisResult: mask_549>, <AnalysisResult: mask_550>, <AnalysisResult: mask_551>, <AnalysisResult: mask_552>, <AnalysisResult: mask_553>, <AnalysisResult: mask_554>, <AnalysisResult: mask_555>, <AnalysisResult: mask_556>, <AnalysisResult: mask_557>, <AnalysisResult: mask_558>, <AnalysisResult: mask_559>, <AnalysisResult: mask_560>, <AnalysisResult: mask_561>, <AnalysisResult: mask_562>, <AnalysisResult: mask_563>, <AnalysisResult: mask_564>, <AnalysisResult: mask_565>, <AnalysisResult: mask_566>, <AnalysisResult: mask_567>, <AnalysisResult: mask_568>, <AnalysisResult: mask_569>, <AnalysisResult: mask_570>, <AnalysisResult: mask_571>, <AnalysisResult: mask_572>, <AnalysisResult: mask_573>, <AnalysisResult: mask_574>, <AnalysisResult: mask_575>, <AnalysisResult: mask_576>, <AnalysisResult: mask_577>, <AnalysisResult: mask_578>, <AnalysisResult: mask_579>, <AnalysisResult: mask_580>, <AnalysisResult: mask_581>, <AnalysisResult: mask_582>, <AnalysisResult: mask_583>, <AnalysisResult: mask_584>, <AnalysisResult: mask_585>, <AnalysisResult: mask_586>, <AnalysisResult: mask_587>, <AnalysisResult: mask_588>, <AnalysisResult: mask_589>, <AnalysisResult: mask_590>, <AnalysisResult: mask_591>, <AnalysisResult: mask_592>, <AnalysisResult: mask_593>, <AnalysisResult: mask_594>, <AnalysisResult: mask_595>, <AnalysisResult: mask_596>, <AnalysisResult: mask_597>, <AnalysisResult: mask_598>, <AnalysisResult: mask_599>, <AnalysisResult: mask_600>, <AnalysisResult: mask_601>, <AnalysisResult: mask_602>, <AnalysisResult: mask_603>, <AnalysisResult: mask_604>, <AnalysisResult: mask_605>, <AnalysisResult: mask_606>, <AnalysisResult: mask_607>, <AnalysisResult: mask_608>, <AnalysisResult: mask_609>, <AnalysisResult: mask_610>, <AnalysisResult: mask_611>, <AnalysisResult: mask_612>, <AnalysisResult: mask_613>, <AnalysisResult: mask_614>, <AnalysisResult: mask_615>, <AnalysisResult: mask_616>, <AnalysisResult: mask_617>, <AnalysisResult: mask_618>, <AnalysisResult: mask_619>, <AnalysisResult: mask_620>, <AnalysisResult: mask_621>, <AnalysisResult: mask_622>, <AnalysisResult: mask_623>, <AnalysisResult: mask_624>, <AnalysisResult: mask_625>, <AnalysisResult: mask_626>, <AnalysisResult: mask_627>, <AnalysisResult: mask_628>, <AnalysisResult: mask_629>, <AnalysisResult: mask_630>, <AnalysisResult: mask_631>, <AnalysisResult: mask_632>, <AnalysisResult: mask_633>, <AnalysisResult: mask_634>, <AnalysisResult: mask_635>, <AnalysisResult: mask_636>, <AnalysisResult: mask_637>, <AnalysisResult: mask_638>, <AnalysisResult: mask_639>, <AnalysisResult: mask_640>, <AnalysisResult: mask_641>, <AnalysisResult: mask_642>, <AnalysisResult: mask_643>, <AnalysisResult: mask_644>, <AnalysisResult: mask_645>, <AnalysisResult: mask_646>, <AnalysisResult: mask_647>, <AnalysisResult: mask_648>, <AnalysisResult: mask_649>, <AnalysisResult: mask_650>, <AnalysisResult: mask_651>, <AnalysisResult: mask_652>, <AnalysisResult: mask_653>, <AnalysisResult: mask_654>, <AnalysisResult: mask_655>, <AnalysisResult: mask_656>, <AnalysisResult: mask_657>, <AnalysisResult: mask_658>, <AnalysisResult: mask_659>, <AnalysisResult: mask_660>, <AnalysisResult: mask_661>, <AnalysisResult: mask_662>, <AnalysisResult: mask_663>, <AnalysisResult: mask_664>, <AnalysisResult: mask_665>, <AnalysisResult: mask_666>, <AnalysisResult: mask_667>, <AnalysisResult: mask_668>, <AnalysisResult: mask_669>, <AnalysisResult: mask_670>, <AnalysisResult: mask_671>, <AnalysisResult: mask_672>, <AnalysisResult: mask_673>, <AnalysisResult: mask_674>, <AnalysisResult: mask_675>, <AnalysisResult: mask_676>, <AnalysisResult: mask_677>, <AnalysisResult: mask_678>, <AnalysisResult: mask_679>, <AnalysisResult: mask_680>, <AnalysisResult: mask_681>, <AnalysisResult: mask_682>, <AnalysisResult: mask_683>, <AnalysisResult: mask_684>, <AnalysisResult: mask_685>, <AnalysisResult: mask_686>, <AnalysisResult: mask_687>, <AnalysisResult: mask_688>, <AnalysisResult: mask_689>, <AnalysisResult: mask_690>, <AnalysisResult: mask_691>, <AnalysisResult: mask_692>, <AnalysisResult: mask_693>, <AnalysisResult: mask_694>, <AnalysisResult: mask_695>, <AnalysisResult: mask_696>, <AnalysisResult: mask_697>, <AnalysisResult: mask_698>, <AnalysisResult: mask_699>, <AnalysisResult: mask_700>, <AnalysisResult: mask_701>, <AnalysisResult: mask_702>, <AnalysisResult: mask_703>, <AnalysisResult: mask_704>, <AnalysisResult: mask_705>, <AnalysisResult: mask_706>, <AnalysisResult: mask_707>, <AnalysisResult: mask_708>, <AnalysisResult: mask_709>, <AnalysisResult: mask_710>, <AnalysisResult: mask_711>, <AnalysisResult: mask_712>, <AnalysisResult: mask_713>, <AnalysisResult: mask_714>, <AnalysisResult: mask_715>, <AnalysisResult: mask_716>, <AnalysisResult: mask_717>, <AnalysisResult: mask_718>, <AnalysisResult: mask_719>, <AnalysisResult: mask_720>, <AnalysisResult: mask_721>, <AnalysisResult: mask_722>, <AnalysisResult: mask_723>, <AnalysisResult: mask_724>, <AnalysisResult: mask_725>, <AnalysisResult: mask_726>, <AnalysisResult: mask_727>, <AnalysisResult: mask_728>, <AnalysisResult: mask_729>, <AnalysisResult: mask_730>, <AnalysisResult: mask_731>, <AnalysisResult: mask_732>, <AnalysisResult: mask_733>, <AnalysisResult: mask_734>, <AnalysisResult: mask_735>, <AnalysisResult: mask_736>, <AnalysisResult: mask_737>, <AnalysisResult: mask_738>, <AnalysisResult: mask_739>, <AnalysisResult: mask_740>, <AnalysisResult: mask_741>, <AnalysisResult: mask_742>, <AnalysisResult: mask_743>, <AnalysisResult: mask_744>, <AnalysisResult: mask_745>, <AnalysisResult: mask_746>, <AnalysisResult: mask_747>, <AnalysisResult: mask_748>, <AnalysisResult: mask_749>, <AnalysisResult: mask_750>, <AnalysisResult: mask_751>, <AnalysisResult: mask_752>, <AnalysisResult: mask_753>, <AnalysisResult: mask_754>, <AnalysisResult: mask_755>, <AnalysisResult: mask_756>, <AnalysisResult: mask_757>, <AnalysisResult: mask_758>, <AnalysisResult: mask_759>, <AnalysisResult: mask_760>, <AnalysisResult: mask_761>, <AnalysisResult: mask_762>, <AnalysisResult: mask_763>, <AnalysisResult: mask_764>, <AnalysisResult: mask_765>, <AnalysisResult: mask_766>, <AnalysisResult: mask_767>, <AnalysisResult: mask_768>, <AnalysisResult: mask_769>, <AnalysisResult: mask_770>, <AnalysisResult: mask_771>, <AnalysisResult: mask_772>, <AnalysisResult: mask_773>, <AnalysisResult: mask_774>, <AnalysisResult: mask_775>, <AnalysisResult: mask_776>, <AnalysisResult: mask_777>, <AnalysisResult: mask_778>, <AnalysisResult: mask_779>, <AnalysisResult: mask_780>, <AnalysisResult: mask_781>, <AnalysisResult: mask_782>, <AnalysisResult: mask_783>, <AnalysisResult: mask_784>, <AnalysisResult: mask_785>, <AnalysisResult: mask_786>, <AnalysisResult: mask_787>, <AnalysisResult: mask_788>, <AnalysisResult: mask_789>, <AnalysisResult: mask_790>, <AnalysisResult: mask_791>, <AnalysisResult: mask_792>, <AnalysisResult: mask_793>, <AnalysisResult: mask_794>, <AnalysisResult: mask_795>, <AnalysisResult: mask_796>, <AnalysisResult: mask_797>, <AnalysisResult: mask_798>, <AnalysisResult: mask_799>, <AnalysisResult: mask_800>, <AnalysisResult: mask_801>, <AnalysisResult: mask_802>, <AnalysisResult: mask_803>, <AnalysisResult: mask_804>, <AnalysisResult: mask_805>, <AnalysisResult: mask_806>, <AnalysisResult: mask_807>, <AnalysisResult: mask_808>, <AnalysisResult: mask_809>, <AnalysisResult: mask_810>, <AnalysisResult: mask_811>, <AnalysisResult: mask_812>, <AnalysisResult: mask_813>, <AnalysisResult: mask_814>, <AnalysisResult: mask_815>, <AnalysisResult: mask_816>, <AnalysisResult: mask_817>, <AnalysisResult: mask_818>, <AnalysisResult: mask_819>, <AnalysisResult: mask_820>, <AnalysisResult: mask_821>, <AnalysisResult: mask_822>, <AnalysisResult: mask_823>, <AnalysisResult: mask_824>, <AnalysisResult: mask_825>, <AnalysisResult: mask_826>, <AnalysisResult: mask_827>, <AnalysisResult: mask_828>, <AnalysisResult: mask_829>, <AnalysisResult: mask_830>, <AnalysisResult: mask_831>, <AnalysisResult: mask_832>, <AnalysisResult: mask_833>, <AnalysisResult: mask_834>, <AnalysisResult: mask_835>, <AnalysisResult: mask_836>, <AnalysisResult: mask_837>, <AnalysisResult: mask_838>, <AnalysisResult: mask_839>, <AnalysisResult: mask_840>, <AnalysisResult: mask_841>, <AnalysisResult: mask_842>, <AnalysisResult: mask_843>, <AnalysisResult: mask_844>, <AnalysisResult: mask_845>, <AnalysisResult: mask_846>, <AnalysisResult: mask_847>, <AnalysisResult: mask_848>, <AnalysisResult: mask_849>, <AnalysisResult: mask_850>, <AnalysisResult: mask_851>, <AnalysisResult: mask_852>, <AnalysisResult: mask_853>, <AnalysisResult: mask_854>, <AnalysisResult: mask_855>, <AnalysisResult: mask_856>, <AnalysisResult: mask_857>, <AnalysisResult: mask_858>, <AnalysisResult: mask_859>, <AnalysisResult: mask_860>, <AnalysisResult: mask_861>, <AnalysisResult: mask_862>, <AnalysisResult: mask_863>, <AnalysisResult: mask_864>, <AnalysisResult: mask_865>, <AnalysisResult: mask_866>, <AnalysisResult: mask_867>, <AnalysisResult: mask_868>, <AnalysisResult: mask_869>, <AnalysisResult: mask_870>, <AnalysisResult: mask_871>, <AnalysisResult: mask_872>, <AnalysisResult: mask_873>, <AnalysisResult: mask_874>, <AnalysisResult: mask_875>, <AnalysisResult: mask_876>, <AnalysisResult: mask_877>, <AnalysisResult: mask_878>, <AnalysisResult: mask_879>, <AnalysisResult: mask_880>, <AnalysisResult: mask_881>, <AnalysisResult: mask_882>, <AnalysisResult: mask_883>, <AnalysisResult: mask_884>, <AnalysisResult: mask_885>, <AnalysisResult: mask_886>, <AnalysisResult: mask_887>, <AnalysisResult: mask_888>, <AnalysisResult: mask_889>, <AnalysisResult: mask_890>, <AnalysisResult: mask_891>, <AnalysisResult: mask_892>, <AnalysisResult: mask_893>, <AnalysisResult: mask_894>, <AnalysisResult: mask_895>, <AnalysisResult: mask_896>, <AnalysisResult: mask_897>, <AnalysisResult: mask_898>, <AnalysisResult: mask_899>, <AnalysisResult: mask_900>, <AnalysisResult: mask_901>, <AnalysisResult: mask_902>, <AnalysisResult: mask_903>, <AnalysisResult: mask_904>, <AnalysisResult: mask_905>, <AnalysisResult: mask_906>, <AnalysisResult: mask_907>, <AnalysisResult: mask_908>, <AnalysisResult: mask_909>, <AnalysisResult: mask_910>, <AnalysisResult: mask_911>, <AnalysisResult: mask_912>, <AnalysisResult: mask_913>, <AnalysisResult: mask_914>, <AnalysisResult: mask_915>, <AnalysisResult: mask_916>, <AnalysisResult: mask_917>, <AnalysisResult: mask_918>, <AnalysisResult: mask_919>, <AnalysisResult: mask_920>, <AnalysisResult: mask_921>, <AnalysisResult: mask_922>, <AnalysisResult: mask_923>, <AnalysisResult: mask_924>, <AnalysisResult: mask_925>, <AnalysisResult: mask_926>, <AnalysisResult: mask_927>, <AnalysisResult: mask_928>, <AnalysisResult: mask_929>, <AnalysisResult: mask_930>, <AnalysisResult: mask_931>, <AnalysisResult: mask_932>, <AnalysisResult: mask_933>, <AnalysisResult: mask_934>, <AnalysisResult: mask_935>, <AnalysisResult: mask_936>, <AnalysisResult: mask_937>, <AnalysisResult: mask_938>, <AnalysisResult: mask_939>, <AnalysisResult: mask_940>, <AnalysisResult: mask_941>, <AnalysisResult: mask_942>, <AnalysisResult: mask_943>, <AnalysisResult: mask_944>, <AnalysisResult: mask_945>, <AnalysisResult: mask_946>, <AnalysisResult: mask_947>, <AnalysisResult: mask_948>, <AnalysisResult: mask_949>, <AnalysisResult: mask_950>, <AnalysisResult: mask_951>, <AnalysisResult: mask_952>, <AnalysisResult: mask_953>, <AnalysisResult: mask_954>, <AnalysisResult: mask_955>, <AnalysisResult: mask_956>, <AnalysisResult: mask_957>, <AnalysisResult: mask_958>, <AnalysisResult: mask_959>, <AnalysisResult: mask_960>, <AnalysisResult: mask_961>, <AnalysisResult: mask_962>, <AnalysisResult: mask_963>, <AnalysisResult: mask_964>, <AnalysisResult: mask_965>, <AnalysisResult: mask_966>, <AnalysisResult: mask_967>, <AnalysisResult: mask_968>, <AnalysisResult: mask_969>, <AnalysisResult: mask_970>, <AnalysisResult: mask_971>, <AnalysisResult: mask_972>, <AnalysisResult: mask_973>, <AnalysisResult: mask_974>, <AnalysisResult: mask_975>, <AnalysisResult: mask_976>, <AnalysisResult: mask_977>, <AnalysisResult: mask_978>, <AnalysisResult: mask_979>, <AnalysisResult: mask_980>, <AnalysisResult: mask_981>, <AnalysisResult: mask_982>, <AnalysisResult: mask_983>, <AnalysisResult: mask_984>, <AnalysisResult: mask_985>, <AnalysisResult: mask_986>, <AnalysisResult: mask_987>, <AnalysisResult: mask_988>, <AnalysisResult: mask_989>, <AnalysisResult: mask_990>, <AnalysisResult: mask_991>, <AnalysisResult: mask_992>, <AnalysisResult: mask_993>, <AnalysisResult: mask_994>, <AnalysisResult: mask_995>, <AnalysisResult: mask_996>, <AnalysisResult: mask_997>, <AnalysisResult: mask_998>, <AnalysisResult: mask_999>]"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time ctx.run(multi_analysis_dense)"
+   ]
   }
  ],
  "metadata": {

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
     install_requires=[
         "numpy",
         "scipy",
+        "sparse",
         "distributed>=1.23.3",
         "click",
         "tornado>=5",

--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -105,8 +105,13 @@ class COMAnalysis(BaseMasksAnalysis):
         cx = parameters.get('cx', detector_x / 2)
         cy = parameters.get('cy', detector_y / 2)
         r = parameters.get('r', float('inf'))
+        use_sparse = parameters.get('use_sparse', None)
+        if use_sparse is None:
+            use_sparse = masks.use_sparse(np.pi * r**2, detector_y * detector_x)
+
         return {
             'cx': cx,
             'cy': cy,
             'r': r,
+            'use_sparse': use_sparse,
         }

--- a/src/libertem/analysis/disk.py
+++ b/src/libertem/analysis/disk.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from libertem import masks
 from libertem.viz import visualize_simple
 from .base import AnalysisResult, AnalysisResultSet
@@ -55,8 +57,13 @@ class DiskMaskAnalysis(BaseMasksAnalysis):
         cx = parameters.get('cx', detector_x / 2)
         cy = parameters.get('cy', detector_y / 2)
         r = parameters.get('r', min(detector_y, detector_x) / 2 * 0.3)
+        use_sparse = parameters.get('use_sparse', None)
+        if use_sparse is None:
+            use_sparse = masks.use_sparse(np.pi * r**2, detector_y * detector_x)
+
         return {
             'cx': cx,
             'cy': cy,
             'r': r,
+            'use_sparse': use_sparse,
         }

--- a/src/libertem/analysis/masks.py
+++ b/src/libertem/analysis/masks.py
@@ -30,15 +30,12 @@ class BaseMasksAnalysis(BaseAnalysis):
         raise NotImplementedError()
 
     def get_use_sparse(self):
-        return False
+        return self.parameters.get('use_sparse', None)
 
 
 class MasksAnalysis(BaseMasksAnalysis):
     def get_mask_factories(self):
         return self.parameters['factories']
-
-    def get_use_sparse(self):
-        return self.parameters['use_sparse']
 
     def get_results(self, job_results):
         shape = tuple(self.dataset.shape.nav)

--- a/src/libertem/analysis/point.py
+++ b/src/libertem/analysis/point.py
@@ -1,4 +1,6 @@
-import scipy.sparse as sp
+import numpy as np
+import sparse
+
 from libertem.viz import visualize_simple
 from .base import AnalysisResult, AnalysisResultSet
 from .masks import BaseMasksAnalysis
@@ -39,8 +41,11 @@ class PointMaskAnalysis(BaseMasksAnalysis):
         dtype = self.dtype
 
         def _point_inner():
-            a = sp.csr_matrix(([1], ([int(cy)], [int(cx)])),
-                    dtype=dtype, shape=sig_shape)
+            a = sparse.COO(
+                data=np.array([1], dtype=dtype),
+                coords=([int(cy)], [int(cx)]),
+                shape=sig_shape
+            )
             return a
         return [_point_inner]
 

--- a/src/libertem/analysis/ring.py
+++ b/src/libertem/analysis/ring.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from libertem import masks
 from libertem.viz import visualize_simple
 from .base import AnalysisResult, AnalysisResultSet
@@ -54,10 +56,14 @@ class RingMaskAnalysis(BaseMasksAnalysis):
         cy = parameters.get('cy', detector_y / 2)
         ro = parameters.get('ro', min(detector_y, detector_x) / 2)
         ri = parameters.get('ri', ro * 0.8)
+        use_sparse = parameters.get('use_sparse', None)
+        if use_sparse is None:
+            use_sparse = masks.use_sparse(np.pi * (ro**2 - ri**2), detector_y * detector_x)
 
         return {
             'cx': cx,
             'cy': cy,
             'ri': ri,
             'ro': ro,
+            'use_sparse': use_sparse,
         }

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -81,9 +81,9 @@ class Context:
         ----------
         factories
             list of functions that take no arguments and create masks. The returned masks can be
-            numpy arrays or scipy.sparse matrices. The mask factories should not reference large
-            objects because they can create significant overheads when they are pickled and
-            unpickled.
+            numpy arrays, scipy.sparse or sparse https://sparse.pydata.org/ matrices. The mask
+            factories should not reference large objects because they can create significant
+            overheads when they are pickled and unpickled.
         dataset
             dataset to work on
         use_sparse
@@ -124,9 +124,9 @@ class Context:
         ----------
         factories
             list of functions that take no arguments and create masks. The returned masks can be
-            numpy arrays or scipy.sparse matrices. The mask factories should not reference large
-            objects because they can create significant overheads when they are pickled and
-            unpickled.
+            numpy arrays, scipy.sparse or sparse https://sparse.pydata.org/ matrices. The mask
+            factories should not reference large objects because they can create significant
+            overheads when they are pickled and unpickled.
         dataset
             dataset to work on
         use_sparse

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
+import sparse
 
 
 def _make_circular_mask(centerX, centerY, imageSizeX, imageSizeY, radius):
@@ -109,14 +110,24 @@ def gradient_y(imageSizeX, imageSizeY, dtype=np.float32):
 
 
 def to_dense(a):
-    if sp.issparse(a):
+    if isinstance(a, sparse.SparseArray):
+        return a.todense()
+    elif sp.issparse(a):
         return a.toarray()
     else:
-        return a
+        return np.array(a)
 
 
 def to_sparse(a):
-    if sp.issparse(a):
+    if isinstance(a, sparse.COO):
         return a
+    elif isinstance(a, sparse.SparseArray):
+        return sparse.COO(a)
+    elif sp.issparse(a):
+        return sparse.COO.from_scipy_sparse(a)
     else:
-        return sp.csr_matrix(a)
+        return sparse.COO.from_numpy(np.array(a))
+
+
+def is_sparse(a):
+    return isinstance(a, sparse.SparseArray) or sp.issparse(a)

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -35,9 +35,18 @@ def _make_circular_mask(centerX, centerY, imageSizeX, imageSizeY, radius):
     return(mask)
 
 
+def use_sparse(mask_area, detector_area):
+    '''
+    Empirical tests have shown that sparse.pydata.org is competitive
+    compared to dense matrices with pytorch up to about 20 % occupancy
+    See Issue #197
+    '''
+    return mask_area < 0.2 * detector_area
+
+
 def circular(centerX, centerY, imageSizeX, imageSizeY, radius):
     """
-    Make a circular mask as a double array.
+    Make a circular mask as a 2D array of bool.
 
     Parameters
     ----------

--- a/src/libertem/preload.py
+++ b/src/libertem/preload.py
@@ -8,7 +8,7 @@
 # flake8: noqa
 
 import numpy
-import scipy.sparse
+import sparse
 from matplotlib import colors, cm
 
 try:

--- a/tests/test_analysis_com.py
+++ b/tests/test_analysis_com.py
@@ -225,3 +225,18 @@ def test_com_default_params(lt_ctx):
         dataset=dataset,
     )
     lt_ctx.run(analysis)
+
+
+def test_com_sparse(lt_ctx):
+    data = _mk_random(size=(16, 16, 16, 16))
+    dataset = MemoryDataSet(
+        data=data.astype("<u2"),
+        tileshape=(1, 16, 16),
+        num_partitions=16,
+        sig_dims=2,
+    )
+
+    analysis = lt_ctx.create_com_analysis(dataset=dataset, cx=8, cy=8, mask_radius=1)
+    job = analysis.get_job()
+    assert analysis.get_use_sparse()
+    assert job.masks.use_sparse

--- a/tests/test_analysis_shapes.py
+++ b/tests/test_analysis_shapes.py
@@ -41,6 +41,13 @@ def test_disk_defaults(lt_ctx, ds_random):
     )
 
 
+def test_disk_sparse(lt_ctx, ds_random):
+    analysis = lt_ctx.create_disk_analysis(dataset=ds_random, cx=8, cy=8, r=1)
+    job = analysis.get_job()
+    assert analysis.get_use_sparse()
+    assert job.masks.use_sparse
+
+
 def test_ring_1(lt_ctx, ds_random):
     analysis = lt_ctx.create_ring_analysis(dataset=ds_random, cx=8, cy=8, ri=5, ro=8)
     results = lt_ctx.run(analysis)
@@ -51,6 +58,13 @@ def test_ring_1(lt_ctx, ds_random):
         results.intensity.raw_data,
         expected,
     )
+
+
+def test_ring_sparse(lt_ctx, ds_random):
+    analysis = lt_ctx.create_ring_analysis(dataset=ds_random, cx=8, cy=8, ri=1, ro=2)
+    job = analysis.get_job()
+    assert analysis.get_use_sparse()
+    assert job.masks.use_sparse
 
 
 def test_ring_3d_ds(lt_ctx):
@@ -126,6 +140,13 @@ def test_point_defaults(lt_ctx, ds_random):
         results.intensity.raw_data,
         expected,
     )
+
+
+def test_point_sparse(lt_ctx, ds_random):
+    analysis = lt_ctx.create_point_analysis(dataset=ds_random)
+    job = analysis.get_job()
+    assert analysis.get_use_sparse()
+    assert job.masks.use_sparse
 
 
 def test_disk_complex(lt_ctx, ds_complex):

--- a/tests/test_mask_container.py
+++ b/tests/test_mask_container.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
+import sparse
 import pytest
 
 from libertem.job.masks import MaskContainer
@@ -12,7 +13,7 @@ from libertem.masks import gradient_x
 def masks():
     input_masks = [
         lambda: np.ones((128, 128)),
-        lambda: np.zeros((128, 128)),
+        lambda: sparse.zeros((128, 128)),
         lambda: np.ones((128, 128)),
         lambda: sp.csr_matrix(((1,), ((64,), (64,))), shape=(128, 128), dtype=np.float32),
         lambda: gradient_x(128, 128, dtype=np.float32),


### PR DESCRIPTION
See #197 for discussion.

The test in the notebook confirms the advantage even if we first generate dense masks and then convert to sparse.