### PR TITLE
Option to mask Zenodo error

### DIFF
--- a/scripts/zenodo_upload
+++ b/scripts/zenodo_upload
@@ -4,6 +4,7 @@
 import os
 import json
 import pprint
+import traceback
 
 import click
 import requests
@@ -307,36 +308,45 @@ def make_data():
 @click.option('--parent', default="264899")
 @click.option('--url', default='https://sandbox.zenodo.org/api/')
 @click.option('--verbose', '-v', is_flag=True)
-def main(wheel, tarball, parent, url, verbose):
-    global BASE_URL
-    BASE_URL = url
+@click.option('--mask-zenodo-exception', is_flag=True)
+def main(wheel, tarball, parent, url, verbose, mask_zenodo_exception):
+    try:
+        # raise ZenodoException("Test")
+        global BASE_URL
+        BASE_URL = url
 
-    global VERBOSE
-    VERBOSE = verbose
+        global VERBOSE
+        VERBOSE = verbose
 
-    log("Creating new version of deposition %s..." % parent)
-    r = new_version(parent_id=parent)
-    prettylog(r)
-
-    deposition_id = get_latest_draft(r)
-    log("Updating draft deposition %s..." % deposition_id)
-    r = update_deposition(deposition_id=deposition_id, data=make_data())
-    prettylog(r)
-
-    for file_id in get_file_ids(r):
-        log("Deleting inherited file %s..." % file_id)
-        r = delete_file(deposition_id, file_id)
+        log("Creating new version of deposition %s..." % parent)
+        r = new_version(parent_id=parent)
         prettylog(r)
 
-    log("Uploading wheel as new file...")
-    wheel_upload = upload_file(deposition_id=deposition_id, filename=wheel.name)
-    prettylog(wheel_upload)
+        deposition_id = get_latest_draft(r)
+        log("Updating draft deposition %s..." % deposition_id)
+        r = update_deposition(deposition_id=deposition_id, data=make_data())
+        prettylog(r)
 
-    log("Uploading tarball as new file...")
-    tar_upload = upload_file(deposition_id=deposition_id, filename=tarball.name)
-    prettylog(tar_upload)
+        for file_id in get_file_ids(r):
+            log("Deleting inherited file %s..." % file_id)
+            r = delete_file(deposition_id, file_id)
+            prettylog(r)
 
-    log("Finished!")
+        log("Uploading wheel as new file...")
+        wheel_upload = upload_file(deposition_id=deposition_id, filename=wheel.name)
+        prettylog(wheel_upload)
+
+        log("Uploading tarball as new file...")
+        tar_upload = upload_file(deposition_id=deposition_id, filename=tarball.name)
+        prettylog(tar_upload)
+
+        log("Finished!")
+    except ZenodoException as e:
+        if mask_zenodo_exception:
+            print("Masking Zenodo exception:")
+            traceback.print_exception(type(e), e, e.__traceback__)
+        else:
+            raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The Zenodo upload caused a row of spurious internal server errors,
see https://github.com/zenodo/zenodo/issues/1833

The new option lets the scrip return with a success status
after an error to continue with the release CI pipeline.

The Zenodo upload can be performed manually in that case, rather than
failing the entire release script.