### PR TITLE
Release script updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
       python: 3.7
       dist: xenial
       install:
-        - pip install click pygithub requests twine
+        - pip install click pygithub requests twine html5lib docutils
       script:
         - python scripts/release upload --pypi-test-user=libertem_bot --pypi-user=libertem_bot --no-dry-run
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,10 @@ jobs:
     - stage: packaging
       sudo: require
       dist: trusty
+      install:
+        - pip install click pygithub requests
       script:
-        - bash -ex packaging/appimage/make_app_image.sh
-        - ls -lh
-      after_success:
-        - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh && bash -c "chmod +x upload.sh && ./upload.sh LiberTEM*.AppImage* dist/*"
+        - python scripts/release --pypi-test-user=libertem_bot --pypi-user=libertem_bot --no-dry-run
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
       install:
         - pip install click pygithub requests twine
       script:
-        - python scripts/release --pypi-test-user=libertem_bot --pypi-user=libertem_bot --no-dry-run
+        - python scripts/release upload --pypi-test-user=libertem_bot --pypi-user=libertem_bot --no-dry-run
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
     - stage: packaging
       sudo: require
       python: 3.7
-      dist: trusty
+      dist: xenial
       install:
         - pip install click pygithub requests twine
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
 
     - stage: packaging
       sudo: require
+      python: 3.7
       dist: trusty
       install:
         - pip install click pygithub requests twine

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
       sudo: require
       dist: trusty
       install:
-        - pip install click pygithub requests
+        - pip install click pygithub requests twine
       script:
         - python scripts/release --pypi-test-user=libertem_bot --pypi-user=libertem_bot --no-dry-run
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include README.rst
 graft client
 prune client/node_modules
 prune client/build
+prune client/coverage

--- a/packaging/appimage/make_app_image.sh
+++ b/packaging/appimage/make_app_image.sh
@@ -1,19 +1,22 @@
 #!/bin/sh
-set -x
+set -ex
 BASE_DIR=$(dirname "$(readlink -f "${0}")")/../../
+
+CONDA_PKGS_DIRS=$BASE_DIR/conda-pkgs/
+
 mkdir -p AppDir
 
 MC_NAME=Miniconda3-latest-Linux-x86_64.sh
 [ ! -f $MC_NAME ] && wget -c -q https://repo.continuum.io/miniconda/$MC_NAME
 
+HERE=$(dirname "$(readlink -f "${0}")")/AppDir
 cd AppDir || exit 1
-HERE=$(dirname "$(readlink -f "${0}")")
 
 bash ../$MC_NAME -b -p ./usr || exit 1
 PATH="${HERE}"/usr/bin:$PATH
 # conda config --add channels conda-forge
 conda create -n libertem python=3.6 -y || exit 1
-# FIXME: install specific version (for example from pypi, or continuous build, ...)n s
+# FIXME: install specific version (for example from pypi, or continuous build, ...)
 
 # Build wheel & sdist
 ( cd "$BASE_DIR" && python setup.py bdist_wheel )

--- a/packaging/appimage/make_app_image.sh
+++ b/packaging/appimage/make_app_image.sh
@@ -4,16 +4,16 @@ BASE_DIR=$(dirname "$(readlink -f "${0}")")/../../
 
 CONDA_PKGS_DIRS=$BASE_DIR/conda-pkgs/
 
-mkdir -p AppDir
 
 MC_NAME=Miniconda3-latest-Linux-x86_64.sh
 [ ! -f $MC_NAME ] && wget -c -q https://repo.continuum.io/miniconda/$MC_NAME
 
-HERE=$(dirname "$(readlink -f "${0}")")/AppDir
-cd AppDir || exit 1
+APPDIR=$(dirname "$(readlink -f "${0}")")/AppDir
+mkdir -p $APPDIR
+cd $APPDIR || exit 1
 
 bash ../$MC_NAME -b -p ./usr || exit 1
-PATH="${HERE}"/usr/bin:$PATH
+PATH="${APPDIR}"/usr/bin:$PATH
 # conda config --add channels conda-forge
 conda create -n libertem python=3.6 -y || exit 1
 # FIXME: install specific version (for example from pypi, or continuous build, ...)
@@ -67,6 +67,6 @@ cd .. || exit 1
 wget -c -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
 chmod a+x appimagetool-x86_64.AppImage
 export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
-./appimagetool-x86_64.AppImage AppDir -g --no-appstream
+./appimagetool-x86_64.AppImage "$APPDIR" -g --no-appstream
 
 echo "done"

--- a/scripts/release
+++ b/scripts/release
@@ -18,8 +18,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.normpath(join(HERE, '..'))
 
 VERSION_PAT = re.compile(
-    r'^(?P<full>(?P<prefix>v)?(?P<breaking>\d+)\.(?P<feature>\d+)\.(?P<fix>\d+)'
-    r'(?P<rc>rc\d+)?(?P<dev>\.dev0)?)$'
+    r'^(?P<full>(?P<prefix>v)?(?P<noprefix>(?P<breaking>\d+)\.(?P<feature>\d+)\.(?P<fix>\d+)'
+    r'(?P<rc>rc\d+)?(?P<dev>\.dev0)?))$'
 )
 
 
@@ -73,7 +73,19 @@ def validate_version_tag():
     v = parse_version(version_tag['full'])
     if isinstance(v, LegacyVersion):
         raise click.ClickException(
-            "could not parse version"
+            "The version tag %s could not be parsed as valid version" % v
+        )
+
+    version_from_file = parse_version(read_version(get_version_fn()))
+    if isinstance(version_from_file, LegacyVersion):
+        raise click.ClickException(
+            "__version__ %s could not be parsed as valid version" % version_from_file
+        )
+    if version_from_file != v:
+        raise click.ClickException(
+            "version tag %s and __version__ %s do not match" % (
+                v, version_from_file
+            )
         )
     return True
 
@@ -126,18 +138,21 @@ def tag_matches(tags):
             if m is not None]
 
 
+def get_version_tag():
+    """
+    get the current version tag as match dict
+    """
+    version_tags = tag_matches(get_current_tags())
+    if len(version_tags) == 1:
+        return version_tags[0]
+
+
 def current_version_tag_is_rc():
-    match = get_release_tag()
-    if match is None:
-        return False
-    return match['rc'] is not None
+    return get_release_kind() == "rc"
 
 
 def current_version_tag_is_release():
-    match = get_release_tag()
-    if match is None:
-        return False
-    return match['rc'] is None and match['dev'] is None
+    return get_release_kind() == "release"
 
 
 def get_release_kind():
@@ -171,7 +186,7 @@ def get_py_release_files():
     return glob.glob("%s/*" % BASE_DIR)
 
 
-def upload_to_zenodo(verbose, dry_run, parent_deposit):
+def upload_to_zenodo(verbose, dry_run):
     if verbose:
         print("uploading to zenodo")
 
@@ -189,6 +204,7 @@ def upload_to_zenodo(verbose, dry_run, parent_deposit):
     elif release == "release":
         url = "https://zenodo.org/api/"
         parent = "1478763"  # FIXME: fix this number?
+        raise Exception("please fix parent deposition IDs for sandbox and prod!")
 
     out = subprocess.check_output([
         "python", join(HERE, "zenodo_upload"),
@@ -213,7 +229,6 @@ def get_release_msg():
 def upload_to_github(verbose, files, token, release):
     if verbose:
         print("uploading files to github:", files)
-    tags = tag_matches(get_current_tags())
     msg = get_release_msg()
 
     if verbose:
@@ -247,7 +262,7 @@ def upload_to_github(verbose, files, token, release):
         tag = get_release_tag()
         release_data = {
             "tag": tag['full'],
-            "name": "Release Candidate",
+            "name": "Release Candidate %s" % tag,
             "draft": False,
             "prerelease": True,
         }
@@ -378,10 +393,16 @@ def is_rc(ctx):
 @click.option('--pypi-test-password', type=str, show_envvar=True)
 @click.option('--token', type=str, show_envvar=True,
               help='Github token for creating releases')
+@click.option('--zenodo-sandbox-token', type=str, show_envvar=True,
+              help='Zenodo sandbox token for RC upload testing')
+@click.option('--zenodo-token', type=str, show_envvar=True,
+              help='Zenodo production token for final release upload')
 @click.pass_context
-def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_password, token):
+def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_password, token,
+           zenodo_sandbox_token, zenodo_token):
     """
-    prepare, build and upload libertem to pypi (if release candidate, to the test instance)
+    prepare, build and upload libertem to github, zenodo and pypi
+    (if release candidate, to the test instance(s))
     """
 
     if dry_run:
@@ -431,7 +452,7 @@ def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_pas
         else:
             upload_to_github(ctx.obj['verbose'], github_files, token=token, release=release)
     else:
-        print("branch is not master, would not upload to github")
+        print("branch is not master (or is PR), not uploading to github (files=%s)" % github_files)
 
 
 @cli.command()
@@ -441,8 +462,12 @@ def status(ctx):
     current_version = read_version(version_file)
     print("current version: %s" % current_version)
     print("version tags for HEAD: %s" % [m['full'] for m in tag_matches(get_current_tags())])
-    print("last version tags: %s" % [m['full'] for m in tag_matches([get_latest_tag()])])
     print("is release candidate? %s" % current_version_tag_is_rc())
+    kind = get_release_kind()
+    if kind in ["rc", "release"]:
+        print("validating version tag...")
+        validate_version_tag()
+        print("done.")
 
 
 @cli.command()
@@ -472,6 +497,7 @@ def bump(new_version, tag, commit, force):
     match = VERSION_PAT.match(new_version)
     if match is None:
         raise click.UsageError("could not parse version, may not conform to our scheme")
+    new_version = match['noprefix']
     version_file = get_version_fn()
     old_version = read_version(version_file)
     render_version(version_file, new_version)

--- a/scripts/release
+++ b/scripts/release
@@ -50,6 +50,28 @@ def do_git_tag(tag):
     subprocess.check_call(cmd)
 
 
+def validate_version_tag():
+    """
+    Validate the current version tag. rules:
+
+     1) There must be exactly one version tag, and it has to conform to
+        to the version pattern.
+     2) The tag needs to have a prefix of "v".
+    """
+    tags = get_current_tags()
+    matches = tag_matches(tags)
+    if len(matches) != 1:
+        raise click.ClickException(
+            "can only have a single version tag for HEAD, aborting"
+        )
+    version_tag = matches[0]
+    if version_tag['prefix'] != 'v':
+        raise click.ClickException(
+            "version tags need to have a 'v' prefix"
+        )
+    return True
+
+
 def get_current_tags():
     """
     returns list of tags that point to HEAD
@@ -58,14 +80,15 @@ def get_current_tags():
     return subprocess.check_output(cmd, text="utf-8").strip().split("\n")
 
 
-def latest_tag_from_tags(tags):
+def get_release_tag():
     """
-    A commit can have more than one version tag, for example if we re-tag
-    a release candidate as final release. This function returns the most current
-    tag, according to setuptools' parse_version
+    A commit can have more than one tag (but should only have one version tag).
+    This function returns the matching version tag as a match dictionary.
     """
-    sorted_tags = list(sorted(tags, key=lambda t: parse_version(t)))
-    return sorted_tags[-1]
+    tags = get_current_tags()
+    matches = tag_matches(tags)
+    assert len(matches) == 1
+    return matches[0]
 
 
 def get_latest_tag():
@@ -92,29 +115,23 @@ def tag_matches(tags):
 
 
 def current_version_tag_is_rc():
-    matches = tag_matches(get_current_tags())
-    for match in matches:
-        if match['rc'] is not None:
-            return True
-    return False
+    match = get_release_tag()
+    return match['rc'] is not None
 
 
 def current_version_tag_is_release():
-    matches = tag_matches(get_current_tags())
-    for match in matches:
-        if match['rc'] is None and match['dev'] is None:
-            return True
-    return False
+    match = get_release_tag()
+    return match['rc'] is None and match['dev'] is None
 
 
 def get_release_kind():
-    matches = tag_matches(get_current_tags())
-    for match in matches:
-        if match['rc'] is not None:
-            return "rc"
-        elif match['rc'] is None and match['dev'] is None:
-            return "release"
-    return "dev"
+    match = get_release_tag()
+    if match['rc'] is not None:
+        return "rc"
+    elif match['rc'] is None and match['dev'] is None:
+        return "release"
+    else:
+        return "dev"
 
 
 def get_wheel():
@@ -209,9 +226,9 @@ def upload_to_github(verbose, files, token, release):
         if verbose:
             print("continuous release")
     elif release == "rc":
-        tag = latest_tag_from_tags(tags)
+        tag = get_release_tag()
         release_data = {
-            "tag": tag,
+            "tag": tag['full'],
             "name": "Release Candidate",
             "draft": False,
             "prerelease": True,
@@ -219,9 +236,9 @@ def upload_to_github(verbose, files, token, release):
         if verbose:
             print("release candidate, tag:", tag)
     elif release == "release":
-        tag = latest_tag_from_tags(tags)
+        tag = get_release_tag()
         release_data = {
-            "tag": tag,
+            "tag": tag['full'],
             "name": "Release %s" % tag,
             "draft": False,
             "prerelease": False,
@@ -351,6 +368,8 @@ def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_pas
 
     if dry_run:
         print("NOTE: running in dry-run mode, specify --no-dry-run to really upload!")
+
+    validate_version_tag()
 
     is_rc = current_version_tag_is_rc()
     is_release = current_version_tag_is_release()

--- a/scripts/release
+++ b/scripts/release
@@ -11,6 +11,7 @@ from os.path import join
 
 from github import Github, UnknownObjectException
 from pkg_resources import parse_version
+from pkg_resources.extern.packaging.version import LegacyVersion
 import click
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -69,6 +70,11 @@ def validate_version_tag():
         raise click.ClickException(
             "version tags need to have a 'v' prefix"
         )
+    v = parse_version(version_tag['full'])
+    if isinstance(v, LegacyVersion):
+        raise click.ClickException(
+            "could not parse version"
+        )
     return True
 
 
@@ -87,8 +93,14 @@ def get_release_tag():
     """
     tags = get_current_tags()
     matches = tag_matches(tags)
-    assert len(matches) == 1
-    return matches[0]
+    if len(matches) == 0:
+        return None
+    elif len(matches) == 1:
+        return matches[0]
+    else:
+        raise Exception(
+            "cannot have more than one version tags per commit"
+        )
 
 
 def get_latest_tag():
@@ -116,16 +128,22 @@ def tag_matches(tags):
 
 def current_version_tag_is_rc():
     match = get_release_tag()
+    if match is None:
+        return False
     return match['rc'] is not None
 
 
 def current_version_tag_is_release():
     match = get_release_tag()
+    if match is None:
+        return False
     return match['rc'] is None and match['dev'] is None
 
 
 def get_release_kind():
     match = get_release_tag()
+    if match is None:
+        return "dev"
     if match['rc'] is not None:
         return "rc"
     elif match['rc'] is None and match['dev'] is None:

--- a/scripts/release
+++ b/scripts/release
@@ -244,7 +244,9 @@ def build_appimage(verbose):
         print("building AppImage in %s" % APPIMAGE_DIR)
 
     # cleanup existing AppDir
-    shutil.rmtree(join(APPIMAGE_DIR, 'AppDir'))
+    APPDIR = join(APPIMAGE_DIR, 'AppDir')
+    if os.path.exists(APPDIR):
+        shutil.rmtree(APPDIR)
 
     cmd = [
         join(APPIMAGE_DIR, 'make_app_image.sh')

--- a/scripts/release
+++ b/scripts/release
@@ -2,13 +2,23 @@
 # -*- encoding: utf-8 -*-
 import os
 import re
+import sys
+import json
+import glob
+import shutil
 import subprocess
+from os.path import join
 
+from github import Github, UnknownObjectException
+from pkg_resources import parse_version
 import click
 
+HERE = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.normpath(join(HERE, '..'))
 
-VERSION_RE = re.compile(
-    r'^(?P<breaking>\d+)\.(?P<feature>\d+)\.(?P<fix>\d+)(?P<rc>\.rc\d+)?(?P<dev>\.dev0)?$'
+VERSION_PAT = re.compile(
+    r'^(?P<full>(?P<prefix>v)?(?P<breaking>\d+)\.(?P<feature>\d+)\.(?P<fix>\d+)'
+    r'(?P<rc>rc\d+)?(?P<dev>\.dev0)?)$'
 )
 
 
@@ -25,6 +35,10 @@ def read_version(version_file):
     return res['__version__']
 
 
+def get_version_fn():
+    return join(BASE_DIR, 'src', 'libertem', '__version__.py')
+
+
 def do_git_commit(old_version, new_version, version_file):
     cmd = ["git", "commit", version_file, "-m",
            "bump version: {} → {}".format(old_version, new_version)]
@@ -36,7 +50,366 @@ def do_git_tag(tag):
     subprocess.check_call(cmd)
 
 
-@click.command()
+def get_current_tags():
+    """
+    returns list of tags that point to HEAD
+    """
+    cmd = ["git", "tag", "--points-at", "HEAD"]
+    return subprocess.check_output(cmd, text="utf-8").strip().split("\n")
+
+
+def latest_tag_from_tags(tags):
+    """
+    A commit can have more than one version tag, for example if we re-tag
+    a release candidate as final release. This function returns the most current
+    tag, according to setuptools' parse_version
+    """
+    sorted_tags = list(sorted(tags, key=lambda t: parse_version(t)))
+    return sorted_tags[-1]
+
+
+def get_latest_tag():
+    """
+    return the latest tags, looking "back" from HEAD
+    """
+    try:
+        cmd = ["git", "describe", "--abbrev=0", "--tags"]
+        return subprocess.check_output(cmd, text="utf-8").strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def tag_matches(tags):
+    """
+    """
+    matches = [
+        VERSION_PAT.match(tag)
+        for tag in tags
+    ]
+    return [m.groupdict()
+            for m in matches
+            if m is not None]
+
+
+def current_version_tag_is_rc():
+    matches = tag_matches(get_current_tags())
+    for match in matches:
+        if match['rc'] is not None:
+            return True
+    return False
+
+
+def current_version_tag_is_release():
+    matches = tag_matches(get_current_tags())
+    for match in matches:
+        if match['rc'] is None and match['dev'] is None:
+            return True
+    return False
+
+
+def get_release_kind():
+    matches = tag_matches(get_current_tags())
+    for match in matches:
+        if match['rc'] is not None:
+            return "rc"
+        elif match['rc'] is None and match['dev'] is None:
+            return "release"
+    return "dev"
+
+
+def get_wheel():
+    wheels = glob.glob("%s/*.whl" % BASE_DIR)
+    assert len(wheels) == 1, "expected only one wheel, have: %s" % wheels
+    return wheels[0]
+
+
+def get_sdist():
+    sdists = glob.glob("%s/*.tar.gz" % BASE_DIR)
+    assert len(sdists) == 1, "expected only one tarball, have: %s" % sdists
+    return sdists[0]
+
+
+def get_py_release_files():
+    """
+    get wheel and sdist files (basically dist/*)
+    """
+    return glob.glob("%s/*" % BASE_DIR)
+
+
+def upload_to_zenodo(verbose, dry_run, parent_deposit):
+    if verbose:
+        print("uploading to zenodo")
+
+    wheel = get_wheel()
+    sdist = get_sdist()
+
+    release = get_release_kind()
+
+    if release == "dev":
+        raise Exception("don't want to upload to zenodo from dev release")
+    elif release == "rc":
+        url = "https://sandbox.zenodo.org/api/"
+        parent = "264899"  # FIXME?
+        raise Exception("please fix parent deposition IDs for sandbox and prod!")
+    elif release == "release":
+        url = "https://zenodo.org/api/"
+        parent = "1478763"  # FIXME: fix this number?
+
+    out = subprocess.check_output([
+        "python", join(HERE, "zenodo_upload"),
+        "--wheel=%s" % wheel,
+        "--tarball=%s" % sdist,
+        "--url=%s" % url,
+        "--parent=%s" % parent,
+    ])
+
+    if verbose and out:
+        print(out.decode("utf-8"))
+
+
+def get_release_msg():
+    parts = []
+    travis_url = os.environ.get("TRAVIS_BUILD_WEB_URL", "")
+    if travis_url:
+        parts.append("Travis CI biuld log: %s" % travis_url)
+    return "\n\n".join(parts)
+
+
+def upload_to_github(verbose, files, token, release):
+    if verbose:
+        print("uploading files to github:", files)
+    tags = tag_matches(get_current_tags())
+    msg = get_release_msg()
+
+    if verbose:
+        print("release message:", msg)
+
+    g = Github(token)
+    repo = g.get_repo("LiberTEM/LiberTEM")
+
+    # FIXME: what if we are not in context of travis?
+    target = os.environ["TRAVIS_COMMIT"]
+    release_data = {
+        "message": msg,
+        "target_commitish": target,
+    }
+    if release == "dev":
+        release_data = {
+            "tag": "continuous",
+            "name": "Continuous build",
+            "draft": False,
+            "prerelease": True,
+        }
+        # first, delete existing continuous tag:
+        try:
+            cont_tag = repo.get_git_ref("tags/continuous")
+            cont_tag.delete()
+        except UnknownObjectException:
+            pass
+        if verbose:
+            print("continuous release")
+    elif release == "rc":
+        tag = latest_tag_from_tags(tags)
+        release_data = {
+            "tag": tag,
+            "name": "Release Candidate",
+            "draft": False,
+            "prerelease": True,
+        }
+        if verbose:
+            print("release candidate, tag:", tag)
+    elif release == "release":
+        tag = latest_tag_from_tags(tags)
+        release_data = {
+            "tag": tag,
+            "name": "Release %s" % tag,
+            "draft": False,
+            "prerelease": False,
+        }
+        if verbose:
+            print("release, tag:", tag)
+    else:
+        raise ValueError("unknown release kind: %s" % release)
+
+    rel = repo.create_git_release(**release_data)
+
+    for path in files:
+        rel.upload_asset(path=path, content_type='application/octet-stream')
+
+
+def build_appimage(verbose):
+    APPIMAGE_DIR = join(BASE_DIR, 'packaging', 'appimage')
+
+    if verbose:
+        print("building AppImage in %s" % APPIMAGE_DIR)
+
+    # cleanup existing AppDir
+    shutil.rmtree(join(APPIMAGE_DIR, 'AppDir'))
+
+    cmd = [
+        join(APPIMAGE_DIR, 'make_app_image.sh')
+    ]
+    output = subprocess.check_output(cmd, text="utf-8", cwd=APPIMAGE_DIR).strip()
+
+    if verbose:
+        print(output)
+
+    # FIXME: where does the zsync file come from?
+    appimage_files = glob.glob(join(APPIMAGE_DIR, 'LiberTEM*.AppImage*'))
+
+    return appimage_files
+
+
+def prepare_upload(verbose):
+    """
+    Prepare for upload. This includes:
+
+     * running readme_to_html.py
+     * building sdist and wheel
+    """
+    if verbose:
+        print("preparing for upload")
+        print("calling readme_to_html.py")
+
+    out = subprocess.check_output([
+        "python", join(HERE, "readme_to_html.py"),
+        join(BASE_DIR, 'README.rst'),  # src
+        join(BASE_DIR, 'packaging', 'README.rst'),  # dest
+    ])
+
+    if verbose and out:
+        print(out.decode("utf-8"))
+
+    if verbose:
+        print("building wheel and sdist")
+
+    out = subprocess.check_output([
+        "python", "setup.py", "sdist", "bdist_wheel"
+    ], cwd=BASE_DIR)
+
+
+def upload_to_pypi(verbose, user, password):
+    files = get_py_release_files()
+    cmd = ["twine", "upload"]
+    release = get_release_kind()
+
+    # upload command for test.pypi.org:
+    # twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+    if release == "dev":
+        raise Exception("won't upload dev release to pypi")
+    elif release == "rc":
+        cmd.extend(["--repository-url", "https://test.pypi.org/legacy/"])
+    elif release == "release":
+        pass
+    else:
+        raise Exception("unknown release kind %s" % release)
+
+    cmd.extend(files)
+
+    out = subprocess.check_output(cmd)
+
+    if verbose:
+        print(out)
+
+
+@click.group()
+@click.option('--verbose/--no-verbose', default=True)
+@click.pass_context
+def cli(ctx, verbose):
+    ctx.obj['verbose'] = verbose
+
+
+@cli.command()
+@click.pass_context
+def is_rc(ctx):
+    res = current_version_tag_is_rc()
+    if ctx.obj['verbose']:
+        print("is rc?", res)
+    sys.exit(int(not res))
+
+
+@cli.command()
+@click.option('--dry-run/--no-dry-run', default=True,
+              help="don't actually upload, only prepare files etc.")
+@click.option('--pypi-user', type=str, show_envvar=True)
+@click.option('--pypi-password', type=str, show_envvar=True)
+@click.option('--pypi-test-user', type=str, show_envvar=True)
+@click.option('--pypi-test-password', type=str, show_envvar=True)
+@click.option('--token', type=str, show_envvar=True,
+              help='Github token for creating releases')
+@click.pass_context
+def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_password, token):
+    """
+    prepare, build and upload libertem to pypi (if release candidate, to the test instance)
+    """
+
+    if dry_run:
+        print("NOTE: running in dry-run mode, specify --no-dry-run to really upload!")
+
+    is_rc = current_version_tag_is_rc()
+    is_release = current_version_tag_is_release()
+
+    if is_rc:
+        # we want to upload release candidates to test.pypi.org:
+        assert (pypi_test_user is not None and pypi_test_password is not None)
+    if is_release:
+        # releases need the "real" pypi credentials:
+        assert (pypi_user is not None and pypi_password is not None)
+
+    prepare_upload(verbose=ctx.obj['verbose'])
+
+    # validate zenodo-upload.json:
+    with open(join(BASE_DIR, 'packaging/zenodo-upload.json')) as f:
+        json.load(f)
+
+    if not dry_run:
+        if is_release or is_rc:
+            upload_to_zenodo(verbose=ctx.obj['verbose'], dry_run=dry_run)
+        if is_release:
+            upload_to_pypi(ctx.obj['verbose'], user=pypi_user, password=pypi_password)
+        elif is_rc:
+            upload_to_pypi(ctx.obj['verbose'], user=pypi_test_user, password=pypi_test_password)
+
+    release = get_release_kind()
+
+    appimage_files = build_appimage(verbose=ctx.obj['verbose'])
+    github_files = get_py_release_files()
+    github_files.extend(appimage_files)
+
+    is_master = os.environ['TRAVIS_BRANCH'] == "master"
+    is_pull_request = os.environ['TRAVIS_PULL_REQUEST'] != "false"
+
+    if is_master and not is_pull_request:
+        if dry_run:
+            print("would upload the following files to github:")
+            for f in github_files:
+                print(f)
+        else:
+            upload_to_github(ctx.obj['verbose'], github_files, token=token, release=release)
+    else:
+        print("branch is not master, would not upload to github")
+
+
+@cli.command()
+@click.pass_context
+def status(ctx):
+    version_file = get_version_fn()
+    current_version = read_version(version_file)
+    print("current version: %s" % current_version)
+    print("version tags for HEAD: %s" % [m['full'] for m in tag_matches(get_current_tags())])
+    print("last version tags: %s" % [m['full'] for m in tag_matches([get_latest_tag()])])
+    print("is release candidate? %s" % current_version_tag_is_rc())
+
+
+@cli.command()
+@click.pass_context
+def do_build_appimage(ctx):
+    appimage_files = build_appimage(verbose=ctx.obj['verbose'])
+    print("success, files=", appimage_files)
+
+
+@cli.command()
 @click.argument('new_version', type=str)
 @click.option('--tag/--no-tag', help='create a git tag after bumping (implies --commit)',
               default=False)
@@ -44,7 +417,7 @@ def do_git_tag(tag):
               default=False)
 @click.option('--force/--no-force', help='force operation, even if it doesn\'t fit our conventions',
               default=False)
-def main(new_version, tag, commit, force):
+def bump(new_version, tag, commit, force):
     """
     bump the version in libertem.__version__
 
@@ -53,11 +426,10 @@ def main(new_version, tag, commit, force):
     if tag and not commit:
         commit = True
         print("NOTE: implicitly enabling --commit")
-    match = VERSION_RE.match(new_version)
+    match = VERSION_PAT.match(new_version)
     if match is None:
         raise click.UsageError("could not parse version, may not conform to our scheme")
-    here = os.path.abspath(os.path.dirname(__file__))
-    version_file = os.path.join(here, '..', 'src', 'libertem', '__version__.py')
+    version_file = get_version_fn()
     old_version = read_version(version_file)
     render_version(version_file, new_version)
     version_tag = "v{}".format(new_version)
@@ -85,4 +457,4 @@ def main(new_version, tag, commit, force):
 
 
 if __name__ == "__main__":
-    main()
+    cli(obj={}, auto_envvar_prefix="LT_RELEASE")

--- a/scripts/release
+++ b/scripts/release
@@ -293,6 +293,9 @@ def upload_to_pypi(verbose, user, password):
     cmd = ["twine", "upload"]
     release = get_release_kind()
 
+    cmd.extend(["-u", user])
+    cmd.extend(["-p", password])
+
     # upload command for test.pypi.org:
     # twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 

--- a/scripts/release
+++ b/scripts/release
@@ -369,10 +369,11 @@ def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_pas
     if dry_run:
         print("NOTE: running in dry-run mode, specify --no-dry-run to really upload!")
 
-    validate_version_tag()
-
     is_rc = current_version_tag_is_rc()
     is_release = current_version_tag_is_release()
+
+    if is_rc or is_release:
+        validate_version_tag()
 
     if is_rc:
         # we want to upload release candidates to test.pypi.org:

--- a/scripts/release
+++ b/scripts/release
@@ -183,7 +183,7 @@ def get_py_release_files():
     """
     get wheel and sdist files (basically dist/*)
     """
-    return glob.glob("%s/*" % BASE_DIR)
+    return glob.glob("%s/dist/*" % BASE_DIR)
 
 
 def upload_to_zenodo(verbose, dry_run):

--- a/scripts/zenodo_upload
+++ b/scripts/zenodo_upload
@@ -300,7 +300,7 @@ def main(wheel, tarball, parent, url, verbose):
 
     global VERBOSE
     VERBOSE = verbose
-    
+
     log("Creating new version of deposition %s..." % parent)
     r = new_version(parent_id=parent)
     prettylog(r)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [metadata]


### PR DESCRIPTION
Before, the release script only handled bumping the version (incl. optionally committing and tagging). 

Now, it also handles:

 + Creating a release on github (via PyGithub)
 + Triggering the wheel/sdist/AppImage build depending on version tags
 + Updating the deposition on zenodo (calls the existing script for now)
 + Uploading release artifacts on github

As the behavior is different for different contexts (branch vs. PR vs. master), I'm putting this up as a PR. In the travis build, wheel/sdist/appimage should be built, but not uploaded anywhere. After merging, the continuous build should be updated and include current wheel/sdist/appimage.

Edit: looks good, continuous release is as it was before.

Still TODO:

 - [x] fix tag-to-release logic (validation that only a single version tag exists for current commit, as we always want to have tag and `__version__.py` in sync)
 - [ ] zenodo upload: fix parent deposition IDs and/or pass in from outside (?)
 - [x] add zenodo credentials to travis as env vars
 - [ ] merge and then test/fix continuous release upload
 - [ ] maybe implement some checks that are run before the packaging stage to get faster feedback (`scripts/release check-env` or something? could check github API connection/credentials, zenodo credentials, etc. - could run as part of `tox -e qa`?)