### PR TITLE
PickUDF now complains about all-zero ROI

### DIFF
--- a/src/libertem/udf/raw.py
+++ b/src/libertem/udf/raw.py
@@ -28,6 +28,8 @@ class PickUDF(UDF):
             navsize = np.count_nonzero(self.meta.roi)
         else:
             navsize = np.prod(self.meta.dataset_shape.nav)
+        if navsize == 0:
+            raise ValueError("cannot load data with all-zeros ROI")
         warn_limit = 2**28
         loaded_size = np.prod(sigshape) * navsize * np.dtype(dtype).itemsize
         if loaded_size > warn_limit:

--- a/tests/udf/test_pick.py
+++ b/tests/udf/test_pick.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 
 from libertem.udf.raw import PickUDF
@@ -17,3 +18,16 @@ def test_pick(lt_ctx):
 
     assert np.allclose(data[roi], res['intensity'].data)
     assert data.dtype == res['intensity'].data.dtype
+
+
+def test_pick_zero_roi(lt_ctx):
+    data = _mk_random(size=(16, 16, 16, 16), dtype="float32")
+    dataset = MemoryDataSet(data=data, tileshape=(3, 7, 7),
+                            num_partitions=7, sig_dims=2)
+    roi = np.zeros(dataset.shape.nav, dtype=bool)
+
+    udf = PickUDF()
+    with pytest.raises(ValueError) as e:
+        res = lt_ctx.run_udf(dataset=dataset, udf=udf, roi=roi)
+
+    assert e.match("cannot load data with all-zeros ROI")


### PR DESCRIPTION
Previously the internals complained about a weird `extra_shape` of the result buffer.

Fixes #609

## Contributor Checklist:

* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases