### PR TITLE
RFC: call preprocess on master node, too

### DIFF
--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -177,6 +177,9 @@ class BufferWrapper(object):
         """
         return partition.slice.adjust_for_roi(self._roi)
 
+    def get_view_for_dataset(self, dataset):
+        return self._data
+
     def get_view_for_partition(self, partition):
         """
         get a view for a single partition in a whole-result-sized buffer
@@ -278,6 +281,9 @@ class AuxBufferWrapper(BufferWrapper):
         assert np.product(new_data.shape) > 0
         assert not buf._data_coords_global
         return buf
+
+    def get_view_for_dataset(self, dataset):
+        return self._data[self._roi]
 
     def set_buffer(self, buf, is_global=True):
         """


### PR DESCRIPTION
Use case: initialization to enable simplifications of the merge
function, in case of a non-zero "neutral element."

Also clean up code duplication between `run_for_dataset{,_async}`

@uellue does this fix your issue?

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases