### PR TITLE
Auto UDF to allow trivial UDFs without boilerplate

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
 install:
-  - "%PYTHON%/Scripts/pip.exe install tox codecov"
+  - "%PYTHON%/Scripts/pip.exe install tox codecov cython"
 
 test_script:
   - "%PYTHON%/Scripts/tox"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
 install:
-  - "%PYTHON%/Scripts/pip.exe install tox codecov cython"
+  - "%PYTHON%/Scripts/pip.exe install --force-reinstall tox codecov"
 
 test_script:
   - "%PYTHON%/Scripts/tox"

--- a/docs/source/app/strain.rst
+++ b/docs/source/app/strain.rst
@@ -1,4 +1,22 @@
 Strain mapping
 ==============
 
-TODO
+TODO write description
+
+Reference
+~~~~~~~~~
+
+.. automodule:: libertem.udf.blobfinder
+   :members:
+   :undoc-members:
+   :special-members: __init__
+
+.. automodule:: libertem.analysis.gridmatching
+   :members:
+   :undoc-members:
+   :special-members: __init__
+
+.. automodule:: libertem.analysis.fullmatch
+   :members:
+   :undoc-members:
+   :special-members: __init__

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -110,7 +110,7 @@ To run the testsuite for the client, first install the JavaScript/TypeScript dep
    $ cd client/
    $ npm install
 
-Then, in the same dircetory, to run the tests execute:
+Then, in the same directory, to run the tests execute:
 
 .. code-block:: shell
 
@@ -194,7 +194,7 @@ If you would like to contribute to the client, you first need to set up the deve
 For this, first install nodejs. On Linux, we recommend to `install via package manager <https://nodejs.org/en/download/package-manager/>`_,
 on Windows `the installer <https://nodejs.org/en/download/>`_ should be fine. Choose the current LTS version, which is 10.x at the time of writing.
 
-One you have nodejs installed, you should have the npm command available in your path. You can then install
+One you have NodeJS installed, you should have the npm command available in your path. You can then install
 the needed build tools and dependencies by changing to the client directory and running the install command:
 
 .. code-block:: shell

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -29,3 +29,8 @@ Internal API
    :members:
    :undoc-members:
    :special-members: __init__
+
+.. automodule:: libertem.job.masks
+   :members: MaskContainer
+   :undoc-members:
+   :special-members: __init__

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -31,6 +31,6 @@ Internal API
    :special-members: __init__
 
 .. automodule:: libertem.job.masks
-   :members: MaskContainer
+   :members: MaskContainer,ApplyMasksJob
    :undoc-members:
    :special-members: __init__

--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -52,7 +52,7 @@ All numpy dtypes are supported for buffers. That includes the :code:`object` dty
 By-frame processing
 -------------------
 Note that :meth:`~libertem.udf.UDFFrameMixin.process_frame` method can interpreted in a slightly different manner for different types of buffer with which you
-are dealing. If the type of the buffer is :code:"sig", then :meth:`~libertem.udf.UDFFrameMixin.process_frame` can be viewed as iteratively `merging` the previous
+are dealing. If the type of the buffer is :code:`"sig"`, then :meth:`~libertem.udf.UDFFrameMixin.process_frame` can be viewed as iteratively `merging` the previous
 computations (i.e., the result computed on previously considered set of frames) and a newly added frame. If the type of
 the buffer is :code:`"nav"`, then :meth:`~libertem.udf.UDFFrameMixin.process_frame` can be viewed as performing operations on each frame independently. Intuitively, when the type of the buffer is :code:`"nav"`, which means that it uses the navigation dimension, two different frames
 correspond to two different scan positions, so the `merging` is in fact an assignment of the result to the correct slot in the result buffer. Lastly, if the type of the buffer is :code:`"single"`, then :meth:`~libertem.udf.UDFFrameMixin.process_frame` can be
@@ -104,7 +104,7 @@ Passing parameters
 
 By default, keyword arguments that are passed to the constructor of a UDF are available as properties of :code:`self.params`:
 
-.. code-block::python
+.. code-block:: python
 
     class MyUDF(UDF):
 
@@ -232,7 +232,7 @@ to use multiple cores, the effectively available L3 cache has to be divided by n
 Real-world example
 ~~~~~~~~~~~~~~~~~~
 
-The :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` uses :meth:`~libertem.udf.UDFTileMixin.process_tile` to implement a custom version of a :class:`~libertem.job.masks.MaskJob` that works on log-scaled data. The mask stack is stored in a :class:`libertem.job.mask.MaskContainer` as part of the task data. Note how the :class:`~libertem.common.Slice` :code:`tile_slice` argument is used to extract the region from the mask stack that matches the tile using the facilities of a :class:`~libertem.job.masks.MaskContainer`. After reshaping, transposing and log scaling the tile data into the right memory layout, the mask stack is applied to the data with a dot product. The result is *added* to the buffer in order to merge it with the results of the other tiles because addition is the correct merge function for a dot product. Other operations would require a different merge function here, for example :meth:`numpy.max()` if a global maximum is to be calculated.
+The :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` uses :meth:`~libertem.udf.UDFTileMixin.process_tile` to implement a custom version of a :class:`~libertem.job.masks.ApplyMasksJob` that works on log-scaled data. The mask stack is stored in a :class:`libertem.job.mask.MaskContainer` as part of the task data. Note how the :class:`~libertem.common.Slice` :code:`tile_slice` argument is used to extract the region from the mask stack that matches the tile using the facilities of a :class:`~libertem.job.masks.MaskContainer`. After reshaping, transposing and log scaling the tile data into the right memory layout, the mask stack is applied to the data with a dot product. The result is *added* to the buffer in order to merge it with the results of the other tiles because addition is the correct merge function for a dot product. Other operations would require a different merge function here, for example :meth:`numpy.max()` if a global maximum is to be calculated.
 
 .. code-block:: python
 
@@ -250,7 +250,7 @@ The :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` uses :meth:`~libertem
 Post-processing
 ~~~~~~~~~~~~~~~
 
-Post-processing allows to perform additional processing steps once the data of a partition is completely processed with :meth:`~libertem.udf.UDFFrameMixin.process_frame`, :meth:`~libertem.udf.UDFTileMixin.process_tile` or :meth:`~libertem.udf.UDFPartitionMixin.process_partition`. Post-processing is particularly relevant for tiled processing since that allows to combine the performance benefits of tiled processing for a first reduction step with additional steps that require reduced data from complete frames or even a complete partition.
+Post-processing allows to perform additional processing steps once the data of a partition is completely processed with :meth:`~libertem.udf.UDFFrameMixin.process_frame`, :meth:`~libertem.udf.UDFTileMixin.process_tile` or :meth:`~libertem.udf.UDFPartitionMixin.process_partition`. Post-processing is particularly relevant for tiled processing since that allows to combine the performance benefits of tiled processing for a first reduction step with subsequent steps that require reduced data from complete frames or even a complete partition.
 
 Real-world example from :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` which evaluates the correlation maps that have been generated with the dot product in the previous processing step and places the results in additional result buffers:
 
@@ -280,9 +280,6 @@ Real-world example from :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` w
 
 Partition processing
 --------------------
-
-Motivation
-~~~~~~~~~~
 
 Some algorithms can benefit from processing entire partitions, for example if they require several passes over the data. In most cases, :ref:`tiled processing<tiled>` will be faster because it uses the L3 cache more efficiently. For that reason, per-partition processing should only be used if there are clear indications for it. Implementing :meth:`~libertem.udf.UDFPartitionMixin.process_partition` activates per-partition processing for an UDF.
 

--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -15,11 +15,11 @@ How UDF works in layman's terms
 
 The UDF interface of LiberTEM is heavily utilizing the existing LiberTEM architecture. First,
 data is partitioned into several `"partitions"` and distributed across workers. Then, each partition,
-which can be viewed as a collection of frames, are processed by the user-defined :meth:`process_frame` or :meth:`process_tile` method. Tiles are described in more detail in `tiled processing`_ and are useful to improve the performance of some numerical operations. In the following, the simpler :meth:`process_frame` interface is described first.
-Here, frames or tiles are fetched in an iterative manner, and the :meth:`process_frame` or :meth:`process_tile` method performs user-defined operations
+which can be viewed as a collection of frames, are processed by the user-defined :meth:`~libertem.udf.UDFFrameMixin.process_frame`, :meth:`~libertem.udf.UDFTileMixin.process_tile` :meth:`~libertem.udf.UDFPartitionMixin.process_partition` method. Tiles are described in more detail in `tiled processing`_ and are useful to improve the performance of some numerical operations. In the following, the simpler :meth:`~libertem.udf.UDFFrameMixin.process_frame` interface is described first.
+Here, frames or tiles are fetched in an iterative manner, and the :meth:`~libertem.udf.UDFFrameMixin.process_frame` or :meth:`~libertem.udf.UDFTileMixin.process_tile` method performs user-defined operations
 on the frames. After all the frames in a partition are processed, LiberTEM iteratively `merges` the results from each worker, which is called
-by the :meth:`merge` method in UDF class. To summarize, the UDF interface of LiberTEM performs operations at two levels: :meth:`process_frame`, which performs user-defined operations
-on frames within each partition, and :meth:`merge`, which merges the output of :meth:`process_frame` from each partition. Note that in both :meth:`process_frame` and :meth:`merge`, buffers store the intermediate
+by the :meth:`~libertem.udf.UDF.merge` method in UDF class. To summarize, the UDF interface of LiberTEM performs operations at two levels: :meth:`~libertem.udf.UDFFrameMixin.process_frame`, which performs user-defined operations
+on frames within each partition, and :meth:`~libertem.udf.UDF.merge`, which merges the output of :meth:`~libertem.udf.UDFFrameMixin.process_frame` from each partition. Note that in both :meth:`~libertem.udf.UDFFrameMixin.process_frame` and :meth:`~libertem.udf.UDF.merge`, buffers store the intermediate
 outcomes of the user-defined operations.
 
 Initializing Buffers
@@ -51,11 +51,11 @@ All numpy dtypes are supported for buffers. That includes the :code:`object` dty
 
 By-frame processing
 -------------------
-Note that :meth:`process_frame` method can interpreted in a slightly different manner for different types of buffer with which you
-are dealing. If the type of the buffer is :code:"sig", then :meth:`process_frame` can be viewed as iteratively `merging` the previous
+Note that :meth:`~libertem.udf.UDFFrameMixin.process_frame` method can interpreted in a slightly different manner for different types of buffer with which you
+are dealing. If the type of the buffer is :code:"sig", then :meth:`~libertem.udf.UDFFrameMixin.process_frame` can be viewed as iteratively `merging` the previous
 computations (i.e., the result computed on previously considered set of frames) and a newly added frame. If the type of
-the buffer is :code:`"nav"`, then :meth:`process_frame` can be viewed as performing operations on each frame independently. Intuitively, when the type of the buffer is :code:`"nav"`, which means that it uses the navigation dimension, two different frames
-correspond to two different scan positions, so the `merging` is in fact an assignment of the result to the correct slot in the result buffer. Lastly, if the type of the buffer is :code:`"single"`, then :meth:`process_frame` can be
+the buffer is :code:`"nav"`, then :meth:`~libertem.udf.UDFFrameMixin.process_frame` can be viewed as performing operations on each frame independently. Intuitively, when the type of the buffer is :code:`"nav"`, which means that it uses the navigation dimension, two different frames
+correspond to two different scan positions, so the `merging` is in fact an assignment of the result to the correct slot in the result buffer. Lastly, if the type of the buffer is :code:`"single"`, then :meth:`~libertem.udf.UDFFrameMixin.process_frame` can be
 interpreted in either way.
 
 As an easy example, let's have a look at a function that simply sums up each frame
@@ -79,9 +79,9 @@ for example :code:`libertem.udf.blobfinder`.
 Auto UDF
 --------
 
-The :class:`AutoUDF` class and :meth:`Context.map()` method allow to run simple functions that accept a frame as the only parameter with an auto-generated :code:`kind="nav"` result buffer over a dataset ad-hoc without defining an UDF class. For more advanced processing, such as custom merge functions, postprocessing or performance optimization through tiled processing, defining an UDF class is required.
+The :class:`~libertem.udf.AutoUDF` class and :meth:`~libertem.api.Context.map` method allow to run simple functions that accept a frame as the only parameter with an auto-generated :code:`kind="nav"` result buffer over a dataset ad-hoc without defining an UDF class. For more advanced processing, such as custom merge functions, post-processing or performance optimization through tiled processing, defining an UDF class is required.
 
-The :class:`AutoUDF` class determines the output shape and type by calling the function with a mock-up frame of the same type and shape as a real detector frame and converting the return value to a numpy array. The :code:`extra_shape` and :code:`dtype` parameters for the result buffer are derived automatically from this numpy array. Additional constant parameters can be passed to the function via :meth:`functools.partial`, for example. The return value should be much smaller than the input size for this to work efficiently.
+The :class:`~libertem.udf.AutoUDF` class determines the output shape and type by calling the function with a mock-up frame of the same type and shape as a real detector frame and converting the return value to a numpy array. The :code:`extra_shape` and :code:`dtype` parameters for the result buffer are derived automatically from this numpy array. Additional constant parameters can be passed to the function via :meth:`functools.partial`, for example. The return value should be much smaller than the input size for this to work efficiently.
 
 Example: Calculate sum over the last signal axis.
 
@@ -91,6 +91,78 @@ Example: Calculate sum over the last signal axis.
             dataset=dataset,
             f=functools.partial(np.sum, axis=-1)
       )
+
+      # or alternatively:
+
+      udf = AutoUDF(f=functools.partial(np.sum, axis=-1))
+      result = self.run_udf(dataset=dataset, udf=udf)
+
+.. _tiled:
+
+Passing parameters
+------------------
+
+By default, keyword arguments that are passed to the constructor of a UDF are available as properties of :code:`self.params`:
+
+.. code-block::python
+
+    class MyUDF(UDF):
+
+        def process_frame(self, frame):
+            result = correlate_peaks(frame, self.params.peaks)
+            ...
+
+    udf = MyUDF(peaks=peaks, ...)
+
+
+AUX data
+~~~~~~~~
+
+If a parameter is an instance of :class:`~libertem.common.buffers.BufferWrapper`, the UDF interface will interpret it as auxiliary data. It will set the views for each tile/frame/partition accordingly so that accessing the parameter returns a view of the auxiliary data matching the data portion that is currently being processed. That way, it is possible to pass parameters individually for each frame or to mask the signal dimension. The :meth:`~libertem.udf.UDF.aux_data` class method helps to wrap data into a suitable :class:`~libertem.common.buffers.BufferWrapper`.
+
+For masks in the signal dimension that are used for dot products in combination with per-tile processing, a :class:`~libertem.job.masks.MaskContainer` allows to use more advanced slicing and transformation methods targeted at preparing mask stacks for optimal dot product performance.
+
+Task data
+---------
+
+A UDF can generate task-specific intermediate data on the worker nodes by defining a :meth:`~libertem.udf.UDF.get_task_data` method. The result is available as an instance of :class:`~libertem.udf.UDFData` in :code:`self.task_data`. Depending on the circumstances, this can be more efficient than making the data available as a parameter since it avoids pickling, network transport and unpickling.
+
+This non-trivial example from :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` creates a :class:`~libertem.job.masks.MaskContainer` based on the parameters in :code:`self.params`. This :class:`~libertem.job.masks.MaskContainer` is then available as :code:`self.task_data['mask_container']` within the processing functions.
+
+.. code-block:: python
+
+    def get_task_data(self):
+        mask = mask_maker(self.params)
+        crop_size = mask.get_crop_size()
+        size = (2 * crop_size + 1, 2 * crop_size + 1)
+        template = mask.get_mask(sig_shape=size)
+        steps = self.params.steps
+        peak_offsetY, peak_offsetX = np.mgrid[-steps:steps + 1, -steps:steps + 1]
+
+        offsetY = self.params.peaks[:, 0, np.newaxis, np.newaxis] + peak_offsetY - crop_size
+        offsetX = self.params.peaks[:, 1, np.newaxis, np.newaxis] + peak_offsetX - crop_size
+
+        offsetY = offsetY.flatten()
+        offsetX = offsetX.flatten()
+
+        stack = functools.partial(
+            sparse_template_multi_stack,
+            mask_index=range(len(offsetY)),
+            offsetX=offsetX,
+            offsetY=offsetY,
+            template=template,
+            imageSizeX=self.meta.dataset_shape.sig[1],
+            imageSizeY=self.meta.dataset_shape.sig[0]
+        )
+        # CSC matrices in combination with transposed data are fastest
+        container = MaskContainer(mask_factories=stack, dtype=np.float32,
+            use_sparse='scipy.sparse.csc')
+
+        kwargs = {
+            'mask_container': container,
+            'crop_size': crop_size,
+        }
+        return kwargs
 
 Tiled processing
 ----------------
@@ -157,7 +229,67 @@ Note: you may have noticed that we talk about block sizes of 1MB as efficient in
 but many CPUs have larger L3 caches. As the L3 cache is shared between cores, and LiberTEM tries
 to use multiple cores, the effectively available L3 cache has to be divided by number of cores.
 
-TODO: documentation on implementing :code:`process_tile`, :code:`process_partition`
+Real-world example
+~~~~~~~~~~~~~~~~~~
+
+The :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` uses :meth:`~libertem.udf.UDFTileMixin.process_tile` to implement a custom version of a :class:`~libertem.job.masks.MaskJob` that works on log-scaled data. The mask stack is stored in a :class:`libertem.job.mask.MaskContainer` as part of the task data. Note how the :class:`~libertem.common.Slice` :code:`tile_slice` argument is used to extract the region from the mask stack that matches the tile using the facilities of a :class:`~libertem.job.masks.MaskContainer`. After reshaping, transposing and log scaling the tile data into the right memory layout, the mask stack is applied to the data with a dot product. The result is *added* to the buffer in order to merge it with the results of the other tiles because addition is the correct merge function for a dot product. Other operations would require a different merge function here, for example :meth:`numpy.max()` if a global maximum is to be calculated.
+
+.. code-block:: python
+
+    def process_tile(self, tile, tile_slice):
+        c = self.task_data['mask_container']
+        tile_t = np.zeros(
+            (np.prod(tile.shape[1:]), tile.shape[0]),
+            dtype=tile.dtype
+        )
+        log_scale(tile.reshape((tile.shape[0], -1)).T, out=tile_t)
+
+        sl = c.get(key=tile_slice, transpose=False)
+        self.results.corr[:] += sl.dot(tile_t).T
+
+Post-processing
+~~~~~~~~~~~~~~~
+
+Post-processing allows to perform additional processing steps once the data of a partition is completely processed with :meth:`~libertem.udf.UDFFrameMixin.process_frame`, :meth:`~libertem.udf.UDFTileMixin.process_tile` or :meth:`~libertem.udf.UDFPartitionMixin.process_partition`. Post-processing is particularly relevant for tiled processing since that allows to combine the performance benefits of tiled processing for a first reduction step with additional steps that require reduced data from complete frames or even a complete partition.
+
+Real-world example from :class:`~libertem.udf.blobfinder.SparseCorrelationUDF` which evaluates the correlation maps that have been generated with the dot product in the previous processing step and places the results in additional result buffers:
+
+.. code-block:: python
+
+    def postprocess(self):
+        steps = 2 * self.params.steps + 1
+        corrmaps = self.results.corr.reshape((
+            -1,  # frames
+            len(self.params.peaks),  # peaks
+            steps,  # Y steps
+            steps,  # X steps
+        ))
+        peaks = self.params.peaks
+        r = self.results
+        for f in range(corrmaps.shape[0]):
+            for p in range(len(self.params.peaks)):
+                corr = corrmaps[f, p]
+                center, refined, peak_value, peak_elevation = evaluate_correlation(corr)
+                abs_center = _shift(center, peaks[p], self.params.steps).astype('u2')
+                abs_refined = _shift(refined, peaks[p], self.params.steps).astype('float32')
+                r.centers[f, p] = abs_center
+                r.refineds[f, p] = abs_refined
+                r.peak_values[f, p] = peak_value
+                r.peak_elevations[f, p] = peak_elevation
+
+
+Partition processing
+--------------------
+
+Motivation
+~~~~~~~~~~
+
+Some algorithms can benefit from processing entire partitions, for example if they require several passes over the data. In most cases, :ref:`tiled processing<tiled>` will be faster because it uses the L3 cache more efficiently. For that reason, per-partition processing should only be used if there are clear indications for it. Implementing :meth:`~libertem.udf.UDFPartitionMixin.process_partition` activates per-partition processing for an UDF.
+
+Precedence
+----------
+
+The UDF interface looks for methods in the order :meth:`~libertem.udf.UDFTileMixin.process_tile`, :meth:`~libertem.udf.UDFFrameMixin.process_frame`, :meth:`~libertem.udf.UDFPartitionMixin.process_partition`. For now, the first in that order is executed. In the future, composition of UDFs may allow to use different methods depending on the circumstances. :meth:`~libertem.udf.UDFTileMixin.process_tile` is the most general method and allows by-frame and by-partition processing as well.
 
 Debugging
 ---------

--- a/src/libertem/analysis/fullmatch.py
+++ b/src/libertem/analysis/fullmatch.py
@@ -29,28 +29,41 @@ class FullMatch(grm.Match):
         This function extracts a list of Match objects as well two PointCollection objects
         for unmatched and weak points from correlation_result and zero point.
         The zero point is included in each of the matches because it is shared between all grids.
+
         Parameters
         ----------
-        correlation_result
+
+        correlation_result:
             A CorrelationResult object with coordinates and weights
-        zero
+        zero:
             Zero point as numpy array (y, x).
-        cand
+        cand:
             Optional list of candidate vectors to use in a first matching round before guessing.
-        parameters
+        parameters:
             Parameters for the matching.
-            min_angle: Minimum angle between two vectors to be considered candidates
-            tolerance: Absolute position tolerance in px for peaks to be considered matches
-            min_points: Minimum points to try clustering matching. Otherwise match directly
-            min_match: Minimum matched clusters from clustering matching to be considered successful
-            min_cluster_size_fraction: Tuning parameter for clustering matching. Larger values allow
+
+            min_angle:
+                Minimum angle between two vectors to be considered candidates
+            tolerance:
+                Absolute position tolerance in px for peaks to be considered matches
+            min_points:
+                Minimum points to try clustering matching. Otherwise match directly
+            min_match:
+                Minimum matched clusters from clustering matching to be considered successful
+            min_cluster_size_fraction:
+                Tuning parameter for clustering matching. Larger values allow
                 smaller or fuzzier clusters.
-            min_samples_fraction: Tuning parameter for clustering matching. Larger values allow
+            min_samples_fraction:
+                Tuning parameter for clustering matching. Larger values allow
                 smaller or fuzzier clusters.
-            min_weight: Minimum weight for a point to be included in the fit
-            num_candidates: Maximum number of candidates to return from clustering matching
-            min_delta: Minimum length of a potential grid vector
-            max_delta: Maximum length of a potential grid vector
+            min_weight:
+                Minimum weight for a point to be included in the fit
+            num_candidates:
+                Maximum number of candidates to return from clustering matching
+            min_delta:
+                Minimum length of a potential grid vector
+            max_delta:
+                Maximum length of a potential grid vector
         returns:
             (matches: list of Match objects, unmatched: PointCollection, weak: PointCollection)
         '''

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -484,6 +484,11 @@ class Context:
 
         roi : np.ndarray
             region of interest as bool mask over the navigation axes of the dataset
+
+        Returns
+        -------
+        UDFData:
+            Return value of the UDF containing the result buffers
         """
         return UDFRunner(udf).run_for_dataset(dataset, self.executor, roi)
 

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -19,6 +19,7 @@ from libertem.analysis.point import PointMaskAnalysis
 from libertem.analysis.masks import MasksAnalysis
 from libertem.analysis.base import BaseAnalysis
 from libertem.udf.base import UDFRunner, UDF
+from libertem.udf.auto import AutoUDF
 
 
 class Context:
@@ -491,6 +492,32 @@ class Context:
             Return value of the UDF containing the result buffers
         """
         return UDFRunner(udf).run_for_dataset(dataset, self.executor, roi)
+
+    def map(self, dataset, f, roi=None):
+        '''
+        Create an :class:`AutoUDF` with function :meth:`f` and run it on :code:`dataset`
+
+        Parameters
+        ----------
+
+        dataset:
+            The dataset to work on
+        f:
+            Function that accepts a frame as the only parameter. It should return a strongly
+            reduced output compared to the size of a frame.
+        roi : np.ndarray
+            region of interest as bool mask over the navigation axes of the dataset
+
+        Returns
+        -------
+
+        UDFData:
+            The result of the UDF with a single buffer named "result" with :code:`extra_shape`
+            and :code:`dtype` set to contain all return values of :meth:`f` converted to a numpy
+            array
+        '''
+        udf = AutoUDF(f=f)
+        return self.run_udf(dataset=dataset, udf=udf, roi=roi)
 
     def _create_local_executor(self):
         cores = psutil.cpu_count(logical=False)

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -31,8 +31,11 @@ def empty_aligned(size, dtype):
 
 
 def zeros_aligned(size, dtype):
-    res = empty_aligned(size, dtype)
-    res[:] = 0
+    if dtype == np.object:
+        res = np.zeros(size, dtype=dtype)
+    else:
+        res = empty_aligned(size, dtype)
+        res[:] = 0
     return res
 
 

--- a/src/libertem/job/masks.py
+++ b/src/libertem/job/masks.py
@@ -108,6 +108,12 @@ class ApplyMasksJob(Job):
 
 
 class MaskContainer(object):
+    '''
+    Container for mask stacks that are created from factory functions.
+
+    It allows stacking, cached slicing, transposing and conversion
+    to condition the masks for high-performance dot products.
+    '''
     def __init__(self, mask_factories, dtype=None, use_sparse=None, count=None):
         '''
         use_sparse can be None, 'scipy.sparse', 'scipy.sparse.csc' or 'sparse.pydata'

--- a/src/libertem/udf/__init__.py
+++ b/src/libertem/udf/__init__.py
@@ -1,10 +1,10 @@
 # FIXME include UDFPartitionMixin as soon as it is implemented
-from .base import UDF, UDFMeta, UDFData, UDFFrameMixin, UDFTileMixin, UDFPostprocessMixin,\
-    check_cast
+from .base import UDF, UDFMeta, UDFData, UDFFrameMixin, UDFTileMixin, UDFPartitionMixin,\
+    UDFPostprocessMixin, check_cast
 from .auto import AutoUDF
 
 
 __all__ = [
-    'UDF', 'UDFFrameMixin', 'UDFTileMixin', 'UDFPostprocessMixin', 'UDFMeta', 'UDFData',
-    'check_cast', 'AutoUDF',
+    'UDF', 'UDFFrameMixin', 'UDFTileMixin', 'UDFPartitionMixin', 'UDFPostprocessMixin', 'UDFMeta',
+    'UDFData', 'check_cast', 'AutoUDF',
 ]

--- a/src/libertem/udf/__init__.py
+++ b/src/libertem/udf/__init__.py
@@ -1,2 +1,10 @@
-from .base import UDF, UDFRunner, check_cast  # NOQA
-from .auto import run_auto, AutoUDF  # NOQA
+# FIXME include UDFPartitionMixin as soon as it is implemented
+from .base import UDF, UDFMeta, UDFData, UDFFrameMixin, UDFTileMixin, UDFPostprocessMixin,\
+    check_cast
+from .auto import run_auto, AutoUDF
+
+
+__all__ = [
+    'UDF', 'UDFFrameMixin', 'UDFTileMixin', 'UDFPostprocessMixin', 'UDFMeta', 'UDFData',
+    'check_cast', 'AutoUDF', 'run_auto',
+]

--- a/src/libertem/udf/__init__.py
+++ b/src/libertem/udf/__init__.py
@@ -1,1 +1,2 @@
 from .base import UDF, UDFRunner, check_cast  # NOQA
+from .auto import run_auto, AutoUDF  # NOQA

--- a/src/libertem/udf/__init__.py
+++ b/src/libertem/udf/__init__.py
@@ -1,10 +1,10 @@
 # FIXME include UDFPartitionMixin as soon as it is implemented
 from .base import UDF, UDFMeta, UDFData, UDFFrameMixin, UDFTileMixin, UDFPostprocessMixin,\
     check_cast
-from .auto import run_auto, AutoUDF
+from .auto import AutoUDF
 
 
 __all__ = [
     'UDF', 'UDFFrameMixin', 'UDFTileMixin', 'UDFPostprocessMixin', 'UDFMeta', 'UDFData',
-    'check_cast', 'AutoUDF', 'run_auto',
+    'check_cast', 'AutoUDF',
 ]

--- a/src/libertem/udf/auto.py
+++ b/src/libertem/udf/auto.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from libertem.udf import UDF
+
+
+class AutoUDF(UDF):
+    '''
+    Generate a UDF for reduction along the signal axis from a regular function
+    that processes one frame, generating result buffers automatically.
+    '''
+    def __init__(self, *args, **kwargs):
+        '''
+        Parameters:
+
+        f:
+            Function that accepts a frame as a single parameter. It will
+            be called with np.ones(tuple(dataset.shape.sig)) to determine the output
+            type and shape
+        '''
+        super().__init__(*args, **kwargs)
+
+    def auto_buffer(self, var):
+        return self.buffer(kind='nav', extra_shape=var.shape, dtype=var.dtype)
+
+    def get_result_buffers(self):
+        mock_frame = np.ones(tuple(self.meta.dataset_shape.sig), dtype=self.meta.dataset_dtype)
+        result = self.params.f(mock_frame)
+
+        return {
+            'result': self.auto_buffer(result)
+        }
+
+    def process_frame(self, frame):
+        res = self.params.f(frame)
+        self.results.result[:] = res
+
+
+def run_auto(ctx, dataset, f, roi=None):
+    udf = AutoUDF(f=f)
+    return ctx.run_udf(dataset=dataset, udf=udf, roi=roi)

--- a/src/libertem/udf/auto.py
+++ b/src/libertem/udf/auto.py
@@ -15,7 +15,7 @@ class AutoUDF(UDF):
         f:
             Function that accepts a frame as a single parameter. It will
             be called with np.ones(tuple(dataset.shape.sig)) to determine the output
-            type and shape
+            type and shape.
         '''
         super().__init__(*args, **kwargs)
 
@@ -23,6 +23,9 @@ class AutoUDF(UDF):
         return self.buffer(kind='nav', extra_shape=var.shape, dtype=var.dtype)
 
     def get_result_buffers(self):
+        '''
+        Auto-generate result buffers based on the return value of f() called with a mock frame.
+        '''
         mock_frame = np.ones(tuple(self.meta.dataset_shape.sig), dtype=self.meta.dataset_dtype)
         result = self.params.f(mock_frame)
 
@@ -31,10 +34,35 @@ class AutoUDF(UDF):
         }
 
     def process_frame(self, frame):
+        '''
+        Call f() for the frame and assign return value to the result buffer slot.
+        '''
         res = self.params.f(frame)
         self.results.result[:] = res
 
 
 def run_auto(ctx, dataset, f, roi=None):
+    '''
+    Create an :code:`AutoUDF` with function :code:`f` and run it through
+    :code:`ctx` on :code:`dataset`
+
+    Parameters
+    ----------
+
+    ctx:
+        LiberTEM Context
+    dataset:
+        Dataset
+    f:
+        Function that accepts a frame as the only parameter
+
+    Returns
+    -------
+
+    UDFData:
+        The result of the UDF with a single buffer named "result" containing all
+        return values of :code:`f` converted to a numpy array
+
+    '''
     udf = AutoUDF(f=f)
     return ctx.run_udf(dataset=dataset, udf=udf, roi=roi)

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -67,6 +67,9 @@ class UDFMeta:
 
 
 class UDFData:
+    '''
+    Container for result buffers, return value from running UDFs
+    '''
     def __init__(self, data):
         self._data = data
         self._views = {}
@@ -150,6 +153,9 @@ class UDFData:
 
 
 class UDFFrameMixin:
+    '''
+    Implement :code:`process_frame` for per-frame processing.
+    '''
     def process_frame(self, frame):
         """
         Implement this method to process the data on a frame-by-frame manner.
@@ -171,6 +177,9 @@ class UDFFrameMixin:
 
 
 class UDFTileMixin:
+    '''
+    Implement :code:`process_tile` for per-tile processing.
+    '''
     def process_tile(self, tile, tile_slice):
         """
         Implement this method to process the data in a tiled manner.
@@ -196,6 +205,9 @@ class UDFTileMixin:
 
 
 class UDFPartitionMixin:
+    '''
+    Implement :code:`process_partition` for per-partition processing.
+    '''
     def process_partition(self, partition):
         """
         Implement this method to process the data partitioned into large
@@ -225,6 +237,11 @@ class UDFPartitionMixin:
 
 
 class UDFPostprocessMixin:
+    '''
+    Implement :code:`postprocess` to modify the resulf buffers of a partition on the worker
+    after the partition data has been completely processed, but before it is returned to the
+    master node for the final merging step.
+    '''
     def postprocess(self):
         """
         Implement this method to postprocess the result data for a partition.
@@ -242,6 +259,9 @@ class UDFPostprocessMixin:
 
 
 class UDFBase:
+    '''
+    Base class for UDFs with helper functions.
+    '''
     def allocate_for_part(self, partition, roi):
         for ns in [self.results]:
             ns.allocate_for_part(partition, roi)

--- a/src/libertem/udf/blobfinder.py
+++ b/src/libertem/udf/blobfinder.py
@@ -559,34 +559,39 @@ def run_refine(ctx, dataset, zero, a, b, params, indices=None, roi=None):
         peaks to be known. See documentation of gridmatching.affinematch() for details.
 
     returns:
-        (result, used_indices) where result is
-        {
-            'centers': BufferWrapper(
-                kind="nav", extra_shape=(num_disks, 2), dtype="u2"
-            ),
-            'refineds': BufferWrapper(
-                kind="nav", extra_shape=(num_disks, 2), dtype="float32"
-            ),
-            'peak_values': BufferWrapper(
-                kind="nav", extra_shape=(num_disks,), dtype="float32"
-            ),
-            'peak_elevations': BufferWrapper(
-                kind="nav", extra_shape=(num_disks,), dtype="float32"
-            ),
-            'zero': BufferWrapper(
-                kind="nav", extra_shape=(2,), dtype="float32"
-            ),
-            'a': BufferWrapper(
-                kind="nav", extra_shape=(2,), dtype="float32"
-            ),
-            'b': BufferWrapper(
-                kind="nav", extra_shape=(2,), dtype="float32"
-            ),
-            'selector': BufferWrapper(
-                kind="nav", extra_shape=(num_disks,), dtype="bool"
-            ),
-        }
-        and used_indices are the indices that were within the frame.
+        :code:`(result, used_indices)` where :code:`result` is a :class:`~libertem.udf.UDFData`
+        instance based on
+
+        .. code-block:: python
+
+            {
+                'centers': BufferWrapper(
+                    kind="nav", extra_shape=(num_disks, 2), dtype="u2"
+                ),
+                'refineds': BufferWrapper(
+                    kind="nav", extra_shape=(num_disks, 2), dtype="float32"
+                ),
+                'peak_values': BufferWrapper(
+                    kind="nav", extra_shape=(num_disks,), dtype="float32"
+                ),
+                'peak_elevations': BufferWrapper(
+                    kind="nav", extra_shape=(num_disks,), dtype="float32"
+                ),
+                'zero': BufferWrapper(
+                    kind="nav", extra_shape=(2,), dtype="float32"
+                ),
+                'a': BufferWrapper(
+                    kind="nav", extra_shape=(2,), dtype="float32"
+                ),
+                'b': BufferWrapper(
+                    kind="nav", extra_shape=(2,), dtype="float32"
+                ),
+                'selector': BufferWrapper(
+                    kind="nav", extra_shape=(num_disks,), dtype="bool"
+                ),
+            }
+
+        and :code:`used_indices` are the indices that were within the frame.
     '''
     if indices is None:
         indices = np.mgrid[-10:10, -10:10]

--- a/src/libertem/udf/logsum.py
+++ b/src/libertem/udf/logsum.py
@@ -39,5 +39,5 @@ def run_logsum(ctx, dataset, roi=None):
     sum(log10(f1) ... log10(f10)) == (10.4, 2.04)
 
     '''
-    udf = LogsumUDF(dataset=dataset)
+    udf = LogsumUDF()
     return ctx.run_udf(dataset=dataset, udf=udf, roi=roi)

--- a/tests/udf/test_auto.py
+++ b/tests/udf/test_auto.py
@@ -2,8 +2,6 @@ import functools
 
 import numpy as np
 
-from libertem.udf import run_auto
-
 from utils import MemoryDataSet, _mk_random
 
 
@@ -13,8 +11,33 @@ def test_auto(lt_ctx):
     dataset = MemoryDataSet(data=data, tileshape=(8, 32, 64),
                             num_partitions=2, sig_dims=2)
 
-    logsum_result = run_auto(ctx=lt_ctx, dataset=dataset, f=functools.partial(np.sum, axis=-1))
+    auto_result = lt_ctx.map(dataset=dataset, f=functools.partial(np.sum, axis=-1))
 
     naive_result = data.sum(axis=-1)
 
-    assert np.allclose(logsum_result['result'].data, naive_result)
+    assert np.allclose(auto_result['result'].data, naive_result)
+
+
+def test_auto_weird(lt_ctx):
+    data = _mk_random((16, 8, 32, 64))
+
+    dataset = MemoryDataSet(data=data, tileshape=(8, 32, 64),
+                            num_partitions=2, sig_dims=2)
+
+    def f(frame):
+        return [
+            "Shape %s" % str(frame.shape),
+            dict(shape=frame.shape, sum=frame.sum()),
+            lambda x: x,
+            MemoryDataSet
+        ]
+
+    auto_result = lt_ctx.map(dataset=dataset, f=f)
+    item = auto_result['result'].data[0, 0]
+
+    assert len(item) == 4
+    assert isinstance(item[0], str)
+    assert isinstance(item[1], dict)
+    assert callable(item[2])
+    assert item[2](1) == 1
+    assert isinstance(item[3], type)

--- a/tests/udf/test_auto.py
+++ b/tests/udf/test_auto.py
@@ -1,0 +1,20 @@
+import functools
+
+import numpy as np
+
+from libertem.udf import run_auto
+
+from utils import MemoryDataSet, _mk_random
+
+
+def test_auto(lt_ctx):
+    data = _mk_random((16, 8, 32, 64))
+
+    dataset = MemoryDataSet(data=data, tileshape=(8, 32, 64),
+                            num_partitions=2, sig_dims=2)
+
+    logsum_result = run_auto(ctx=lt_ctx, dataset=dataset, f=functools.partial(np.sum, axis=-1))
+
+    naive_result = data.sum(axis=-1)
+
+    assert np.allclose(logsum_result['result'].data, naive_result)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ commands=
     pytest --doctest-modules src/libertem/common/
 deps=
     -rtest_requirements.txt
+extras=
+    hdbscan
 
 [testenv:flake8]
 changedir={toxinidir}


### PR DESCRIPTION
That can wrap a function that accepts a frame as a single argument. Together with functools.partial, this allows for a lot of flexibility.