### PR TITLE
HDF5 tests: create alias of time.time for mocking

### DIFF
--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -9,6 +9,10 @@ from libertem.web.messages import MessageConverter
 from .base import DataSet, Partition, DataTile, DataSetException, DataSetMeta
 
 
+# alias for mocking:
+current_time = time.time
+
+
 def unravel_nav(slice_, containing_shape):
     """
     inverse of flatten_nav, currently limited to 1d -> 2d nav
@@ -61,10 +65,10 @@ def _get_datasets(path):
     datasets = []
 
     timeout = 3
-    t0 = time.time()
+    t0 = current_time()
 
     def _make_list(name, obj):
-        if time.time() - t0 > timeout:
+        if current_time() - t0 > timeout:
             raise TimeoutError
         if hasattr(obj, 'size') and hasattr(obj, 'shape'):
             datasets.append((name, obj.size, obj.shape, obj.dtype))

--- a/tests/io/test_hdf5.py
+++ b/tests/io/test_hdf5.py
@@ -183,10 +183,9 @@ def test_timeout_1(hdf5, lt_ctx):
         print(diags)
 
 
-@pytest.mark.skip(reason="mocking time.time is dangerous in multi-threaded environments")
 def test_timeout_2(hdf5, lt_ctx):
     print(threading.enumerate())
-    with mock.patch('time.time', side_effect=[1, 30]):
+    with mock.patch('libertem.io.dataset.hdf5.current_time', side_effect=[1, 30]):
         params = H5DataSet.detect_params(hdf5.filename, executor=lt_ctx.executor)
         assert list(params.keys()) == ["path"]
 
@@ -196,7 +195,7 @@ def test_timeout_2(hdf5, lt_ctx):
     ds = ds.initialize(lt_ctx.executor)
 
     print(threading.enumerate())
-    with mock.patch('time.time', side_effect=[30, 60]):
+    with mock.patch('libertem.io.dataset.hdf5.current_time', side_effect=[30, 60]):
         diags = ds.diagnostics
         print(diags)
 


### PR DESCRIPTION
Patching only the local `current_time` alias of `time.time` should not interfere with other threads.

## Contributor Checklist:

* [x] I have added myself to [the creators.json file]
* [x] I have added/updated test cases