### PR TITLE
Peak finding correlation pattern in separate function

### DIFF
--- a/src/libertem/udf/blobfinder/correlation.py
+++ b/src/libertem/udf/blobfinder/correlation.py
@@ -35,6 +35,25 @@ else:
     from numba.unsafe.ndarray import to_fixed_tuple
 
 
+def get_correlation(sum_result, match_pattern: MatchPattern):
+    '''
+    Calculate the correlation between :code:`sum_result` and :code:`match_pattern`.
+
+    Parameters
+    ----------
+
+    sum_result: numpy.ndarray
+        2D result frame as correlation input
+    match_pattern : MatchPattern
+        Instance of :class:`~libertem.udf.blobfinder.MatchPattern` to correlate
+        :code:`sum_result` with
+    '''
+    spec_mask = match_pattern.get_template(sig_shape=sum_result.shape)
+    spec_sum = fft.rfft2(sum_result)
+    corrspec = spec_mask * spec_sum
+    return fft.fftshift(fft.irfft2(corrspec))
+
+
 def get_peaks(sum_result, match_pattern: MatchPattern, num_peaks):
     '''
     Find peaks of the correlation between :code:`sum_result` and :code:`match_pattern`.
@@ -71,10 +90,7 @@ def get_peaks(sum_result, match_pattern: MatchPattern, num_peaks):
      [48 64]
      [64 96]]
     '''
-    spec_mask = match_pattern.get_template(sig_shape=sum_result.shape)
-    spec_sum = fft.rfft2(sum_result)
-    corrspec = spec_mask * spec_sum
-    corr = fft.fftshift(fft.irfft2(corrspec))
+    corr = get_correlation(sum_result, match_pattern)
     peaks = peak_local_max(corr, num_peaks=num_peaks)
     return peaks
 


### PR DESCRIPTION
This allows users to get the correlation pattern for debugging and
visualization purposes.

I was missing this function when working on the bullseye example

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes -- will be part of an upcoming example in LiberTEM-Examples
* [ ] I have added/updated test cases -- tested by existing blobfinder tests
