### PR TITLE
Fix EMPAD bug; resolve performance regression

### DIFF
--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -102,9 +102,7 @@ class COMAnalysis(BaseMasksAnalysis):
         cx = parameters.get('cx', detector_x / 2)
         cy = parameters.get('cy', detector_y / 2)
         r = parameters.get('r', float('inf'))
-        use_sparse = parameters.get('use_sparse', None)
-        if use_sparse is None:
-            use_sparse = masks.use_sparse(np.pi * r**2, detector_y * detector_x)
+        use_sparse = parameters.get('use_sparse', False)
 
         return {
             'cx': cx,

--- a/src/libertem/analysis/disk.py
+++ b/src/libertem/analysis/disk.py
@@ -57,9 +57,7 @@ class DiskMaskAnalysis(BaseMasksAnalysis):
         cx = parameters.get('cx', detector_x / 2)
         cy = parameters.get('cy', detector_y / 2)
         r = parameters.get('r', min(detector_y, detector_x) / 2 * 0.3)
-        use_sparse = parameters.get('use_sparse', None)
-        if use_sparse is None:
-            use_sparse = masks.use_sparse(np.pi * r**2, detector_y * detector_x)
+        use_sparse = parameters.get('use_sparse', False)
 
         return {
             'cx': cx,

--- a/src/libertem/analysis/point.py
+++ b/src/libertem/analysis/point.py
@@ -26,7 +26,7 @@ class PointMaskAnalysis(BaseMasksAnalysis):
         ])
 
     def get_use_sparse(self):
-        return True
+        return False
 
     def get_mask_factories(self):
         if self.dataset.shape.sig.dims != 2:

--- a/src/libertem/analysis/ring.py
+++ b/src/libertem/analysis/ring.py
@@ -56,9 +56,7 @@ class RingMaskAnalysis(BaseMasksAnalysis):
         cy = parameters.get('cy', detector_y / 2)
         ro = parameters.get('ro', min(detector_y, detector_x) / 2)
         ri = parameters.get('ri', ro * 0.8)
-        use_sparse = parameters.get('use_sparse', None)
-        if use_sparse is None:
-            use_sparse = masks.use_sparse(np.pi * (ro**2 - ri**2), detector_y * detector_x)
+        use_sparse = parameters.get('use_sparse', False)
 
         return {
             'cx': cx,

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -24,7 +24,8 @@ def xml_get_text(nodelist):
 class EMPADFile(RawFile):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._frame_size = np.product(EMPAD_DETECTOR_SIZE_RAW) * self._meta.raw_dtype.itemsize
+        self._frame_size = int(np.product(EMPAD_DETECTOR_SIZE_RAW)) * int(
+            self._meta.raw_dtype.itemsize)
 
     def readinto(self, start, stop, out, crop_to=None):
         """
@@ -153,9 +154,9 @@ class EMPADDataSet(DataSet):
     def check_valid(self):
         try:
             # check filesize:
-            framesize = np.product(EMPAD_DETECTOR_SIZE_RAW)
-            num_frames = np.product(self._scan_size)
-            expected_filesize = num_frames * framesize * np.dtype("float32").itemsize
+            framesize = int(np.product(EMPAD_DETECTOR_SIZE_RAW))
+            num_frames = int(np.product(self._scan_size))
+            expected_filesize = num_frames * framesize * int(np.dtype("float32").itemsize)
             if expected_filesize != self._filesize:
                 raise DataSetException("invalid filesize; expected %d, got %d" % (
                     expected_filesize, self._filesize
@@ -185,7 +186,7 @@ class EMPADDataSet(DataSet):
                 fileset=fileset,
                 partition_slice=part_slice,
                 start_frame=start,
-                num_frames=stop - start,
+                num_frames=int(stop - start),
             )
 
     def __repr__(self):

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -37,15 +37,6 @@ def _make_circular_mask(centerX, centerY, imageSizeX, imageSizeY, radius):
     return(mask)
 
 
-def use_sparse(mask_area, detector_area):
-    '''
-    Empirical tests have shown that sparse.pydata.org is competitive
-    compared to dense matrices with pytorch up to about 20 % occupancy
-    See Issue #197
-    '''
-    return mask_area < 0.2 * detector_area
-
-
 def sparse_template_multi_stack(mask_index, offsetX, offsetY, template, imageSizeX, imageSizeY):
     '''
     Stamp the template in a multi-mask 3D stack at the positions indicated by

--- a/tests/test_analysis_com.py
+++ b/tests/test_analysis_com.py
@@ -225,18 +225,3 @@ def test_com_default_params(lt_ctx):
         dataset=dataset,
     )
     lt_ctx.run(analysis)
-
-
-def test_com_sparse(lt_ctx):
-    data = _mk_random(size=(16, 16, 16, 16))
-    dataset = MemoryDataSet(
-        data=data.astype("<u2"),
-        tileshape=(1, 16, 16),
-        num_partitions=16,
-        sig_dims=2,
-    )
-
-    analysis = lt_ctx.create_com_analysis(dataset=dataset, cx=8, cy=8, mask_radius=1)
-    job = analysis.get_job()
-    assert analysis.get_use_sparse()
-    assert job.masks.use_sparse

--- a/tests/test_analysis_shapes.py
+++ b/tests/test_analysis_shapes.py
@@ -41,13 +41,6 @@ def test_disk_defaults(lt_ctx, ds_random):
     )
 
 
-def test_disk_sparse(lt_ctx, ds_random):
-    analysis = lt_ctx.create_disk_analysis(dataset=ds_random, cx=8, cy=8, r=1)
-    job = analysis.get_job()
-    assert analysis.get_use_sparse()
-    assert job.masks.use_sparse
-
-
 def test_ring_1(lt_ctx, ds_random):
     analysis = lt_ctx.create_ring_analysis(dataset=ds_random, cx=8, cy=8, ri=5, ro=8)
     results = lt_ctx.run(analysis)
@@ -58,13 +51,6 @@ def test_ring_1(lt_ctx, ds_random):
         results.intensity.raw_data,
         expected,
     )
-
-
-def test_ring_sparse(lt_ctx, ds_random):
-    analysis = lt_ctx.create_ring_analysis(dataset=ds_random, cx=8, cy=8, ri=1, ro=2)
-    job = analysis.get_job()
-    assert analysis.get_use_sparse()
-    assert job.masks.use_sparse
 
 
 def test_ring_3d_ds(lt_ctx):
@@ -140,13 +126,6 @@ def test_point_defaults(lt_ctx, ds_random):
         results.intensity.raw_data,
         expected,
     )
-
-
-def test_point_sparse(lt_ctx, ds_random):
-    analysis = lt_ctx.create_point_analysis(dataset=ds_random)
-    job = analysis.get_job()
-    assert analysis.get_use_sparse()
-    assert job.masks.use_sparse
 
 
 def test_disk_complex(lt_ctx, ds_complex):


### PR DESCRIPTION
1. Fix integer overflow in EMPAD reader

2. Switching the sparse matrix back-end has degraded performance for shallow mask stacks, like for example for the various shape analyses. Since sparse matrices are critical for deep mask stacks where the tests showed good performance (to be checked again, perhaps), disable sparse matrices for the default analyses for now and rely on dense matrices that show good, predictable performance in this scenario.