### PR TITLE
Fix indentation issue in PyPI description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ def read(*parts):
 
 
 def remove_rst_roles(txt):
-    return re.sub(':(cite|doc):`[^`]+`', '', txt)
+    return re.sub(':(cite|doc):`[^`]+` ?', '', txt)
 
 
 def get_git_rev():


### PR DESCRIPTION
Extract bugfix from #460 to crystallize PR

Make sure that a :cite:`...` block at the beginning of a line doesn't create an indentation
when it is removed.