### PR TITLE
Create dask arrays from LiberTEM DataSet; UDF process_partition. Based on PR #377

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ on_success:
 
 branches:
   except:
-    - # Do not build tags that we create when we upload to GitHub Releases
-    - /^continuous/
+    # Do not build tags that we create when we upload to GitHub Releases
+    - "/^continuous/"

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -34,3 +34,8 @@ Internal API
    :members: MaskContainer,ApplyMasksJob
    :undoc-members:
    :special-members: __init__
+
+.. automodule:: libertem.contrib.dask
+   :members:
+   :undoc-members:
+   :special-members: __init__

--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -81,6 +81,8 @@ Auto UDF
 
 The :class:`~libertem.udf.AutoUDF` class and :meth:`~libertem.api.Context.map` method allow to run simple functions that accept a frame as the only parameter with an auto-generated :code:`kind="nav"` result buffer over a dataset ad-hoc without defining an UDF class. For more advanced processing, such as custom merge functions, post-processing or performance optimization through tiled processing, defining an UDF class is required.
 
+As an alternative to Auto UDF, you can use the :meth:`~libertem.io.dataset.base.DataSet.get_dask_array` method of a :class:`~libertem.io.dataset.base.DataSet` and use a `dask.array <https://docs.dask.org/en/latest/array.html>`_ to perform your calculations. See :ref:`Integration with Dask arrays<daskarray>` for more details.
+
 The :class:`~libertem.udf.AutoUDF` class determines the output shape and type by calling the function with a mock-up frame of the same type and shape as a real detector frame and converting the return value to a numpy array. The :code:`extra_shape` and :code:`dtype` parameters for the result buffer are derived automatically from this numpy array. Additional constant parameters can be passed to the function via :meth:`functools.partial`, for example. The return value should be much smaller than the input size for this to work efficiently.
 
 Example: Calculate sum over the last signal axis.

--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -81,7 +81,7 @@ Auto UDF
 
 The :class:`~libertem.udf.AutoUDF` class and :meth:`~libertem.api.Context.map` method allow to run simple functions that accept a frame as the only parameter with an auto-generated :code:`kind="nav"` result buffer over a dataset ad-hoc without defining an UDF class. For more advanced processing, such as custom merge functions, post-processing or performance optimization through tiled processing, defining an UDF class is required.
 
-As an alternative to Auto UDF, you can use the :meth:`~libertem.io.dataset.base.DataSet.get_dask_array` method of a :class:`~libertem.io.dataset.base.DataSet` and use a `dask.array <https://docs.dask.org/en/latest/array.html>`_ to perform your calculations. See :ref:`Integration with Dask arrays<daskarray>` for more details.
+As an alternative to Auto UDF, you can use the :meth:`~libertem.contrib.dask.make_dask_array` method to create a `dask.array <https://docs.dask.org/en/latest/array.html>`_ from a :class:`~libertem.io.dataset.base.DataSet` to perform calculations. See :ref:`Integration with Dask arrays<daskarray>` for more details.
 
 The :class:`~libertem.udf.AutoUDF` class determines the output shape and type by calling the function with a mock-up frame of the same type and shape as a real detector frame and converting the return value to a numpy array. The :code:`extra_shape` and :code:`dtype` parameters for the result buffer are derived automatically from this numpy array. Additional constant parameters can be passed to the function via :meth:`functools.partial`, for example. The return value should be much smaller than the input size for this to work efficiently.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -126,7 +126,7 @@ For a full API reference, please see :doc:`Reference <reference>`.
 Integration with Dask arrays
 ----------------------------
 
-A :class:`DataSet` can generate a `distributed Dask array <https://docs.dask.org/en/latest/array.html>`_ using its partitions as blocks through the :meth:`DataSet.get_dask_array` method. The typical LiberTEM partition size is close to the optimum size for Dask array blocks under most circumstances. The dask array is accompanied with a map of optimal workers. This map should be passed to the :meth:`compute` method in order to construct the blocks on the workers that have them in local storage.
+The :meth:`~libertem.contrib.dask.make_dask_array` function can generate a `distributed Dask array <https://docs.dask.org/en/latest/array.html>`_ from a :class:`~libertem.io.dataset.base.DataSet` using its partitions as blocks. The typical LiberTEM partition size is close to the optimum size for Dask array blocks under most circumstances. The dask array is accompanied with a map of optimal workers. This map should be passed to the :meth:`compute` method in order to construct the blocks on the workers that have them in local storage.
 
 .. include:: /../../examples/dask_array.py
     :code:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -121,6 +121,16 @@ For a full API reference, please see :doc:`Reference <reference>`.
 .. include:: /../../examples/basic.py
     :code:
 
+.. _daskarray:
+
+Integration with Dask arrays
+----------------------------
+
+A :class:`DataSet` can generate a `distributed Dask array <https://docs.dask.org/en/latest/array.html>`_ using its partitions as blocks through the :meth:`DataSet.get_dask_array` method. The typical LiberTEM partition size is close to the optimum size for Dask array blocks under most circumstances. The dask array is accompanied with a map of optimal workers. This map should be passed to the :meth:`compute` method in order to construct the blocks on the workers that have them in local storage.
+
+.. include:: /../../examples/dask_array.py
+    :code:
+
 From an embedded interpreter
 ----------------------------
 

--- a/examples/dask_array.py
+++ b/examples/dask_array.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+import matplotlib.pyplot as plt
+
+from libertem import api
+
+
+if __name__ == '__main__':
+    with api.Context() as ctx:
+        try:
+            path = sys.argv[1]
+        except IndexError:
+            path = ('C:/Users/weber/Nextcloud/Projects/'
+                    'Open Pixelated STEM framework/Data/EMPAD/'
+                    'acquisition_12.xml')
+        
+        ds = ctx.load(
+            'EMPAD',
+            path=path
+        )
+
+        # Construct a Dask array from the dataset
+        # The second return value contains information
+        # on workers that hold parts of a dataset in local
+        # storage to ensure optimal data locality
+        dask_array, workers = ds.get_dask_array()
+
+        # Perform calculations using the worker map.
+        result = dask_array.sum(axis=(-1, -2)).compute(workers=workers)
+
+        plt.figure()
+        plt.imshow(result)
+        plt.show()

--- a/examples/dask_array.py
+++ b/examples/dask_array.py
@@ -8,6 +8,7 @@ os.environ["OPENBLAS_NUM_THREADS"] = "1"
 import matplotlib.pyplot as plt
 
 from libertem import api
+from libertem.contrib.dask import make_dask_array
 
 
 if __name__ == '__main__':
@@ -18,7 +19,7 @@ if __name__ == '__main__':
             path = ('C:/Users/weber/Nextcloud/Projects/'
                     'Open Pixelated STEM framework/Data/EMPAD/'
                     'acquisition_12.xml')
-        
+
         ds = ctx.load(
             'EMPAD',
             path=path
@@ -28,7 +29,7 @@ if __name__ == '__main__':
         # The second return value contains information
         # on workers that hold parts of a dataset in local
         # storage to ensure optimal data locality
-        dask_array, workers = ds.get_dask_array()
+        dask_array, workers = make_dask_array(ds)
 
         # Perform calculations using the worker map.
         result = dask_array.sum(axis=(-1, -2)).compute(workers=workers)

--- a/src/libertem/contrib/dask.py
+++ b/src/libertem/contrib/dask.py
@@ -1,0 +1,24 @@
+import dask
+import dask.array
+
+
+def make_dask_array(dataset, dtype='float32', roi=None):
+    '''
+    Create a Dask array using the DataSet's partitions as blocks.
+    '''
+    chunks = []
+    workers = {}
+    for p in dataset.get_partitions():
+        d = dask.delayed(p.get_macrotile)(
+            dest_dtype=dtype, roi=roi
+        )
+        workers[d] = p.get_locations()
+        chunks.append(
+            dask.array.from_delayed(
+                d.data,
+                dtype=dtype,
+                shape=p.shape
+            )
+        )
+    arr = dask.array.concatenate(chunks, axis=0)
+    return (arr.reshape(dataset.shape), workers)

--- a/src/libertem/io/dataset/base.py
+++ b/src/libertem/io/dataset/base.py
@@ -1,8 +1,6 @@
 import itertools
 
 import numpy as np
-import dask
-import dask.array
 
 from libertem.io.utils import get_partition_shape
 from libertem.common import Slice, Shape
@@ -145,27 +143,6 @@ class DataSet(object):
         Return a generator over all Partitions in this DataSet
         """
         raise NotImplementedError()
-
-    def get_dask_array(self, dtype='float32', roi=None):
-        '''
-        Create a Dask array using the DataSet's partitions as blocks.
-        '''
-        chunks = []
-        workers = {}
-        for p in self.get_partitions():
-            d = dask.delayed(p.get_macrotile)(
-                dest_dtype=dtype, roi=roi
-            )
-            workers[d] = p.get_locations()
-            chunks.append(
-                dask.array.from_delayed(
-                    d.data,
-                    dtype=dtype,
-                    shape=p.shape
-                )
-            )
-        arr = dask.array.concatenate(chunks, axis=0)
-        return (arr.reshape(self.shape), workers)
 
     @property
     def dtype(self):

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -510,16 +510,7 @@ class UDFRunner:
         elif method == 'frame':
             tiles = partition.get_tiles(full_frames=True, roi=roi, dest_dtype=dtype)
         elif method == 'partition':
-            tiles = partition.get_tiles(full_frames=False, roi=roi, dest_dtype=dtype)
-            raise NotImplementedError("process_partition is not implemented yet")
-
-        partition_data = None
-        if method == 'partition':
-            # FIXME: allocate a buffer the size of the partition (nav+sig)
-            # (or more correct: the size of the part of the partition that is
-            # selected by the `roi`; see meta.partition_shape)
-            # partition_data = ...
-            pass
+            tiles = [partition.get_macrotile(roi=roi, dest_dtype=dtype)]
 
         for tile in tiles:
             if method == 'tile':
@@ -530,10 +521,8 @@ class UDFRunner:
                     self._udf.set_views_for_frame(partition, tile, frame_idx)
                     self._udf.process_frame(frame)
             elif method == 'partition':
-                raise NotImplementedError("TODO: copy tiles into partition_data")
-
-        if method == 'partition':
-            self._udf.process_partition(partition_data)
+                self._udf.set_views_for_tile(partition, tile)
+                self._udf.process_partition(tile.data)
 
         if hasattr(self._udf, 'postprocess'):
             self._udf.clear_views()

--- a/tests/io/test_dask_array.py
+++ b/tests/io/test_dask_array.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from utils import MemoryDataSet, _mk_random
+
+
+def test_dask_array():
+    data = _mk_random(size=(16, 16, 16, 16))
+    dataset = MemoryDataSet(
+        data=data,
+        tileshape=(16, 16, 16),
+        num_partitions=2,
+    )
+    da = dataset.get_dask_array()
+    assert np.allclose(da, data)
+    assert np.allclose(da.sum().compute(), data.sum())
+    assert da.shape == data.shape

--- a/tests/io/test_dask_array.py
+++ b/tests/io/test_dask_array.py
@@ -10,7 +10,7 @@ def test_dask_array():
         tileshape=(16, 16, 16),
         num_partitions=2,
     )
-    da = dataset.get_dask_array()
+    (da, workers) = dataset.get_dask_array()
     assert np.allclose(da, data)
-    assert np.allclose(da.sum().compute(), data.sum())
+    assert np.allclose(da.sum().compute(workers=workers), data.sum())
     assert da.shape == data.shape

--- a/tests/io/test_dask_array.py
+++ b/tests/io/test_dask_array.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from libertem.contrib.dask import make_dask_array
+
 from utils import MemoryDataSet, _mk_random
 
 
@@ -10,7 +12,7 @@ def test_dask_array():
         tileshape=(16, 16, 16),
         num_partitions=2,
     )
-    (da, workers) = dataset.get_dask_array()
+    (da, workers) = make_dask_array(dataset)
     assert np.allclose(da, data)
     assert np.allclose(da.sum().compute(workers=workers), data.sum())
     assert da.shape == data.shape

--- a/tests/udf/test_by_partition.py
+++ b/tests/udf/test_by_partition.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from libertem.udf import UDF
+from utils import MemoryDataSet, _mk_random
+
+
+class PixelsumUDF(UDF):
+    def get_result_buffers(self):
+        return {
+            'pixelsum': self.buffer(
+                kind="nav", dtype="float32"
+            )
+        }
+
+    def process_partition(self, partition):
+        self.results.pixelsum[:] += np.sum(partition, axis=(-1, -2))
+
+
+def test_sum_tiles(lt_ctx):
+    data = _mk_random(size=(16, 16, 16, 16), dtype="float32")
+    dataset = MemoryDataSet(data=data, tileshape=(7, 16, 16),
+                            num_partitions=2, sig_dims=2)
+
+    pixelsum = PixelsumUDF()
+    res = lt_ctx.run_udf(dataset=dataset, udf=pixelsum)
+    assert 'pixelsum' in res
+    print(data.shape, res['pixelsum'].data.shape)
+    assert np.allclose(res['pixelsum'].data, np.sum(data, axis=(2, 3)))


### PR DESCRIPTION
Both are based on creating a tile that covers an entire partition.

FIXMEs:
* Documentation
* Tests for each supported file type -- may require special measures as encountered in K2IS support

Based on PR #377, mostly for practical testing through the new Context.map() function.

Closes #376
See also #286