### PR TITLE
Adaptive rate for GUI update

### DIFF
--- a/src/libertem/web/jobs.py
+++ b/src/libertem/web/jobs.py
@@ -105,15 +105,15 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
 
         t = time.time()
         post_t = time.time()
-        prev = 0
+        window = 0.3
         async for udf_results in UDFRunner(udf).run_for_dataset_async(ds, executor, roi):
             results = await run_blocking(
                 analysis.get_udf_results,
                 udf_results=udf_results,
             )
-            if time.time() - t < min(max(0.3, 2*(t - post_t), prev * 0.8), 10):
+            window = min(max(window, 2*(t - post_t)), 5)
+            if time.time() - t < window:
                 continue
-            prev = 2*(t - post_t)
             post_t = time.time()
             images = await result_images(results)
 
@@ -173,14 +173,14 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
 
         t = time.time()
         post_t = time.time()
-        prev = 0
+        window = 0.3
         try:
             async for result in executor.run_job(job):
                 for tile in result:
                     tile.reduce_into_result(full_result)
-                if time.time() - t < min(max(0.3, 2*(t - post_t), prev * 0.8), 10):
+                window = min(max(window, 2*(t - post_t)), 5)
+                if time.time() - t < window:
                     continue
-                prev = 2*(t - post_t)
                 post_t = time.time()
                 results = yield full_result
                 images = await result_images(results)

--- a/src/libertem/web/jobs.py
+++ b/src/libertem/web/jobs.py
@@ -110,7 +110,7 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
                 analysis.get_udf_results,
                 udf_results=udf_results,
             )
-            if time.time() - t < min(max(0.3, time.time() - post_t), 10):
+            if time.time() - t < min(max(0.3, t - post_t), 10):
                 continue
             post_t = time.time()
             images = await result_images(results)
@@ -175,7 +175,7 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
             async for result in executor.run_job(job):
                 for tile in result:
                     tile.reduce_into_result(full_result)
-                if time.time() - t < min(max(0.3, time.time() - post_t), 10):
+                if time.time() - t < min(max(0.3, t - post_t), 10):
                     continue
                 post_t = time.time()
                 results = yield full_result

--- a/src/libertem/web/jobs.py
+++ b/src/libertem/web/jobs.py
@@ -110,7 +110,7 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
                 analysis.get_udf_results,
                 udf_results=udf_results,
             )
-            if time.time() - t < min(max(0.3, t - post_t), 10):
+            if time.time() - t < min(max(0.3, 2*(t - post_t)), 10):
                 continue
             post_t = time.time()
             images = await result_images(results)
@@ -175,7 +175,7 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
             async for result in executor.run_job(job):
                 for tile in result:
                     tile.reduce_into_result(full_result)
-                if time.time() - t < min(max(0.3, t - post_t), 10):
+                if time.time() - t < min(max(0.3, 2*(t - post_t)), 10):
                     continue
                 post_t = time.time()
                 results = yield full_result

--- a/src/libertem/web/jobs.py
+++ b/src/libertem/web/jobs.py
@@ -105,13 +105,15 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
 
         t = time.time()
         post_t = time.time()
+        prev = 0
         async for udf_results in UDFRunner(udf).run_for_dataset_async(ds, executor, roi):
             results = await run_blocking(
                 analysis.get_udf_results,
                 udf_results=udf_results,
             )
-            if time.time() - t < min(max(0.3, 2*(t - post_t)), 10):
+            if time.time() - t < min(max(0.3, 2*(t - post_t), prev * 0.8), 10):
                 continue
+            prev = 2*(t - post_t)
             post_t = time.time()
             images = await result_images(results)
 
@@ -171,12 +173,14 @@ class JobDetailHandler(CORSMixin, tornado.web.RequestHandler):
 
         t = time.time()
         post_t = time.time()
+        prev = 0
         try:
             async for result in executor.run_job(job):
                 for tile in result:
                     tile.reduce_into_result(full_result)
-                if time.time() - t < min(max(0.3, 2*(t - post_t)), 10):
+                if time.time() - t < min(max(0.3, 2*(t - post_t), prev * 0.8), 10):
                     continue
+                prev = 2*(t - post_t)
                 post_t = time.time()
                 results = yield full_result
                 images = await result_images(results)


### PR DESCRIPTION
Adapt the integration window for results to match the postprocessing and communication time.

This strongly reduces the update rate and increases the integration window if the network creates
backpressure or if calculating the result images is slow. That improves the overall performance and
user experience. We are not getting the results to the GUI anyway -- at least the merging is not
stalled and the next update will show more data when it finally comes.