### PR TITLE
Improvements of gridmatching

### DIFF
--- a/src/libertem/analysis/fullmatch.py
+++ b/src/libertem/analysis/fullmatch.py
@@ -3,8 +3,6 @@ import hdbscan
 
 import libertem.analysis.gridmatching as grm
 from libertem.utils import make_polar
-# import (Match, PointSelection, CorrelationResult,
-# make_polar, NotFoundException, make_polar_vectors)
 
 
 def full_match(centers, zero=None, parameters={}):
@@ -42,7 +40,7 @@ class FullMatch(grm.Match):
         parameters
             Parameters for the matching.
             min_angle: Minimum angle between two vectors to be considered candidates
-            tolerance: Relative position tolerance for peaks to be considered matches
+            tolerance: Absolute position tolerance in px for peaks to be considered matches
             min_points: Minimum points to try clustering matching. Otherwise match directly
             min_match: Minimum matched clusters from clustering matching to be considered successful
             min_cluster_size_fraction: Tuning parameter for clustering matching. Larger values allow
@@ -143,7 +141,7 @@ def hdbscan_candidates(points, parameters):
     In the end we return the shortest matches.
 
     '''
-    cutoff = parameters["tolerance"] * parameters["max_delta"]
+    cutoff = parameters["tolerance"]
     clusterer = hdbscan.HDBSCAN(**make_hdbscan_config(points, parameters))
     vectors = grm.make_polar_vectors(points, parameters)
     clusterer.fit(vectors)

--- a/src/libertem/analysis/gridmatching.py
+++ b/src/libertem/analysis/gridmatching.py
@@ -341,11 +341,30 @@ class Match(PointSelection):
         '''
         Return the match that matches most points
         '''
+        def fom(d):
+            m = d[1]
+            na = np.linalg.norm(m.a)
+            nb = np.linalg.norm(m.b)
+            res = len(m)
+            # Orthogonal
+            if np.abs(np.dot(m.a, m.b)) < 0.1 * na * nb:
+                res *= 5
+            elif np.abs(np.dot(m.a, m.b)) < 0.3 * na * nb:
+                res *= 2
+            # nearly equal length
+            if (na - nb) < 0.1 * max(na, nb):
+                res *= 5
+            if (na - nb) < 0.3 * max(na, nb):
+                res *= 2
+            res /= na
+            res /= nb
+            return res
+
         match_matrix = cls._do_match(point_selection, zero, candidates, parameters)
         if match_matrix:
             # we select the entry with highest number of matches
             candidate_index, match = sorted(
-                match_matrix.items(), key=lambda d: len(d[1]), reverse=True
+                match_matrix.items(), key=fom, reverse=True
             )[0]
             return match
         else:

--- a/src/libertem/analysis/gridmatching.py
+++ b/src/libertem/analysis/gridmatching.py
@@ -120,7 +120,7 @@ class Match(PointSelection):
 
         parameters = {
             "min_angle": np.pi / 5,
-            "tolerance": 0.02,
+            "tolerance": 1,
             "min_points": 10,
             "min_match": 3,
             "min_cluster_size_fraction": 4,
@@ -222,7 +222,7 @@ class Match(PointSelection):
             The near approximate vectors a, b to match the grid as numpy arrays (y, x).
         parameters
             Parameters for the matching.
-            tolerance: Relative position tolerance for peaks to be considered matches
+            tolerance: Position tolerance in px for peaks to be considered matches
             min_delta: Minimum length of a potential grid vector
             max_delta: Maximum length of a potential grid vector
 
@@ -291,13 +291,6 @@ class Match(PointSelection):
 
         Return match
         '''
-        # If we have a properly set max_delta, we scale the tolerance so that
-        # it can stay at a default value
-        # Otherwise we just assume a scaling factor 1, for better or for worse
-        if parameters['max_delta'] < np.float('inf'):
-            cutoff = parameters['max_delta'] * parameters["tolerance"]
-        else:
-            cutoff = parameters["tolerance"]
         try:
             indices = get_indices(point_selection.refineds, zero, a, b)
         # FIXME proper error handling strategy
@@ -305,7 +298,7 @@ class Match(PointSelection):
             raise
         rounded = np.around(indices)
         errors = np.linalg.norm(np.absolute(indices - rounded), axis=1)
-        matched_selector = errors < cutoff
+        matched_selector = errors < parameters["tolerance"]
         matched_indices = rounded[matched_selector].astype(np.int)
         # remove the ones that weren't matched
         new_selector = point_selection.new_selector(matched_selector)

--- a/tests/test_gridmatching.py
+++ b/tests/test_gridmatching.py
@@ -232,9 +232,9 @@ def test_fullmatch_three_residual(zero, a, b):
     grid_2 = _fullgrid(zero, aa, bb, 4, skip_zero=True)
 
     random = np.array([
-        (0.3, 0.5),
-        (-0.3, 12.5),
-        (-0.3, -17.5),
+        (0.3, 0.4),
+        (-0.33, 12.5),
+        (-0.37, -17.4),
     ])
 
     grid = np.vstack((grid_1, grid_2, random))
@@ -242,9 +242,13 @@ def test_fullmatch_three_residual(zero, a, b):
     parameters = {
         'min_delta': 0.3,
         'max_delta': 3,
+        'tolerance': 0.05
     }
 
     (matches, unmatched, weak) = fm.full_match(grid, zero=zero, parameters=parameters)
+
+    print(matches[0])
+    print(matches[1])
 
     assert(len(matches) == 2)
 
@@ -253,11 +257,11 @@ def test_fullmatch_three_residual(zero, a, b):
 
     match1 = matches[0]
 
-    assert(np.allclose(zero, match1.zero))
+    assert np.allclose(zero, match1.zero)
     assert(np.allclose(a, match1.a) or np.allclose(b, match1.a)
-           or np.allclose(-a, match1.a) or np.allclose(-b, match1.a))
+          or np.allclose(-a, match1.a) or np.allclose(-b, match1.a))
     assert(np.allclose(a, match1.b) or np.allclose(b, match1.b)
-           or np.allclose(-a, match1.b) or np.allclose(-b, match1.b))
+          or np.allclose(-a, match1.b) or np.allclose(-b, match1.b))
     assert(len(match1) == len(grid_1))
     assert(np.allclose(match1.calculated_refineds, grid_1))
 
@@ -297,6 +301,7 @@ def test_fullmatch_one_residual(zero, a, b):
     parameters = {
         'min_delta': 0.3,
         'max_delta': 3,
+        'tolerance': 0.1
     }
     (matches, unmatched, weak) = fm.full_match(grid, zero=zero, parameters=parameters)
 
@@ -320,8 +325,12 @@ def test_fullmatch_no_residual(zero, a, b):
     parameters = {
         'min_delta': 0.3,
         'max_delta': 3,
+        'tolerance': 0.1
     }
     (matches, unmatched, weak) = fm.full_match(grid, zero=zero, parameters=parameters)
+
+    print(matches[0])
+    print(matches[1])
 
     assert(len(matches) == 2)
 
@@ -347,6 +356,7 @@ def test_fullmatch_weak(zero, a, b):
     parameters = {
         'min_delta': 0.3,
         'max_delta': 3,
+        'tolerance': 0.05
     }
 
     values = np.ones(len(grid))


### PR DESCRIPTION
* Prefer short, orthogonal vectors of equal size -- introduce figure of merit for matches. This leads to more "reasonable", predictable and uniform matches that depend less on the positions in the point cloud.
* Refactoring to make importlib.reload() easier to use
* Uniform behavior of tolerance: always in px, since the limits are hardly used in practice.