### PR TITLE
add extra_shape param to single type buffer

### DIFF
--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -93,7 +93,10 @@ class BufferWrapper(object):
         elif self._kind == "sig":
             return tuple(orig_shape.sig) + self._extra_shape
         elif self._kind == "single":
-            return (1,)
+            if len(self._extra_shape) > 0:
+                return self._extra_shape
+            else:
+                return (1, )
         else:
             raise ValueError("unknown kind: %s" % kind)
 


### PR DESCRIPTION
Added extra_shape parameter for kind="single" buffer so that users can arbitrarily set the dimension of the buffer beyond 1 dimension.