### PR TITLE
More tests for distributed use case

### DIFF
--- a/src/libertem/io/dataset/cluster.py
+++ b/src/libertem/io/dataset/cluster.py
@@ -138,9 +138,10 @@ class ClusterDataSet(WritableDataSet, DataSet):
             json.dump(self._structure.serialize(), fh)
 
     def check_valid(self):
-        # FIXME: assert -> DataSetException
-        assert os.path.exists(self._path)
-        assert os.path.isdir(self._path)
+        if not os.path.exists(self._path):
+            raise DataSetException("path %s does not exist" % self._path)
+        if not os.path.isdir(self._path):
+            raise DataSetException("path %s is not a directory" % self._path)
 
     @classmethod
     def detect_params(cls, path, executor):
@@ -178,7 +179,10 @@ class ClusterDataSet(WritableDataSet, DataSet):
         """
         returns a mapping idx -> workers
         """
-        assert self._executor is not None
+        if self._executor is None:
+            raise RuntimeError(
+                "invalid state: _get_all_workers needs access to the executor"
+            )
 
         paths = [
             (idx, self._get_path_for_idx(idx))

--- a/src/libertem/io/dataset/cluster.py
+++ b/src/libertem/io/dataset/cluster.py
@@ -73,7 +73,11 @@ class ClusterDataSet(WritableDataSet, DataSet):
         if not all(s == given_structure for s in sidecars.values()):
             print(sidecars.values())
             print(given_structure)
-            raise DataSetException("inconsistent sidecars, what now?")
+            raise DataSetException(
+                "inconsistent sidecars, please inspect %s on each node" % (
+                    self._sidecar_path(),
+                )
+            )
         self._executor = executor
         return self
 

--- a/src/libertem/io/dataset/cluster.py
+++ b/src/libertem/io/dataset/cluster.py
@@ -138,10 +138,8 @@ class ClusterDataSet(WritableDataSet, DataSet):
             json.dump(self._structure.serialize(), fh)
 
     def check_valid(self):
-        if not os.path.exists(self._path):
-            raise DataSetException("path %s does not exist" % self._path)
-        if not os.path.isdir(self._path):
-            raise DataSetException("path %s is not a directory" % self._path)
+        if not os.path.exists(self._path) or not os.path.isdir(self._path):
+            raise DataSetException("path %s does not exist or is not a directory" % self._path)
 
     @classmethod
     def detect_params(cls, path, executor):

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -168,14 +168,13 @@ class DMDataSet(DataSet):
         self._scan_size = tuple(scan_size) if scan_size else scan_size
         self._filesize = None
         self._files = files
+        if len(files) == 0:
+            raise DataSetException("need at least one file as input!")
         self._fileset = None
         self._offsets = {}
 
     def _get_fileset(self):
-        try:
-            first_fn = self._get_files()[0]
-        except IndexError:
-            raise DataSetException("need at least one file as input!")
+        first_fn = self._get_files()[0]
         first_file = fileDM(first_fn, on_memory=True)
         if first_file.numObjects == 1:
             idx = 0
@@ -183,14 +182,9 @@ class DMDataSet(DataSet):
             idx = 1
         try:
             raw_dtype = first_file._DM2NPDataType(first_file.dataType[idx])
-        except IndexError as e:
-            raise DataSetException("could not determine dtype") from e
-
-        try:
             shape = (first_file.ySize[idx], first_file.xSize[idx])
         except IndexError as e:
-            raise DataSetException("could not determine signal shape") from e
-
+            raise DataSetException("could not determine dtype or signal shape") from e
         start_idx = 0
         files = []
         for fn in self._get_files():

--- a/tests/io/test_blo.py
+++ b/tests/io/test_blo.py
@@ -106,3 +106,12 @@ def test_pick_analysis(default_blo, lt_ctx):
 
 def test_cache_key_json_serializable(default_blo):
     json.dumps(default_blo.get_cache_key())
+
+
+@pytest.mark.dist
+def test_blo_dist(dist_ctx):
+    ds = BloDataSet(path="/data/default.blo")
+    ds = ds.initialize(dist_ctx.executor)
+    analysis = dist_ctx.create_sum_analysis(dataset=ds)
+    results = dist_ctx.run(analysis)
+    assert results[0].raw_data.shape == (144, 144)

--- a/tests/io/test_dm.py
+++ b/tests/io/test_dm.py
@@ -64,3 +64,15 @@ def test_same_offset(lt_ctx):
 
 def test_repr(default_dm):
     assert repr(default_dm) == "<DMDataSet for a stack of 10 files>"
+
+
+@pytest.mark.dist
+def test_dm_dist(dist_ctx):
+    files = dist_ctx.executor.run_function(lambda: list(sorted(glob.glob("/data/dm/*.dm4"))))
+    print(files)
+    ds = DMDataSet(files=files)
+    ds = ds.initialize(dist_ctx.executor)
+    analysis = dist_ctx.create_sum_analysis(dataset=ds)
+    roi = np.random.choice([True, False], size=len(files))
+    results = dist_ctx.run(analysis, roi=roi)
+    assert results[0].raw_data.shape == (3838, 3710)

--- a/tests/io/test_empad.py
+++ b/tests/io/test_empad.py
@@ -178,3 +178,12 @@ def test_crop_to(default_empad, lt_ctx):
 
 def test_cache_key_json_serializable(default_empad):
     json.dumps(default_empad.get_cache_key())
+
+
+@pytest.mark.dist
+def test_empad_dist(dist_ctx):
+    ds = EMPADDataSet(path="/data/EMPAD/acquisition_12_pretty.xml")
+    ds = ds.initialize(dist_ctx.executor)
+    analysis = dist_ctx.create_sum_analysis(dataset=ds)
+    results = dist_ctx.run(analysis)
+    assert results[0].raw_data.shape == (128, 128)

--- a/tests/io/test_k2is.py
+++ b/tests/io/test_k2is.py
@@ -231,3 +231,18 @@ def test_macrotile_roi_3(lt_ctx, default_k2is):
 
 def test_cache_key_json_serializable(default_k2is):
     json.dumps(default_k2is.get_cache_key())
+
+
+@pytest.mark.dist
+def test_k2is_dist(dist_ctx):
+    ds = K2ISDataSet(path="/data/Capture52/Capture52_.gtg")
+    import glob
+    print(dist_ctx.executor.run_function(lambda: os.listdir("/data/Capture52/")))
+    print(dist_ctx.executor.run_function(lambda: list(sorted(glob.glob("/data/Capture52/*")))))
+    ds = ds.initialize(dist_ctx.executor)
+    roi = np.zeros(ds.shape.nav, dtype=bool)
+    roi[0, 5] = 1
+    roi[0, 17] = 1
+    analysis = dist_ctx.create_sum_analysis(dataset=ds)
+    results = dist_ctx.run(analysis, roi=roi)
+    assert results[0].raw_data.shape == (1860, 2048)

--- a/tests/io/test_mib.py
+++ b/tests/io/test_mib.py
@@ -168,3 +168,13 @@ def test_diagnostics(default_mib):
 
 def test_cache_key_json_serializable(default_mib):
     json.dumps(default_mib.get_cache_key())
+
+
+@pytest.mark.dist
+def test_mib_dist(dist_ctx):
+    scan_size = (32, 32)
+    ds = MIBDataSet(path="/data/default.mib", tileshape=(1, 3, 256, 256), scan_size=scan_size)
+    ds = ds.initialize(dist_ctx.executor)
+    analysis = dist_ctx.create_sum_analysis(dataset=ds)
+    results = dist_ctx.run(analysis)
+    assert results[0].raw_data.shape == (256, 256)


### PR DESCRIPTION
This adds tests for the NFS-ish use-case for non-natively-distributed formats, and also some tests for the `ClusterDataSet`.

The following formats now have such test cases: DM, K2IS, EMPAD, RAW, MIB.

Most of these don't run in CI yet though, because of missing test data and infra (#86).

This already caught a bug in the DM reader regarding dataset size calculation :grin:

## Contributor Checklist:

* [x] I have added/updated test cases