### PR TITLE
Trigger a timeout when guessing parameters for HDF5 takes too long

### DIFF
--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -197,7 +197,7 @@ class H5DataSet(DataSet):
     def get_diagnostics(self):
         with self.get_reader().get_h5ds() as ds:
             try:
-                datasets =  _get_datasets(self.path)
+                datasets = _get_datasets(self.path)
             except TimeoutError:
                 datasets = []
             datasets = [


### PR DESCRIPTION
TODO better error handling. Right now, the opening dialogue defaults to RAW
if the timeout is triggered.

TODO There seems to be code duplication. between _get_datasets() and detect_params().
@sk1p is there a specific reason to do it like that? I have to admit that I don't fully
understand the consequences of changing this.

TODO: Choose a well-balanced timeout value in case traversing a legitimate file
takes longer than that, for example over network.

Closes #440