### PR TITLE
HDF5: fix tile offset if reading with roi

### DIFF
--- a/docs/source/changelog/bugfix/hdf5_roi_fix.rst
+++ b/docs/source/changelog/bugfix/hdf5_roi_fix.rst
@@ -1,0 +1,4 @@
+[Bugfix] Fix reading from HDF5 with roi
+=======================================
+
+* Offset calculation for tiles was wrong beyond the first partition (:pr:`606`)

--- a/docs/source/changelog/misc/removeme.rst
+++ b/docs/source/changelog/misc/removeme.rst
@@ -1,4 +1,0 @@
-No changes yet
-==============
-
-No changes yet. Remove this file as soon as the first real change log entry is created.

--- a/docs/source/udf/profiling.rst
+++ b/docs/source/udf/profiling.rst
@@ -61,7 +61,7 @@ Then the easiest way to get started is to use the ipython/jupyter integration of
 `line_profiler`. Put :code:`%load_ext line_profiler` somewhere in your notebook,
 then you can use the :code:`%lprun` magic command to run your UDF while profiling:
 
-.. code-block::
+.. code-block:: text
 
    %lprun -f YourUDF.get_task_data -f YourUDF.process_frame ctx.run_udf(dataset=dataset, YourUDF())
 

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -277,13 +277,14 @@ class H5Partition(Partition):
                 yield DataTile(data=buf.reshape(tile_slice_flat.shape), tile_slice=tile_slice_flat)
 
     def _get_tiles_with_roi(self, roi, dest_dtype):
+        flat_roi = roi.reshape((-1,))
         roi = roi.reshape(self.meta.shape.nav)
 
         result_shape = Shape((1,) + tuple(self.meta.shape.sig), sig_dims=self.meta.shape.sig.dims)
         sig_origin = tuple([0] * self.meta.shape.sig.dims)
         frames_read = 0
         start_at_frame = self.slice.origin[0]
-        frame_offset = np.count_nonzero(roi[:start_at_frame])
+        frame_offset = np.count_nonzero(flat_roi[:start_at_frame])
 
         indices = _roi_to_nd_indices(roi, self.slice_nd)
 


### PR DESCRIPTION
The `roi` needs to be flat when calculating the frame offset.

## Contributor Checklist:

* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases