### PR TITLE
Custom templates for blobfinder

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -15,6 +15,11 @@ Python API
 Internal API
 ------------
 
+.. automodule:: libertem.masks
+   :members:
+   :undoc-members:
+   :special-members: __init__
+
 .. automodule:: libertem.common.shape
    :members:
    :undoc-members:

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -279,7 +279,7 @@ def radial_bins(centerX, centerY, imageSizeX, imageSizeY,
         return np.stack(slices)
 
 
-def background_substraction(centerX, centerY, imageSizeX, imageSizeY, radius, radius_inner):
+def background_subtraction(centerX, centerY, imageSizeX, imageSizeY, radius, radius_inner):
     mask_1 = circular(centerX, centerY, imageSizeX, imageSizeY, radius_inner)
     sum_1 = np.sum(mask_1)
     mask_2 = ring(centerX, centerY, imageSizeX, imageSizeY, radius, radius_inner)

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -181,8 +181,11 @@ def polar_map(centerX, centerY, imageSizeX, imageSizeY, stretchY=1., angle=0.):
     dy = y - centerY
     dx = x - centerX
     if stretchY != 1.0 or angle != 0.:
-        dx = dx*np.cos(angle) + dy*np.sin(angle)
-        dy = (dy*np.cos(angle) - dx*np.sin(angle)) / stretchY
+        (dy, dx) = (
+            (dy*np.cos(angle) - dx*np.sin(angle)) / stretchY,
+            dx*np.cos(angle) + dy*np.sin(angle),
+        )
+
     dy = dy.flatten()
     dx = dx.flatten()
     cartesians = np.stack((dy, dx)).T

--- a/src/libertem/udf/blobfinder.py
+++ b/src/libertem/udf/blobfinder.py
@@ -110,13 +110,6 @@ class UserTemplate(MatchPattern):
         return result
 
 
-def condition_template(template, texture, lower, upper):
-    truncated = np.maximum(lower, np.minimum(upper, template))
-    truncated -= lower
-    truncated /= (upper - lower)
-    return truncated * texture
-
-
 def mask_maker(parameters):
     if parameters['mask_type'] == 'radial_gradient':
         return RadialGradient(parameters)

--- a/src/libertem/udf/blobfinder.py
+++ b/src/libertem/udf/blobfinder.py
@@ -91,22 +91,29 @@ class UserTemplate(MatchPattern):
         result = np.zeros((sig_shape), dtype=self.template.dtype)
         dy, dx = sig_shape
         ty, tx = self.template.shape
-        left = dx // 2 - tx // 2
-        right = left + tx
-        top = dy // 2 - ty // 2
-        bottom = top + ty
+
+        left = dx / 2 - tx / 2
+        top = dy / 2 - ty / 2
 
         r_left = max(0, left)
-        r_right = min(dx, right)
         r_top = max(0, top)
-        r_bottom = min(dy, bottom)
 
         t_left = max(0, -left)
-        t_right = min(tx, right)
         t_top = max(0, -top)
-        t_bottom = min(ty, bottom)
 
-        result[r_top:r_bottom, r_left:r_right] = self.template[t_top:t_bottom, t_left:t_right]
+        crop_x = r_left - left
+        crop_y = r_top - top
+
+        h = int(ty - 2*crop_y)
+        w = int(tx - 2*crop_x)
+
+        r_left = int(r_left)
+        r_top = int(r_top)
+        t_left = int(t_left)
+        t_top = int(t_top)
+
+        result[r_top:r_top + h, r_left:r_left + w] = \
+            self.template[t_top:t_top + h, t_left:t_left + w]
         return result
 
 

--- a/src/libertem/udf/blobfinder.py
+++ b/src/libertem/udf/blobfinder.py
@@ -6,7 +6,7 @@ import scipy.ndimage as nd
 import matplotlib.pyplot as plt
 
 from libertem.udf import UDF
-from libertem.masks import radial_gradient, background_substraction, sparse_template_multi_stack
+from libertem.masks import radial_gradient, background_subtraction, sparse_template_multi_stack
 from libertem.job.masks import MaskContainer
 
 import libertem.analysis.gridmatching as grm
@@ -59,7 +59,7 @@ class RadialGradient(MatchPattern):
         )
 
 
-class BackgroundSubstraction(MatchPattern):
+class BackgroundSubtraction(MatchPattern):
     def __init__(self, parameters):
         self.radius = parameters['radius']
         self.padding = parameters['padding']
@@ -69,7 +69,7 @@ class BackgroundSubstraction(MatchPattern):
         return int(np.ceil(max(self.radius, self.radius_outer) * (1 + self.padding)))
 
     def get_mask(self, sig_shape):
-        return background_substraction(
+        return background_subtraction(
             centerY=sig_shape[0] // 2,
             centerX=sig_shape[1] // 2,
             imageSizeY=sig_shape[0],
@@ -113,8 +113,8 @@ class UserTemplate(MatchPattern):
 def mask_maker(parameters):
     if parameters['mask_type'] == 'radial_gradient':
         return RadialGradient(parameters)
-    elif parameters['mask_type'] == 'background_substraction':
-        return BackgroundSubstraction(parameters)
+    elif parameters['mask_type'] == 'background_subtraction':
+        return BackgroundSubtraction(parameters)
     elif parameters['mask_type'] == 'template':
         return UserTemplate(parameters)
     else:
@@ -272,14 +272,14 @@ class FastCorrelationUDF(CorrelationUDF):
             Numpy array of (y, x) coordinates with peak positions to correlate
         mask_type : str
             Mask to use for correlation. Currently one of 'radial_gradient' and
-            'background_substraction'
+            'background_subtraction'
         radius:
             Radius of the CBED disks in px
         padding:
             Extra space around radius as a fraction of radius, which defines the search
             area around a peak
         radius_outer:
-            Only with 'background_substraction': Radius of outer region with negative values.
+            Only with 'background_subtraction': Radius of outer region with negative values.
             For calculating the padding, the maximum of radius and radius_outer is used.
         '''
         super().__init__(*args, **kwargs)
@@ -332,14 +332,14 @@ class SparseCorrelationUDF(CorrelationUDF):
             Numpy array of (y, x) coordinates with peak positions to correlate
         mask_type : str
             Mask to use for correlation. Currently one of 'radial_gradient' and
-            'background_substraction'
+            'background_subtraction'
         radius:
             Radius of the CBED disks in px
         padding:
             Extra space around radius as a fraction of radius. Can be zero for this method
             since the shifting is performed independently of the template size.
         radius_outer:
-            Only with 'background_substraction': Radius of outer region with negative values.
+            Only with 'background_subtraction': Radius of outer region with negative values.
             For calculating the padding, the maximum of radius and radius_outer is used.
         steps:
             The template is correlated with 2 * steps + 1 symmetrically around the peak position

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -3,8 +3,8 @@ import numpy as np
 import libertem.masks as m
 
 
-def test_background_substraction():
-    mask = m.background_substraction(10, 10, 20, 20, 5, 3)
+def test_background_subtraction():
+    mask = m.background_subtraction(10, 10, 20, 20, 5, 3)
     assert(np.allclose(np.sum(mask), 0))
 
 
@@ -18,3 +18,68 @@ def test_radial_bins_dense():
     bins = m.radial_bins(40, 41, 80, 80, n_bins=2)
     assert np.allclose(1, bins.sum(axis=0))
     assert bins.shape == (2, 80, 80)
+
+
+def test_oval_radial_background_balance():
+    radius, angle = m.polar_map(
+        centerX=10, centerY=10,
+        imageSizeX=21, imageSizeY=21,
+        stretchY=1.5,
+        angle=np.pi/4
+    )
+    template = m.radial_gradient_background_subtraction(
+        r=radius,
+        r0=5,
+        r_outer=7
+    )
+    template = m.balance(template)
+    outside = radius > 7
+    inside = (radius < 5) * (radius > 0)
+
+    assert np.allclose(template.sum(), 0)
+    assert np.allclose(template[outside], 0)
+    assert np.all(template[inside] > 0)
+
+    assert np.allclose(template[0, :], 0)
+    assert np.allclose(template[20, :], 0)
+    assert np.allclose(template[:, 0], 0)
+    assert np.allclose(template[:, 20], 0)
+
+    diag = int(np.sqrt(5))
+
+    # Confirm stretched gradient in 45 diagonal
+    assert template[10+diag, 10+diag] > 0
+    assert template[10-diag, 10+diag] < template[10+diag, 10+diag]
+
+
+def test_oval_radial_background_symmetry():
+    radius, angle = m.polar_map(
+        centerX=10, centerY=10,
+        imageSizeX=21, imageSizeY=21,
+        stretchY=1.5,
+        angle=0.
+    )
+
+    radius2, angle2 = m.polar_map(
+        centerX=10, centerY=10,
+        imageSizeX=21, imageSizeY=21,
+        stretchY=1.5,
+        angle=np.pi
+    )
+
+    radius3, angle3 = m.polar_map(
+        centerX=10, centerY=10,
+        imageSizeX=21, imageSizeY=21,
+        stretchY=1.5,
+        angle=np.pi/4
+    )
+
+    radius4, angle4 = m.polar_map(
+        centerX=10, centerY=10,
+        imageSizeX=21, imageSizeY=21,
+        stretchY=1.5,
+        angle=-np.pi/4
+    )
+
+    assert np.allclose(radius, radius2)
+    assert np.allclose(radius3, np.flip(radius4, axis=1))


### PR DESCRIPTION
Include utility functions to generate advanced templates

The combination of background subtraction, radial gradient, antialiased border and elliptical distortion to match the CBED disk as closely as possible gives outstanding results with CBED strain maps at higher convergence angles recorded with fine detector resolution.

Fix a typo in function name. This might break examples or downstream code, should be included in release 0.2.

Closes #392 