### PR TITLE
Reduce likelyhood of jumps to wrong position

### DIFF
--- a/tests/udf/test_blobfinder.py
+++ b/tests/udf/test_blobfinder.py
@@ -432,7 +432,7 @@ def test_correlation_methods(lt_ctx, cls, dtype, kwargs):
     indices = np.mgrid[-2:3, -2:3]
     indices = np.concatenate(indices.T)
 
-    radius = 10
+    radius = 8
 
     data, indices, peaks = cbed_frame(*shape, zero, a, b, indices, radius)
 


### PR DESCRIPTION
Reduce radius to increase clearance between peaks. This fixes occasional issues in CI.

Note: This tries all correlation patterns, that means including the ones that are not so good
at separating close disks.

## Contributor Checklist:

* [x] I have added/updated test cases
