### PR TITLE
Issue 80 - Fix to allow container deployment

### DIFF
--- a/packaging/creators.json
+++ b/packaging/creators.json
@@ -73,5 +73,12 @@
         "affiliation": "ETH Zürich" ,
         "github": "@jaewshin",
         "contribution": "Single pass numerically stable standard deviation"
+    },
+    {
+        "displayname": "Jay van Schyndel",
+        "authorname": "van Schyndel, Jay",
+        "affiliation": "Monash University eResearch Centre" ,
+        "github": "@ozej8y",
+        "contribution": "Fix issue 80 to allow container deployment"
     }
 ]

--- a/src/libertem/web/base.py
+++ b/src/libertem/web/base.py
@@ -135,12 +135,20 @@ class SharedData(object):
         self.dataset_to_id = {}
         self.executor = None
         self.cluster_params = {}
+        self.local_directory = "dask-worker-space"
 
     def get_local_cores(self, default=2):
         cores = psutil.cpu_count(logical=False)
         if cores is None:
             cores = default
         return cores
+
+    def set_local_directory(self, local_directory):
+        if local_directory is not None:
+            self.local_directory = local_directory
+
+    def get_local_directory(self):
+        return self.local_directory
 
     def get_config(self):
         return {

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -5,7 +5,7 @@ import os
 @click.command()
 @click.option('--port', help='port on which the server should listen on',
               default=9000, type=int)
-@click.option('--local_directory', help='local directory to manage dask-worker-space files',
+@click.option('--local-directory', help='local directory to manage dask-worker-space files',
               default='dask-worker-space', type=str)
 # FIXME: the host parameter is currently disabled, as it poses a security risk
 # as long as there is no authentication

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -5,12 +5,14 @@ import os
 @click.command()
 @click.option('--port', help='port on which the server should listen on',
               default=9000, type=int)
+@click.option('--local_directory', help='local directory to manage dask-worker-space files',
+              default='dask-worker-space', type=str)
 # FIXME: the host parameter is currently disabled, as it poses a security risk
 # as long as there is no authentication
 # see also: https://github.com/LiberTEM/LiberTEM/issues/67
 # @click.option('--host', help='host on which the server should listen on',
 #               default="localhost", type=str)
-def main(port, host="localhost"):
+def main(port, local_directory, host="localhost"):
     os.environ.setdefault('OMP_NUM_THREADS', '1')
     os.environ.setdefault('MKL_NUM_THREADS', '1')
     os.environ.setdefault('OPENBLAS_NUM_THREADS', '1')
@@ -18,4 +20,4 @@ def main(port, host="localhost"):
     from libertem.cli_tweaks import console_tweaks
     from .server import run
     console_tweaks()
-    run(host, port)
+    run(host, port, local_directory)

--- a/src/libertem/web/connect.py
+++ b/src/libertem/web/connect.py
@@ -44,6 +44,7 @@ class ConnectHandler(tornado.web.RequestHandler):
         elif connection["type"].lower() == "local":
             cluster_kwargs = {
                 "threads_per_worker": 1,
+                "local_dir": self.data.get_local_directory()
             }
             if "numWorkers" in connection:
                 cluster_kwargs.update({"n_workers": connection["numWorkers"]})

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -96,10 +96,12 @@ def main(host, port, event_registry, shared_data):
     return app
 
 
-def run(host, port):
+def run(host, port, local_directory):
     # shared state:
     event_registry = EventRegistry()
     shared_data = SharedData()
+
+    shared_data.set_local_directory(local_directory)
 
     main(host, port, event_registry, shared_data)
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
This fix allows the user to set --local_directory to a folder outside the container.
This then allows Dask to write files for a container deployment.

e.g.
libertem-server --local_directory=$home/dask-user-space