### PR TITLE
Add `filetype=auto` to `Context.load`

### DIFF
--- a/docs/source/changelog/features/filetype_auto.rst
+++ b/docs/source/changelog/features/filetype_auto.rst
@@ -1,0 +1,5 @@
+[Feature] :code:`filetype="auto"` for Context.load
+==================================================
+
+* :meth:`libertem.api.Context.load` now automatically detects file
+  type and parameters if :code:`filetype="auto"` is passed (:pr:`621`)

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -26,6 +26,13 @@ pattern is:
 So, you need to specify the data set type, the path, and dataset-specific
 arguments. These arguments are documented below.
 
+For most file types, it is possible to automatically detect the type and
+parameters, which you can trigger by using :code:`"auto"` as file type:
+
+.. code-block:: python
+
+   ctx.load("auto", path="/path/to/some/file")
+
 For the full list of supported file formats with links to their reference
 documentation, see :ref:`supported formats` below.
 

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -3,7 +3,7 @@ from typing import Union, Tuple
 
 import psutil
 import numpy as np
-from libertem.io.dataset import load, filetypes, detect
+from libertem.io.dataset import load, filetypes
 from libertem.io.dataset.base import DataSet
 from libertem.job.masks import ApplyMasksJob
 from libertem.job.raw import PickFrameJob

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -3,7 +3,7 @@ from typing import Union, Tuple
 
 import psutil
 import numpy as np
-from libertem.io.dataset import load, filetypes
+from libertem.io.dataset import load, filetypes, detect
 from libertem.io.dataset.base import DataSet
 from libertem.job.masks import ApplyMasksJob
 from libertem.job.raw import PickFrameJob
@@ -90,6 +90,37 @@ class Context:
         return load(filetype, executor=self.executor, *args, **kwargs)
 
     load.__doc__ = load.__doc__ % {"types": ", ".join(filetypes.keys())}
+
+    def dataset_info(self, path: str):
+        """
+        Try to detect the dataset at `path` and return some
+        diagnostics about it.
+
+        Note
+        ----
+        The information in the `diags` key is subject to change!
+
+        Parameters
+        ----------
+
+        path
+            Path to a file of the dataset you are interested in
+
+        Returns
+        -------
+        dict
+            Dictionary with keys `type`, `params` and `diags`.
+        """
+        params = detect(path, executor=self.executor)
+        ftype = params.pop('type', None)
+        if ftype is None:
+            return
+        ds = self.load(ftype, **params)
+        return {
+            'type': ftype,
+            'params': params,
+            'diags': ds.get_diagnostics(),
+        }
 
     def create_mask_job(self, factories, dataset, use_sparse=None,
                         mask_count=None, mask_dtype=None, dtype=None):

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -62,10 +62,13 @@ class Context:
         you can load and process datasets that are bigger than your available RAM.
         Using fast storage (i.e. SSD) is advisable.
 
+        .. versionchanged:: 0.5.0.dev0
+            Added support for filetype="auto"
+
         Parameters
         ----------
         filetype : str
-            one of: %(types)s
+            one of: %(types)s or auto to automatically determine filetype and parameters
         args
             passed on to the DataSet implementation
         kwargs
@@ -90,37 +93,6 @@ class Context:
         return load(filetype, executor=self.executor, *args, **kwargs)
 
     load.__doc__ = load.__doc__ % {"types": ", ".join(filetypes.keys())}
-
-    def dataset_info(self, path: str):
-        """
-        Try to detect the dataset at `path` and return some
-        diagnostics about it.
-
-        Note
-        ----
-        The information in the `diags` key is subject to change!
-
-        Parameters
-        ----------
-
-        path
-            Path to a file of the dataset you are interested in
-
-        Returns
-        -------
-        dict
-            Dictionary with keys `type`, `params` and `diags`.
-        """
-        params = detect(path, executor=self.executor)
-        ftype = params.pop('type', None)
-        if ftype is None:
-            return
-        ds = self.load(ftype, **params)
-        return {
-            'type': ftype,
-            'params': params,
-            'diags': ds.get_diagnostics(),
-        }
 
     def create_mask_job(self, factories, dataset, use_sparse=None,
                         mask_count=None, mask_dtype=None, dtype=None):

--- a/src/libertem/io/dataset/__init__.py
+++ b/src/libertem/io/dataset/__init__.py
@@ -19,6 +19,21 @@ filetypes = {
 }
 
 
+def _auto_load(path, executor):
+    if path is None:
+        raise DataSetException(
+            "please specify the `path` kwarg to allow auto detection"
+        )
+
+    params = detect(path, executor=executor)
+    filetype_detected = params.pop('type', None)
+    if filetype_detected is None:
+        raise DataSetException(
+            "could not determine DataSet type for file '%s'" % path,
+        )
+    return load(filetype_detected, executor=executor, **params)
+
+
 def load(filetype, executor, enable_async=False, *args, **kwargs):
     """
     Low-level method to load a dataset. Usually you will want
@@ -33,6 +48,9 @@ def load(filetype, executor, enable_async=False, *args, **kwargs):
 
     additional parameters are passed to the concrete DataSet implementation
     """
+    if filetype == "auto":
+        return _auto_load(kwargs.get('path'), executor)
+
     cls = get_dataset_cls(filetype)
 
     async def _init_async():

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -210,7 +210,9 @@ class H5DataSet(DataSet):
                     {"name": "Shape", "value": str(shape)},
                     {"name": "Datatype", "value": str(dtype)},
                 ]}
-                for name, size, shape, dtype in sorted(datasets, key=lambda i: i[0])
+                for name, size, shape, dtype in sorted(
+                    datasets, key=lambda i: i[1], reverse=True
+                )
             ]
             return [
                 {"name": "dtype", "value": str(ds.dtype)},

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import numpy as np
 import pytest
 
+from libertem.io.dataset.base import DataSetException
 from libertem.io.dataset import get_extensions
 from libertem.io.dataset.base import (
     FileTree, Partition3D, _roi_to_nd_indices
@@ -130,3 +131,19 @@ def test_get_extensions():
     assert "mib" in exts
     assert "gtg" in exts
     # etc...
+
+
+def test_filetype_auto(hdf5, lt_ctx):
+    ds = lt_ctx.load("auto", path=hdf5.filename)
+    assert ds.ds_path == "data"
+
+def test_filetype_auto_fail_no_path(lt_ctx):
+    with pytest.raises(DataSetException) as e:
+        ds = lt_ctx.load("auto")
+    assert e.match("please specify the `path` kwarg to allow auto detection")
+
+
+def test_filetype_auto_fail_file_does_not_exist(lt_ctx):
+    with pytest.raises(DataSetException) as e:
+        ds = lt_ctx.load("auto", path="/does/not/exist/believe_me")
+    assert e.match("could not determine DataSet type for file")


### PR DESCRIPTION
This adds a new method `dataset_info` to our `Context` class, which detects the dataset type and returns some information about it (same as is available via the web GUI). This is for example useful if you are opening an HDF5 file and don't know which `ds_path` to choose.

Would love to get some feedback on this!

Also contains a little fix to sort HDF5 data sets in the diagnostics by size, as that is often the most useful when trying to decide what `ds_path` to open.

If this is useful, I'll add ~tests~, documentation and changelog entry!

Closes: #616 

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases