### PR TITLE
Add `get_extensions` function to `libertem.io.dataset`

### DIFF
--- a/docs/source/changelog/features/get_extensions.rst
+++ b/docs/source/changelog/features/get_extensions.rst
@@ -1,0 +1,4 @@
+[Feature] `:code:`libertem.io.dataset.get_extensions`
+=====================================================
+
+* Returns a set of supported file extensions for all datasets

--- a/src/libertem/io/dataset/__init__.py
+++ b/src/libertem/io/dataset/__init__.py
@@ -1,3 +1,4 @@
+import typing
 import importlib
 
 from libertem.io.dataset.base import DataSetException
@@ -94,3 +95,16 @@ def detect(path, executor):
         params.update({"type": filetype})
         return params
     return {}
+
+
+def get_extensions() -> typing.Set[str]:
+    """
+    Return supported extensions as a set of strings.
+
+    Plain extensions only, no pattern!
+    """
+    types = set()
+    for filetype in filetypes.keys():
+        cls = get_dataset_cls(filetype)
+        types = types.union(set(ext.lower() for ext in cls.get_supported_extensions()))
+    return types

--- a/src/libertem/io/dataset/base.py
+++ b/src/libertem/io/dataset/base.py
@@ -1,3 +1,4 @@
+import typing
 import itertools
 
 import jsonschema
@@ -285,6 +286,15 @@ class DataSet(object):
             target_size_items=target_size // np.dtype(dtype).itemsize,
             min_num=min_num_partitions
         )
+
+    @classmethod
+    def get_supported_extensions(cls) -> typing.Set[str]:
+        """
+        Return supported extensions as a set of strings.
+
+        Plain extensions only, no pattern!
+        """
+        return set()
 
     def get_cache_key(self):
         raise NotImplementedError()

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -182,6 +182,10 @@ class BloDataSet(DataSet):
     def get_msg_converter(cls):
         return BLODatasetParams
 
+    @classmethod
+    def get_supported_extensions(cls):
+        return set(["blo"])
+
     @property
     def dtype(self):
         return self._meta.raw_dtype

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -239,6 +239,10 @@ class DMDataSet(DataSet):
         return self
 
     @classmethod
+    def get_supported_extensions(cls):
+        return set(["dm3", "dm4"])
+
+    @classmethod
     def detect_params(cls, path, executor):
         # FIXME: this doesn't really make sense for file series
         pl = path.lower()

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -166,6 +166,10 @@ class EMPADDataSet(DataSet):
         return EMPADDatasetParams
 
     @classmethod
+    def get_supported_extensions(cls):
+        return set(["xml", "raw"])
+
+    @classmethod
     def detect_params(cls, path, executor):
         """
         Detect parameters. If an `path` is an xml file, we try to automatically

--- a/src/libertem/io/dataset/frms6.py
+++ b/src/libertem/io/dataset/frms6.py
@@ -413,6 +413,10 @@ class FRMS6DataSet(DataSet):
         return {"path": path}
 
     @classmethod
+    def get_supported_extensions(cls):
+        return set(["frms6", "hdr"])
+
+    @classmethod
     def get_msg_converter(cls):
         return FRMS6DatasetParams
 

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -143,6 +143,10 @@ class H5DataSet(DataSet):
         return HDF5DatasetParams
 
     @classmethod
+    def get_supported_extensions(cls):
+        return set(["h5", "hdf5", "hspy", "nxs"])
+
+    @classmethod
     def detect_params(cls, path, executor):
         def _do_detect():
             with h5py.File(path, 'r'):

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -516,6 +516,10 @@ class K2ISDataSet(DataSet):
         return K2ISDatasetParams
 
     @classmethod
+    def get_supported_extensions(cls):
+        return set(["gtg", "bin"])
+
+    @classmethod
     def detect_params(cls, path, executor):
         """
         detect if path points to a file that is part of a k2is dataset.

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -363,6 +363,10 @@ class MIBDataSet(DataSet):
         return MIBDatasetParams
 
     @classmethod
+    def get_supported_extensions(cls):
+        return set(["mib", "hdr"])
+
+    @classmethod
     def detect_params(cls, path, executor):
         pathlow = path.lower()
         if pathlow.endswith(".mib"):

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -135,6 +135,10 @@ class SERDataSet(DataSet):
         return SERDatasetParams
 
     @classmethod
+    def get_supported_extensions(cls):
+        return set(["ser"])
+
+    @classmethod
     def detect_params(cls, path, executor):
         if path.lower().endswith(".ser"):
             return {"path": path}

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -3,7 +3,10 @@ from collections import namedtuple
 import numpy as np
 import pytest
 
-from libertem.io.dataset.base import FileTree, Partition3D, _roi_to_nd_indices
+from libertem.io.dataset import get_extensions
+from libertem.io.dataset.base import (
+    FileTree, Partition3D, _roi_to_nd_indices
+)
 from libertem.common import Shape, Slice
 from libertem.io.dataset.memory import MemoryDataSet
 
@@ -119,3 +122,11 @@ def test_roi_to_nd_indices():
         (2, 1), (2, 2), (2, 3),
                 (3, 2)
     ]
+
+
+def test_get_extensions():
+    exts = get_extensions()
+    assert len(exts) >= 15
+    assert "mib" in exts
+    assert "gtg" in exts
+    # etc...


### PR DESCRIPTION
Returns a set of supported file extensions for all datasets

## Contributor Checklist:

* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases