### PR TITLE
Calculate size as int64 to avoid overflows

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -129,6 +129,8 @@ def large_raw(tmpdir_factory):
     else:
         with open(filename, 'wb') as f:
             f.truncate(size)
+        stat = os.stat(filename)
+        assert stat.st_blocks == 0
     ds = RawFileDataSet(
         path=str(filename),
         scan_size=shape[:2],

--- a/docs/source/changelog/bugfix/overflow.rst
+++ b/docs/source/changelog/bugfix/overflow.rst
@@ -1,0 +1,4 @@
+[Bugfix] Use int64 for dataset size calculation
+===============================================
+
+* Ensure that dataset sizes are calculated as int64 to avoid integer overflows (:pr:`495`, :issue:`493`)

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -80,7 +80,7 @@ class RawFile(File3D):
 
         self._num_frames = num_frames
         self._dtype = np.dtype(dtype)
-        self._frame_size = np.product(frame_shape) * self._dtype.itemsize
+        self._frame_size = np.product(np.int64(frame_shape)) * self._dtype.itemsize
         self._frame_shape = frame_shape
         self._start_idx = start_idx
 

--- a/tests/io/test_raw.py
+++ b/tests/io/test_raw.py
@@ -12,6 +12,14 @@ def test_simple_open(default_raw):
     assert tuple(default_raw.shape) == (16, 16, 128, 128)
 
 
+def test_large_pick(large_raw, lt_ctx):
+    y, x = large_raw.shape.nav
+    dy, dx = large_raw.shape.sig
+    analysis = lt_ctx.create_pick_analysis(large_raw, y=y-1, x=x-1)
+    result = lt_ctx.run(analysis)
+    assert result.intensity.raw_data.shape == tuple(large_raw.shape.sig)
+
+
 def test_check_valid(default_raw):
     default_raw.check_valid()
 


### PR DESCRIPTION
Include efficient test case for large file using a sparse file

TODO confirm sparsity on Linux

Fixes #493

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases
