### PR TITLE
Streamline code around RadialFourierAnalysis

### DIFF
--- a/src/libertem/analysis/base.py
+++ b/src/libertem/analysis/base.py
@@ -9,7 +9,7 @@ class AnalysisResult(object):
     """
     def __init__(self, raw_data, visualized, title, desc, key):
         self.raw_data = raw_data
-        self.visualized = visualized
+        self._visualized = visualized
         self.title = title
         self.desc = desc
         self.key = key
@@ -26,10 +26,16 @@ class AnalysisResult(object):
     def get_image(self, save_kwargs=None):
         return encode_image(self.visualized, save_kwargs=save_kwargs)
 
+    @property
+    def visualized(self):
+        if callable(self._visualized):
+            self._visualized = self._visualized()
+        return self._visualized
+
 
 class AnalysisResultSet(object):
     def __init__(self, results, raw_results=None):
-        self.results = results
+        self._results = results
         self.raw_results = raw_results
 
     def __repr__(self):
@@ -48,6 +54,12 @@ class AnalysisResultSet(object):
 
     def __len__(self):
         return len(self.results)
+
+    @property
+    def results(self):
+        if callable(self._results):
+            self._results = self._results()
+        return self._results
 
 
 class BaseAnalysis(object):

--- a/src/libertem/analysis/base.py
+++ b/src/libertem/analysis/base.py
@@ -28,8 +28,9 @@ class AnalysisResult(object):
 
 
 class AnalysisResultSet(object):
-    def __init__(self, results):
+    def __init__(self, results, raw_results=None):
         self.results = results
+        self.raw_results = raw_results
 
     def __repr__(self):
         return repr(self.results)

--- a/src/libertem/analysis/radialfourier.py
+++ b/src/libertem/analysis/radialfourier.py
@@ -83,7 +83,7 @@ class RadialFourierAnalysis(BaseMasksAnalysis):
                         desc="Fourier component",
                     )
                 )
-        return AnalysisResultSet(sets)
+        return AnalysisResultSet(sets, raw_results=job_results)
 
     def get_mask_factories(self):
         if self.dataset.shape.sig.dims != 2:

--- a/src/libertem/analysis/radialfourier.py
+++ b/src/libertem/analysis/radialfourier.py
@@ -3,6 +3,7 @@ from functools import partial
 
 import numpy as np
 import sparse
+import matplotlib.cm as cm
 
 from libertem import masks
 from libertem.viz import CMAP_CIRCULAR_DEFAULT, visualize_simple, cmaps
@@ -27,7 +28,23 @@ class RadialFourierAnalysis(BaseMasksAnalysis):
             min_absolute = np.min(absolute[:, 1:, ...] / normal[:, np.newaxis, ...])
             max_absolute = np.max(absolute[:, 1:, ...] / normal[:, np.newaxis, ...])
             angle = np.angle(job_results)
+            below_threshold = absolute[:, 1:20, ...] < \
+                absolute[:, 2:7:2, ...].max(axis=(1, 2, 3)) * 0.5
+            below_threshold = np.all(below_threshold, axis=1)
+            dominant = np.argmax(absolute[:, 1:20], axis=1) + 1
+            dominant[below_threshold] = 0
             for b in range(n_bins):
+                sets.append(
+                    AnalysisResult(
+                        raw_data=dominant[b],
+                        visualized=partial(
+                            visualize_simple, dominant[b], colormap=cm.tab20, vmin=0, vmax=20
+                        ),
+                        key="dominant_%s" % b,
+                        title="dominant order of bin %s" % b,
+                        desc="Dominant Fourier component",
+                    )
+                )
                 sets.append(
                     AnalysisResult(
                         raw_data=absolute[b, 0],

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -222,7 +222,8 @@ class Context:
         return analysis
 
     def create_radial_fourier_analysis(self, dataset, cx: float = None, cy: float = None,
-            ri: float = None, ro: float = None, n_bins: int = None, max_order: int = None):
+            ri: float = None, ro: float = None, n_bins: int = None, max_order: int = None,
+            use_sparse: bool = None):
         """
         Calculate the Fourier transform of rings around the center.
 
@@ -248,7 +249,7 @@ class Context:
         loc = locals()
         parameters = {
             name: loc[name]
-            for name in ['cx', 'cy', 'ri', 'ro', 'n_bins', 'max_order']
+            for name in ['cx', 'cy', 'ri', 'ro', 'n_bins', 'max_order', 'use_sparse']
             if loc[name] is not None
         }
         analysis = RadialFourierAnalysis(


### PR DESCRIPTION
* Optionally include raw results with analysis
* Corrected and improved back-end selection, closes #361 
* Allow overriding the sparse back-end
* More control over radial_bins() to generate it in the desired format right from the start and avoid conversions
* Visualization and AnalysisResult list optionally lazy to avoid unnecessary overheads when using RadialFourierAnalysis within a script. The savings are very significant in some cases and remove a bottleneck in the head node.
* Add visualization of dominant order, display as default