### PR TITLE
Round peak positions and convert to int

### DIFF
--- a/src/libertem/udf/blobfinder.py
+++ b/src/libertem/udf/blobfinder.py
@@ -410,6 +410,17 @@ class CorrelationUDF(UDF):
     '''
     Abstract base class for peak correlation implementations
     '''
+
+    def __init__(self, peaks, *args, **kwargs):
+        '''
+        Parameters
+        ----------
+
+        peaks : numpy.ndarray
+            Numpy array of (y, x) coordinates with peak positions in px to correlate
+        '''
+        super().__init__(peaks=np.round(peaks).astype(int), *args, **kwargs)
+
     def get_result_buffers(self):
         """
         we 'declare' what kind of result buffers we need, without concrete shapes


### PR DESCRIPTION
Giving peak positions as floats is a common mistake and annoyance because
the wrong type leads to an opaque error message downstream. Converting
automatically to int gives the expected result and I can't imagine a scenario
where it wouldn't work.

Crystallizing PR #458 