### PR TITLE
Record coverage for numba njit functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ jobs:
       dist: xenial
       sudo: true
     - stage: test
+      env: TOXENV=numba_coverage
+      python: 3.7
+      dist: xenial
+      sudo: true
+    - stage: test
       env: TOXENV=flake8
       python: 3.7
       dist: xenial

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,4 @@ markers =
     slow: mark a test as slow, i.e. takes a couple of seconds to run
     dist: tests that exercise the distributed parts of libertem
     functional: mark a test as functional, testing the whole libertem stack
+    with_numba: mark tests that exercise a numba function so we can re-run for coverage

--- a/tests/io/test_k2is_uint12.py
+++ b/tests/io/test_k2is_uint12.py
@@ -1,5 +1,6 @@
 import math
 
+import pytest
 import numpy as np
 import numba
 
@@ -122,6 +123,7 @@ def encode_12_little_little(inp, out):
         out[encoded_remainder_offset + 1] = b
 
 
+@pytest.mark.with_numba
 def test_encode_decode_uint12_ref():
     mult = 45
     inp = np.arange(2*mult, dtype=np.uint16)
@@ -137,6 +139,7 @@ def test_encode_decode_uint12_ref():
     assert np.allclose(inp, result)
 
 
+@pytest.mark.with_numba
 def test_encode_decode_uint12():
     mult = 45
     inp = np.arange(2*mult, dtype=np.uint16)

--- a/tests/udf/test_blobfinder.py
+++ b/tests/udf/test_blobfinder.py
@@ -14,6 +14,7 @@ from libertem.io.dataset.memory import MemoryDataSet
 from utils import _mk_random
 
 
+@pytest.mark.with_numba
 def test_refinement():
     data = np.array([
         (0, 0, 0, 0, 0, 1),
@@ -39,6 +40,8 @@ def test_refinement():
     assert (rx < x) and (rx > (x - 1))
 
 
+# FIXME: numba coverage disabled because of to_fixed_tuple issue:
+# @pytest.mark.with_numba
 def test_smoke(lt_ctx):
     """
     just check if the analysis runs without throwing exceptions:
@@ -52,6 +55,7 @@ def test_smoke(lt_ctx):
     )
 
 
+@pytest.mark.with_numba
 def test_crop_disks_from_frame():
     match_pattern = blobfinder.RadialGradient(radius=2, search=2)
     crop_size = match_pattern.get_crop_size()
@@ -104,6 +108,7 @@ def test_crop_disks_from_frame():
     ])
 
 
+@pytest.mark.with_numba
 def test_com():
     data = np.random.random((7, 9))
     ref = scipy.ndimage.measurements.center_of_mass(data)
@@ -415,6 +420,8 @@ def test_featurevector(lt_ctx):
     assert np.allclose(res, peak_sum)
 
 
+# FIXME: numba coverage disabled because of to_fixed_tuple issue:
+# @pytest.mark.with_numba
 @pytest.mark.parametrize(
     "cls,dtype,kwargs",
     [
@@ -479,6 +486,8 @@ def test_correlation_methods(lt_ctx, cls, dtype, kwargs):
         assert np.allclose(res['refineds'].data[0], peaks, atol=0.5)
 
 
+# FIXME: numba coverage disabled because of to_fixed_tuple issue:
+# @pytest.mark.with_numba
 @pytest.mark.parametrize(
     "cls,dtype,kwargs",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,12 @@ setenv=
 passenv=
     DASK_SCHEDULER_ADDRESS
 
+[testenv:numba_coverage]
+commands=
+    pytest --durations=5 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml -m with_numba {posargs:tests/}
+setenv=
+    NUMBA_DISABLE_JIT=1
+
 [testenv:flake8]
 changedir={toxinidir}
 deps=


### PR DESCRIPTION
This is done by marking tests that exercise jitted functions with
the marker `with_numba`, which are then run again with `NUMBA_DISABLE_JIT=1` as a separate job in the tests stage.

Note that some numba functions are not supported in Python-mode, notably
`to_fixed_tuple`, so we can't get coverage for those functions (yet).

Fixes #474.