### PR TITLE
Blobfinder fixes; changelog update

### DIFF
--- a/docs/source/changelog/bugfix/blobfinder.rst
+++ b/docs/source/changelog/bugfix/blobfinder.rst
@@ -1,4 +1,5 @@
 [Bugfix] Bounds checking in blobfinder
 ======================================
 
- * Fix bounds checking, size and index calculation bugs (:issue:`539`, :pr:`548`)
+ * Fix bounds checking, size and index calculation bugs in blobfinder (:issue:`539`, :pr:`548`)
+ 

--- a/docs/source/changelog/bugfix/blobfinder.rst
+++ b/docs/source/changelog/bugfix/blobfinder.rst
@@ -1,0 +1,4 @@
+[Bugfix] Bounds checking in blobfinder
+======================================
+
+ * Fix bounds checking, size and index calculation bugs (:issue:`539`, :pr:`548`)

--- a/docs/source/changelog/bugfix/fix_pick_roi_interaction.rst
+++ b/docs/source/changelog/bugfix/fix_pick_roi_interaction.rst
@@ -1,4 +1,0 @@
-Disable ROI selector if the current mode is PICK
-================================================
-
- * ROI doesn't have any effect if in pick mode, so we hide the dropdown in that case (:issue:`511`)

--- a/docs/source/changelog/bugfix/frms6_dist.rst
+++ b/docs/source/changelog/bugfix/frms6_dist.rst
@@ -1,5 +1,5 @@
-Fix FRMS6 in a distributed setting
-==================================
+[Bugfix] Fix FRMS6 in a distributed setting
+===========================================
 
  * We now make sure to only do I/O in methods that are running on worker nodes (:pr:`531`).
 

--- a/docs/source/changelog/bugfix/run_each_host_nonpure.rst
+++ b/docs/source/changelog/bugfix/run_each_host_nonpure.rst
@@ -1,4 +1,4 @@
-Fix DaskJobExecutor.run_each_host
-=================================
+[Bugfix] Fix DaskJobExecutor.run_each_host
+==========================================
 
  * Need to pass :code:`pure=False` to ensure multiple runs of the function (:pr:`528`).

--- a/docs/source/changelog/features/dismiss_err_via_keys.rst
+++ b/docs/source/changelog/features/dismiss_err_via_keys.rst
@@ -1,4 +1,4 @@
-Dismiss error messages via keyboard
-===================================
+[Feature] Dismiss error messages via keyboard
+=============================================
 
  * Allows pressing the escape key to close all currently open error messages (:issue:`437`)

--- a/docs/source/changelog/features/fix_pick_roi_interaction.rst
+++ b/docs/source/changelog/features/fix_pick_roi_interaction.rst
@@ -1,0 +1,4 @@
+[Feature] Disable ROI selector if the current mode is PICK
+==========================================================
+
+ * ROI doesn't have any effect if in pick mode, so we hide the dropdown in that case (:issue:`511`)

--- a/docs/source/changelog/obsolescence/remove_hdfs.rst
+++ b/docs/source/changelog/obsolescence/remove_hdfs.rst
@@ -1,5 +1,5 @@
-Remove HDFS support
-===================
+[Obsolescence] Remove HDFS support
+==================================
 
  * Because HDFS support is right now not tested (and to my knowledge also not
    used) and the upstream :code:`hdfs3` project is not actively maintained, remove

--- a/src/libertem/utils/generate.py
+++ b/src/libertem/utils/generate.py
@@ -4,7 +4,9 @@ from libertem.utils import make_cartesian, make_polar, frame_peaks
 import libertem.masks as m
 
 
-def cbed_frame(fy=128, fx=128, zero=None, a=None, b=None, indices=None, radius=4, all_equal=False):
+def cbed_frame(
+        fy=128, fx=128, zero=None, a=None, b=None, indices=None,
+        radius=4, all_equal=False, margin=None):
     if zero is None:
         zero = (fy//2, fx//2)
     zero = np.array(zero)
@@ -16,7 +18,9 @@ def cbed_frame(fy=128, fx=128, zero=None, a=None, b=None, indices=None, radius=4
     b = np.array(b)
     if indices is None:
         indices = np.mgrid[-10:11, -10:11]
-    indices, peaks = frame_peaks(fy=fy, fx=fx, zero=zero, a=a, b=b, r=radius, indices=indices)
+    if margin is None:
+        margin = radius
+    indices, peaks = frame_peaks(fy=fy, fx=fx, zero=zero, a=a, b=b, r=margin, indices=indices)
 
     data = np.zeros((1, fy, fx), dtype=np.float32)
 


### PR DESCRIPTION
* Allow running blobfinder tests with NUMBA_JIT_DISABLED
* Fixes and test cases for the bugs that were uncovered in the process

* Managing changelog entries as a minor drive-by change

@sk1p it was really worth working on the NUMBA_JIT_DISABLED test capability.  Numba doesn't do bounds checks just as C, and testing with JIT disabled catches bugs that access the wrong memory.

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases
