### PR TITLE
zenodo_upload: support for uploading more than two files

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -211,11 +211,11 @@ def upload_to_zenodo(verbose, parent, token, sandbox_token):
 
     out = subprocess.check_output([
         "python", join(HERE, "zenodo_upload"),
-        "--wheel=%s" % wheel,
-        "--tarball=%s" % sdist,
         "--url=%s" % url,
         "--parent=%s" % parent,
         "--mask-zenodo-exception",
+        wheel,
+        sdist,
     ])
 
     if verbose and out:

--- a/scripts/zenodo_upload
+++ b/scripts/zenodo_upload
@@ -371,13 +371,12 @@ def make_data():
 
 
 @click.command()
-@click.option('--wheel', required=True, type=click.File())
-@click.option('--tarball', required=True, type=click.File())
 @click.option('--parent', default="264899")
 @click.option('--url', default='https://sandbox.zenodo.org/api/')
 @click.option('--verbose', '-v', is_flag=True)
 @click.option('--mask-zenodo-exception', is_flag=True)
-def main(wheel, tarball, parent, url, verbose, mask_zenodo_exception):
+@click.argument('files', nargs=-1, required=True, type=click.File())
+def main(files, parent, url, verbose, mask_zenodo_exception):
     try:
         # raise ZenodoException("Test")
         global BASE_URL
@@ -400,13 +399,10 @@ def main(wheel, tarball, parent, url, verbose, mask_zenodo_exception):
             r = delete_file(deposition_id, file_id)
             prettylog(r)
 
-        log("Uploading wheel as new file...")
-        wheel_upload = upload_file(deposition_id=deposition_id, filename=wheel.name)
-        prettylog(wheel_upload)
-
-        log("Uploading tarball as new file...")
-        tar_upload = upload_file(deposition_id=deposition_id, filename=tarball.name)
-        prettylog(tar_upload)
+        for fh in files:
+            log("Uploading file %s..." % fh.name)
+            upload_result = upload_file(deposition_id=deposition_id, filename=fh.name)
+            prettylog(upload_result)
 
         log("Finished!")
     except ZenodoException as e:


### PR DESCRIPTION
First part of #431. Next part will need some restructuring of the release script, switching the ordering of GitHub release and Zenodo upload.

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)