### PR TITLE
Use folder structure for changelog of continuous release

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,32 +7,10 @@ Changelog
 0.3.0.dev0 (continuous)
 #######################
 
-Features
---------
+.. toctree::
+   :glob:
 
-* :ref:`Clustering` analysis (:pr:`401,408` by :user:`kruzaeva`).
-
-Bug fixes
----------
-
-* Improved error and validation handling when opening files with GUI (:issue:`433,442`)
-
-Documentation
--------------
-
-* Documentation for :ref:`crystallinity map` and :ref:`clustering` analysis (:pr:`408` by :user:`kruzaeva`)
-* Instructions for profiling slow tests (:issue:`447`, :pr:`448`)
-* Include review of issues, PRs and release notes in release checklist (:pr:`445,453`)
-* Change management (:issue:`443`, :pr:`451,453`)
-
-.. Commented out
-   Obsolescence
-   ------------
-
-Miscellaneous
--------------
-
-* Performance improvements for unit tests (:issue:`447`, :pr:`448`)
+   changelog/*/*
 
 .. _latest:
 .. _`v0-2-2`:

--- a/docs/source/changelog/bugfix/errorhandling.rst
+++ b/docs/source/changelog/bugfix/errorhandling.rst
@@ -1,0 +1,4 @@
+[Bugfix] Error handling
+=======================
+
+* Improved error and validation handling when opening files with GUI (:issue:`433,442`)

--- a/docs/source/changelog/documentation/changemanagement.rst
+++ b/docs/source/changelog/documentation/changemanagement.rst
@@ -1,0 +1,4 @@
+[Doc] Change management
+=======================
+
+* Change management (:issue:`443`, :pr:`451,453`)

--- a/docs/source/changelog/documentation/checklist.rst
+++ b/docs/source/changelog/documentation/checklist.rst
@@ -1,0 +1,4 @@
+[Doc] Release checklist
+=======================
+
+* Include review of issues, PRs and release notes in release checklist (:pr:`445,453`)

--- a/docs/source/changelog/documentation/clusteringanalysis.rst
+++ b/docs/source/changelog/documentation/clusteringanalysis.rst
@@ -1,0 +1,4 @@
+[Doc] Clustering analysis
+=========================
+
+* Documentation for :ref:`crystallinity map` and :ref:`clustering` analysis (:pr:`408` by :user:`kruzaeva`)

--- a/docs/source/changelog/documentation/profiling.rst
+++ b/docs/source/changelog/documentation/profiling.rst
@@ -1,0 +1,4 @@
+[Doc] Profiling
+===============
+
+* Instructions for profiling slow tests (:issue:`447`, :pr:`448`)

--- a/docs/source/changelog/features/clusteringanalysis.rst
+++ b/docs/source/changelog/features/clusteringanalysis.rst
@@ -1,0 +1,4 @@
+[New] Clustering analysis
+=========================
+
+* :ref:`Clustering` analysis (:pr:`401,408` by :user:`kruzaeva`).

--- a/docs/source/changelog/misc/testperformance.rst
+++ b/docs/source/changelog/misc/testperformance.rst
@@ -1,0 +1,4 @@
+[Misc] Test performance
+-----------------------
+
+* Performance improvements for unit tests (:issue:`447`, :pr:`448`)

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -76,10 +76,15 @@ The previous behavior was this and that*. If applicable, use
 `versionadded <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded>`_
 and related directives.
 
+The changelog for the development branch is maintained as a collection of files
+in the :code:`docs/source/changelog/*/` folder structure. Each change should get
+a separate file to avoid merge conflicts. The files are merged into the
+master changelog when creating a release.
+
 The following items might require an
 update upon introducing or changing a feature:
 
-* Changelog in :code:`docs/source/changelog.rst`
+* Changelog snippet in :code:`docs/source/changelog/*/`
 * Docstrings
 * Examples
 * Main Documentation

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -19,7 +19,8 @@ Before (using a release candidate package)
   ``sphinx-build -b linkcheck "docs/source" "docs/build/html"``
 * Update the expected version in notes on changes, i.e. from :code:`0.3.0.dev0`
   to :code:`0.3` when releasing version 0.3.
-* Update and review change log in :code:`docs/source/changelog.rst`
+* Update and review change log in :code:`docs/source/changelog.rst`, merging
+  snippets in :code:`docs/source/changelog/*/ as appropriate.
 * Update the JSON files in the ``packaging/`` folder with author and project information
 * Update ``contributors.rst`` and  ``creators.rst`` in ``docs/source`` from the JSON source
   files in ``packaging/`` using ``python scripts/build-authors-contributors``

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -20,7 +20,7 @@ Before (using a release candidate package)
 * Update the expected version in notes on changes, i.e. from :code:`0.3.0.dev0`
   to :code:`0.3` when releasing version 0.3.
 * Update and review change log in :code:`docs/source/changelog.rst`, merging
-  snippets in :code:`docs/source/changelog/*/ as appropriate.
+  snippets in :code:`docs/source/changelog/*/` as appropriate.
 * Update the JSON files in the ``packaging/`` folder with author and project information
 * Update ``contributors.rst`` and  ``creators.rst`` in ``docs/source`` from the JSON source
   files in ``packaging/`` using ``python scripts/build-authors-contributors``


### PR DESCRIPTION
This helps to avoid merge conflicts and keeps changes nicely separated.

For now, manual merging should do fine. As soon as it becomes annoying we can automate it.