### PR TITLE
Ameliorate the effect of network backpressure

### DIFF
--- a/src/libertem/web/jobs.py
+++ b/src/libertem/web/jobs.py
@@ -167,7 +167,6 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
                     tile.reduce_into_result(full_result)
                 if time.time() - t < 0.3:
                     continue
-                t = time.time()
                 results = yield full_result
                 images = await result_images(results)
 
@@ -187,6 +186,9 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
                 for image in images:
                     raw_bytes = image.read()
                     self.event_registry.broadcast_event(raw_bytes, binary=True)
+                # The broadcast might have taken quite some time due to
+                # backpressure from the network
+                t = time.time()
         except JobCancelledError:
             return  # TODO: maybe write a message on the websocket?
 


### PR DESCRIPTION
Sending the messages at the end of the loop can block because of network backpressure if the connection between client and server is slow or unreliable.

Previously, this could severely stall the loop because it would enforce an update for each calculation result, acerbating the problem.

With this change, the delay from sending messages is not counted for the debouncing, which allows the server to process a larger number of results until sending the next message over the network. Additionally, this skips a lot of visualization steps in combination with the lazy calculation implemented in PR #362.

Implement the same logic for UDFs.

Thx @sk1p for the help! :-)