### PR TITLE
Upload release repo snapshot to zenodo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
       python: 3.7
       dist: xenial
       install:
-        - pip install click pygithub requests twine html5lib docutils bibtexparser
+        - pip install -r scripts/requirements.txt
       script:
         - python scripts/release upload --pypi-test-user=libertem_bot --pypi-user=libertem_bot --no-dry-run
 

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -14,7 +14,8 @@ reason we should perform some manual tests before and after a release.
 Tagging a version
 ~~~~~~~~~~~~~~~~~
 
-Install :code:`pygithub`, which is used by :code:`scripts/release`. Then call the script with
+Install dependencies from :code:`scripts/requirements.txt`,
+which are used by :code:`scripts/release`. Then call the script with
 the :code:`bump` command, with the new version as parameter:
 
 .. code-block:: shell
@@ -49,7 +50,7 @@ Before (using a release candidate package)
 * For the GUI-related items, open in an incognito window to start from a clean slate
 * Correct version info displayed in info dialogue?
 * Link check in version info dialogue
-* Copy test files of all supported types to a fresh location or purge the parameter cache
+* Make sure you have test files of all supported types available
     * Include floats, ints, big endian, little endian, complex raw data
 * Open each test file
     * Are parameters recognized correctly, as far as implemented?

--- a/scripts/release
+++ b/scripts/release
@@ -186,11 +186,10 @@ def get_py_release_files():
 
 
 def stream_download(dest_fn, url):
-    with open(dest_fn, "wb") as f:
-        with requests.get(url, stream=True) as resp:
-            resp.raise_for_status()
-            for chunk in resp.iter_content(chunk_size=1024*1024):
-                f.write(chunk)
+    with open(dest_fn, "wb") as f, requests.get(url, stream=True) as resp:
+        resp.raise_for_status()
+        for chunk in resp.iter_content(chunk_size=1024*1024):
+            f.write(chunk)
 
 
 @contextlib.contextmanager

--- a/scripts/release
+++ b/scripts/release
@@ -6,13 +6,16 @@ import sys
 import json
 import glob
 import shutil
+import tempfile
 import subprocess
+import contextlib
 from os.path import join
 
 from github import Github, UnknownObjectException
 from pkg_resources import parse_version
 from pkg_resources.extern.packaging.version import LegacyVersion
 import click
+import requests
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.normpath(join(HERE, '..'))
@@ -143,15 +146,6 @@ def tag_matches(tags):
             if m is not None]
 
 
-def get_version_tag():
-    """
-    get the current version tag as match dict
-    """
-    version_tags = tag_matches(get_current_tags())
-    if len(version_tags) == 1:
-        return version_tags[0]
-
-
 def current_version_tag_is_rc():
     return get_release_kind() == "rc"
 
@@ -191,7 +185,38 @@ def get_py_release_files():
     return glob.glob("%s/dist/*" % BASE_DIR)
 
 
+def stream_download(dest_fn, url):
+    with open(dest_fn, "wb") as f:
+        with requests.get(url, stream=True) as resp:
+            resp.raise_for_status()
+            for chunk in resp.iter_content(chunk_size=1024*1024):
+                f.write(chunk)
+
+
+@contextlib.contextmanager
+def get_archive(tag):
+    """
+    Download repository archive from github releases page.
+
+    Parameters
+    ----------
+    tag : re.Match
+        Release tag to download the archive for, as
+        matched by VERSION_PAT
+    """
+    filename = "libertem-repo-archive-%s.tar.gz" % tag['full']
+    with tempfile.TemporaryDirectory() as tempdir:
+        full_fn = os.path.join(tempdir, filename)
+        url = "https://github.com/LiberTEM/LiberTEM/archive/%s.tar.gz" % tag['full']
+        stream_download(dest_fn=full_fn, url=url)
+        yield full_fn
+
+
 def upload_to_zenodo(verbose, parent, token, sandbox_token):
+    """
+    Upload wheel, sdist and repo archive to zenodo. Only works if
+    there is a matching GitHub release already created.
+    """
     if verbose:
         print("uploading to zenodo")
 
@@ -209,14 +234,18 @@ def upload_to_zenodo(verbose, parent, token, sandbox_token):
         url = "https://zenodo.org/api/"
         os.environ['ZENODO_OAUTH_TOKEN'] = token
 
-    out = subprocess.check_output([
-        "python", join(HERE, "zenodo_upload"),
-        "--url=%s" % url,
-        "--parent=%s" % parent,
-        "--mask-zenodo-exception",
-        wheel,
-        sdist,
-    ])
+    tag = get_release_tag()
+
+    with get_archive(tag) as repo_archive:
+        out = subprocess.check_output([
+            "python", join(HERE, "zenodo_upload"),
+            "--url=%s" % url,
+            "--parent=%s" % parent,
+            "--mask-zenodo-exception",
+            wheel,
+            sdist,
+            repo_archive,
+        ])
 
     if verbose and out:
         print(out.decode("utf-8"))
@@ -437,10 +466,6 @@ def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_pas
         json.load(f)
 
     if not dry_run:
-        if is_release or is_rc:
-            upload_to_zenodo(verbose=ctx.obj['verbose'],
-                             parent=zenodo_sandbox_parent if is_rc else zenodo_parent,
-                             token=zenodo_token, sandbox_token=zenodo_sandbox_token)
         if is_release:
             upload_to_pypi(ctx.obj['verbose'], user=pypi_user, password=pypi_password)
         elif is_rc:
@@ -470,6 +495,11 @@ def upload(ctx, dry_run, pypi_user, pypi_password, pypi_test_user, pypi_test_pas
             "branch is not master or stable (or CI run is for PR)"
             ", not uploading to github (files=%s)" % github_files
         )
+
+    if not dry_run and (is_release or is_rc):
+        upload_to_zenodo(verbose=ctx.obj['verbose'],
+                         parent=zenodo_sandbox_parent if is_rc else zenodo_parent,
+                         token=zenodo_token, sandbox_token=zenodo_sandbox_token)
 
 
 @cli.command()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,7 @@
+click
+pygithub
+requests
+twine
+html5lib
+docutils
+bibtexparser


### PR DESCRIPTION
Download repo snapshot from `/archive/{tag}.tar.gz`, upload that to zenodo and move zenodo upload after GitHub release creation. Fixes #431.