### PR TITLE
Tiled StdDevUDF

### DIFF
--- a/docs/source/changelog/features/preprocess.rst
+++ b/docs/source/changelog/features/preprocess.rst
@@ -1,0 +1,8 @@
+[Feature] :code:`preprocess()` and AUX data
+===========================================
+
+* Run :meth:`~libertem.udf.base.UDFPreprocessMixin.preprocess` before merge on
+  the master node to allocate or initialize buffers (:pr:`624`).
+* Set correct view of AUX data during
+  :meth:`~libertem.udf.base.UDFPreprocessMixin.preprocess` on the control node
+  (:pr:`624`)

--- a/docs/source/changelog/features/stddev.rst
+++ b/docs/source/changelog/features/stddev.rst
@@ -1,0 +1,4 @@
+[Feature] :code:`StdDevUDF` speed-up
+====================================
+
+* More than 2x speed-up of standard deviation calculation with tiled processing (:pr:`625`)

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -147,6 +147,11 @@ by the ROI.
 
 .. versionadded:: 0.3.0
 
+.. versionchanged:: 0.5.0.dev0
+    :meth:`libertem.udf.UDFPreprocessMixin.preprocess` is executed on the master
+    node, too. Views for aux data are set correctly on the master node. Previously,
+    it was only executed on the worker nodes.
+
 Partition processing
 --------------------
 

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -137,9 +137,11 @@ Pre-processing
 ---------------
 
 Pre-processing allows to initialize result buffers by implementing
-:meth:`libertem.udf.UDFPreprocessMixin.preprocess`. This method is executed after all
-buffers are allocated, but before the partition data is processed, with views set for
-the whole partition masked by the current ROI. This is particularly useful to set up
+:meth:`libertem.udf.UDFPreprocessMixin.preprocess`. This method is executed
+after all buffers are allocated, but before the data is processed. On the worker
+nodes it is executed with views set for the whole partition masked by the
+current ROI. On the central node it is executed with views set for the whole
+result masked by the ROI. This is particularly useful to set up
 :code:`dtype=object` buffers, for example ragged arrays.
 
 .. versionadded:: 0.3.0

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -136,13 +136,14 @@ buffers:
 Pre-processing
 ---------------
 
-Pre-processing allows to initialize result buffers by implementing
-:meth:`libertem.udf.UDFPreprocessMixin.preprocess`. This method is executed
-after all buffers are allocated, but before the data is processed. On the worker
-nodes it is executed with views set for the whole partition masked by the
-current ROI. On the central node it is executed with views set for the whole
-result masked by the ROI. This is particularly useful to set up
-:code:`dtype=object` buffers, for example ragged arrays.
+Pre-processing allows to initialize result buffers before processing or merging.
+This is particularly useful to set up :code:`dtype=object` buffers, for example
+ragged arrays, or to initialize buffers for operations where the neutral element
+is not 0. :meth:`libertem.udf.UDFPreprocessMixin.preprocess` is executed after
+all buffers are allocated, but before the data is processed. On the worker nodes
+it is executed with views set for the whole partition masked by the current ROI.
+On the central node it is executed with views set for the whole dataset masked
+by the ROI. 
 
 .. versionadded:: 0.3.0
 

--- a/src/libertem/analysis/clust.py
+++ b/src/libertem/analysis/clust.py
@@ -4,7 +4,7 @@ from libertem.utils.async_utils import run_blocking
 from libertem.executor.base import JobCancelledError
 import libertem.udf.feature_vector_maker as feature
 from libertem.udf.base import UDFRunner
-from libertem.udf.stddev import StdDevUDF
+from libertem.udf.stddev import StdDevUDF, consolidate_result
 from libertem import masks
 from sklearn.cluster import AgglomerativeClustering
 import numpy as np
@@ -68,15 +68,7 @@ class ClusterAnalysis(BaseAnalysis):
         if job_is_cancelled():
             raise JobCancelledError()
 
-        sd_udf_results['var'].data
-        sd_udf_results['num_frame'].data
-
-        sd_udf_results = dict(sd_udf_results.items())
-        sd_udf_results['var'] = sd_udf_results['var'].data/sd_udf_results['num_frame'].data
-        sd_udf_results['std'] = np.sqrt(sd_udf_results['var'].data)
-        sd_udf_results['mean'] = sd_udf_results['sum_frame'].data/sd_udf_results['num_frame'].data
-        sd_udf_results['num_frame'] = sd_udf_results['num_frame'].data
-        sd_udf_results['sum_frame'] = sd_udf_results['sum_frame'].data
+        sd_udf_results = consolidate_result(sd_udf_results)
 
         center = (self.parameters["cy"], self.parameters["cx"])
         rad_in = self.parameters["ri"]

--- a/tests/udf/test_stddev.py
+++ b/tests/udf/test_stddev.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 
 from libertem.udf.stddev import run_stddev
@@ -6,7 +7,10 @@ from libertem.io.dataset.memory import MemoryDataSet
 from utils import _mk_random
 
 
-def test_stddev(lt_ctx):
+@pytest.mark.parametrize(
+    "use_roi", [True, False]
+)
+def test_stddev(lt_ctx, use_roi):
     """
     Test variance, standard deviation, sum of frames, and mean computation
     implemented in udf/stddev.py
@@ -16,13 +20,17 @@ def test_stddev(lt_ctx):
     lt_ctx
         Context class for loading dataset and creating jobs on them
     """
-    data = _mk_random(size=(16, 16, 16, 16), dtype="float32")
+    data = _mk_random(size=(16, 17, 18, 19), dtype="float32")
     # FIXME the tiling in signal dimension can only be tested once MemoryDataSet
     # actually supports it
     dataset = MemoryDataSet(data=data, tileshape=(3, 2, 16),
                             num_partitions=8, sig_dims=2)
-
-    res = run_stddev(lt_ctx, dataset)
+    if use_roi:
+        roi = np.random.choice([True, False], size=dataset.shape.nav)
+        res = run_stddev(lt_ctx, dataset, roi=roi)
+    else:
+        roi = np.ones(dataset.shape.nav, dtype=bool)
+        res = run_stddev(lt_ctx, dataset)
 
     assert 'sum_frame' in res
     assert 'num_frame' in res
@@ -30,15 +38,15 @@ def test_stddev(lt_ctx):
     assert 'mean' in res
     assert 'std' in res
 
-    N = data.shape[2] * data.shape[3]
+    N = np.count_nonzero(roi)
     assert res['num_frame'] == N  # check the total number of frames
 
-    assert np.allclose(res['sum_frame'], np.sum(data, axis=(0, 1)))  # check sum of frames
+    assert np.allclose(res['sum_frame'], np.sum(data[roi], axis=0))  # check sum of frames
 
-    assert np.allclose(res['mean'], np.mean(data, axis=(0, 1)))  # check mean
+    assert np.allclose(res['mean'], np.mean(data[roi], axis=0))  # check mean
 
-    var = np.var(data, axis=(0, 1))
+    var = np.var(data[roi], axis=0)
     assert np.allclose(var, res['var'])  # check variance
 
-    std = np.std(data, axis=(0, 1))
+    std = np.std(data[roi], axis=0)
     assert np.allclose(std, res['std'])  # check standard deviation

--- a/tests/udf/test_stddev.py
+++ b/tests/udf/test_stddev.py
@@ -17,8 +17,10 @@ def test_stddev(lt_ctx):
         Context class for loading dataset and creating jobs on them
     """
     data = _mk_random(size=(16, 16, 16, 16), dtype="float32")
-    dataset = MemoryDataSet(data=data, tileshape=(1, 16, 16),
-                            num_partitions=2, sig_dims=2)
+    # FIXME the tiling in signal dimension can only be tested once MemoryDataSet
+    # actually supports it
+    dataset = MemoryDataSet(data=data, tileshape=(3, 2, 16),
+                            num_partitions=8, sig_dims=2)
 
     res = run_stddev(lt_ctx, dataset)
 


### PR DESCRIPTION
* Documentation and changelog for #624
* More than 2x speed-up of StdDevUDF  in tests

The computation can likely be accelerated further with a cache-optimized Numba implementation of combined variance and sum:

```
Timer unit: 1e-07 s

Total time: 0.397086 s
File: c:\users\weber\documents\libertem\libertem\src\libertem\udf\stddev.py
Function: merge at line 11

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    11                                           def merge(p0, p1):
    12                                               """
    13                                               Given two sets of partitions, with sum of frames
    14                                               and sum of variances, compute joint sum of frames
    15                                               and sum of variances using one pass algorithm
    16                                           
    17                                               Parameters
    18                                               ----------
    19                                               p0
    20                                                   Contains information about the first partition, including
    21                                                   sum of variances, sum of pixels, and number of frames used
    22                                           
    23                                               p1
    24                                                   Contains information about the second partition, including
    25                                                   sum of variances, sum of pixels, and number of frames used
    26                                           
    27                                               Returns
    28                                               -------
    29                                               VariancePart
    30                                                   colletions.namedtuple object that contains information about
    31                                                   the merged partitions, including sum of variances,
    32                                                   sum of pixels, and number of frames used
    33                                               """
    34      1363      37788.0     27.7      1.0      if p0.N == 0:
    35         2         23.0     11.5      0.0          return p1
    36      1361      28691.0     21.1      0.7      N = p0.N + p1.N
    37                                           
    38                                               # compute mean for each partitions
    39      1361     491589.0    361.2     12.4      mean_A = (p0.sum_im / p0.N)
    40      1361     432568.0    317.8     10.9      mean_B = (p1.sum_im / p1.N)
    41                                           
    42                                               # compute mean for joint samples
    43      1361     324747.0    238.6      8.2      delta = mean_B - mean_A
    44      1361     913165.0    671.0     23.0      mean = mean_A + (p1.N * delta) / (p0.N + p1.N)
    45                                           
    46                                               # compute sum of images for joint samples
    47      1361     286967.0    210.9      7.2      sum_im_AB = p0.sum_im + p1.sum_im
    48                                           
    49                                               # compute sum of variances for joint samples
    50      1361     290469.0    213.4      7.3      delta_P = mean_B - mean
    51      1361    1073569.0    788.8     27.0      var_AB = p0.var + p1.var + (p1.N * delta * delta_P)
    52                                           
    53      1361      91281.0     67.1      2.3      return VariancePart(var=var_AB, sum_im=sum_im_AB, N=N)

Total time: 0.0001785 s
File: c:\users\weber\documents\libertem\libertem\src\libertem\udf\stddev.py
Function: merge at line 116

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   116                                               def merge(self, dest, src):
   117                                                   """
   118                                                   Given two buffers that contain sum of variances, sum of frames,
   119                                                   and the number of frames used in each of the partitions, merge the
   120                                                   partitions and compute the joint sum of variances and sum of frames
   121                                                   over all frames used
   122                                           
   123                                                   Parameters
   124                                                   ----------
   125                                                   dest
   126                                                       Partial results that contains sum of variances, sum of frames, and the
   127                                                       number of frames used over all the frames used
   128                                           
   129                                                   src
   130                                                       Partial results that contains sum of variances, sum of frames, and the
   131                                                       number of frames used over current iteration of partition
   132                                                   """
   133         1         89.0     89.0      5.0          N0 = _validate_n(dest['num_frame'][0])
   134         1        800.0    800.0     44.8          N1 = _validate_n(src['num_frame'][0])
   135         1         33.0     33.0      1.8          p0 = VariancePart(var=dest['var'][:],
   136         1         14.0     14.0      0.8                          sum_im=dest['sum_frame'][:],
   137         1         66.0     66.0      3.7                          N=N0)
   138         1         14.0     14.0      0.8          p1 = VariancePart(var=src['var'][:],
   139         1         15.0     15.0      0.8                          sum_im=src['sum_frame'][:],
   140         1         27.0     27.0      1.5                          N=N1)
   141         1         91.0     91.0      5.1          compute_merge = merge(p0, p1)
   142                                           
   143         1        264.0    264.0     14.8          dest['var'][:] = compute_merge.var
   144         1        221.0    221.0     12.4          dest['sum_frame'][:] = compute_merge.sum_im
   145         2         40.0     20.0      2.2          for key in src['num_frame'][0]:
   146         1        111.0    111.0      6.2              dest['num_frame'][0][key] = compute_merge.N

Total time: 1.8721 s
File: c:\users\weber\documents\libertem\libertem\src\libertem\udf\stddev.py
Function: process_tile at line 148

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   148                                               def process_tile(self, tile):
   149                                                   """
   150                                                   Given a frame, update sum of variances, sum of frames,
   151                                                   and the number of total frames
   152                                           
   153                                                   Parameters
   154                                                   ----------
   155                                                   tile
   156                                                       tile of the data
   157                                                   """
   158                                           
   159      1362    1068279.0    784.3      5.7          key = self.meta.slice.discard_nav()
   160                                           
   161      1362     495944.0    364.1      2.6          if key not in self.results.num_frame[0]:
   162         1        200.0    200.0      0.0              self.results.num_frame[0][key] = 0
   163                                           
   164      1362    2045527.0   1501.9     10.9          tile_sum = tile.sum(axis=0)
   165                                           
   166      1362      32599.0     23.9      0.2          p0 = VariancePart(
   167      1362     163854.0    120.3      0.9              var=self.results.var,
   168      1362      90900.0     66.7      0.5              sum_im=self.results.sum_frame,
   169      1362     429694.0    315.5      2.3              N=self.results.num_frame[0][key]
   170                                                   )
   171      1362      22723.0     16.7      0.1          p1 = VariancePart(
   172                                                       # We doctor ddof to ensure the sum of variances is divided by one.
   173                                                       # That way we avoid multiplying by N again for this algorithm
   174      1362    8720328.0   6402.6     46.6              var=np.var(tile, axis=0, ddof=tile.shape[0]-1),
   175      1362      35048.0     25.7      0.2              sum_im=tile_sum,
   176      1362     104123.0     76.4      0.6              N=tile.shape[0]
   177                                                   )
   178      1362    4265962.0   3132.1     22.8          compute_merge = merge(p0, p1)
   179                                           
   180      1362     457712.0    336.1      2.4          self.results.var[:] = compute_merge.var
   181                                           
   182      1362     287602.0    211.2      1.5          self.results.sum_frame[:] = compute_merge.sum_im
   183      1362     500486.0    367.5      2.7          self.results.num_frame[0][key] = compute_merge.N
```

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
