### PR TITLE
Remove NumPy pin again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,9 +134,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.6',
     install_requires=[
-        # FIXME pinned due to https://github.com/pydata/sparse/issues/257
-        # Unpin as soon as this is fixed, check regularly
-        "numpy<=1.16.4",
+        "numpy",
         "scipy",
         "sparse",
         "distributed>=1.23.3,<1.28",


### PR DESCRIPTION
Apparently, a merge undid parts of PR #406. This adds the missing change again.