### PR TITLE
Switch to current pywin32 package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
         # Ensure compatibility with numpy 1.17
         "numba>=0.45.1",
         "ncempy>=1.4",
-        'pypiwin32;platform_system=="Windows"',
+        'pywin32;platform_system=="Windows"',
         # FIXME pull request #259
         # https://github.com/LiberTEM/LiberTEM/pull/259#discussion_r251877431
         'scikit-image',

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,9 @@ setup(
         # Ensure compatibility with numpy 1.17
         "numba>=0.45.1",
         "ncempy>=1.4",
-        'pywin32;platform_system=="Windows"',
+        # FIXME pin for https://github.com/mhammond/pywin32/issues/1439
+        # Revisit if fix is released
+        'pywin32<=225;platform_system=="Windows"',
         # FIXME pull request #259
         # https://github.com/LiberTEM/LiberTEM/pull/259#discussion_r251877431
         'scikit-image',


### PR DESCRIPTION
pypiwin32 is deprecated

This might affect some recent CI failures