### PR TITLE
Configure codeclimate maintainability rules

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,11 @@
 version: "2"
+checks:
+  file-lines:
+    config:
+      threshold: 400
+  return-statements:
+    config:
+      threshold: 15
 plugins:
   tslint:
     enabled: true


### PR DESCRIPTION
 * Increase number of lines per file allowed to 400. This should allow
   us to keep things together that belong together, and not force
   the reader to jump around multiple files to understand some part of
   LiberTEM.
 * Increase number of return statements allowed - redux reducers are an
   example of code that needs needs to be structured like this - for
   example, not having a return statement for each case in the reducer
   means we have to watch out for fall-through into the next case etc.

Refs #541