### PR TITLE
Cleanup for changelog items

### DIFF
--- a/docs/source/changelog/bugfix/hdf5_full_frame_auto_tileshape.rst
+++ b/docs/source/changelog/bugfix/hdf5_full_frame_auto_tileshape.rst
@@ -1,4 +1,0 @@
-[Bugfix] Fix HDF5 with automatic tileshape 
-==========================================
-
- * Fix type confusion error: tuple vs :code:`Shape` (:pr:`608`)

--- a/docs/source/changelog/bugfix/hdf5_roi_fix.rst
+++ b/docs/source/changelog/bugfix/hdf5_roi_fix.rst
@@ -1,4 +1,0 @@
-[Bugfix] Fix reading from HDF5 with roi
-=======================================
-
-* Offset calculation for tiles was wrong beyond the first partition (:pr:`606`)

--- a/docs/source/changelog/features/get_extensions.rst
+++ b/docs/source/changelog/features/get_extensions.rst
@@ -1,4 +1,4 @@
-[Feature] `:code:`libertem.io.dataset.get_extensions`
-=====================================================
+[Feature] :code:`libertem.io.dataset.get_extensions`
+====================================================
 
 * Returns a set of supported file extensions for all datasets


### PR DESCRIPTION
 * Remove items that were released as part of v0.4.1
 * Fix typo/syntax error in headline of get_extensions.rst

## Contributor Checklist:

* [x] I have added/updated documentation for all user-facing changes