### PR TITLE
Numba-based StdDevUDF

### DIFF
--- a/docs/source/app/amorphous.rst
+++ b/docs/source/app/amorphous.rst
@@ -21,7 +21,7 @@ volume of beam and sample will lead to increased "speckle", i.e. intensity
 fluctuations within this ring, since regions with local ordering will diffract
 the beam to preferred directions similar to a crystal. For Fluctuation EM
 :cite:`Gibson1997`, the standard deviation within this ring is calculated to
-obtain a measure of this local ordering.
+obtain a measure of this local ordering. :cite:`Schubert2018`
 
 GUI use
 -------

--- a/docs/source/app/amorphous.rst
+++ b/docs/source/app/amorphous.rst
@@ -21,7 +21,7 @@ volume of beam and sample will lead to increased "speckle", i.e. intensity
 fluctuations within this ring, since regions with local ordering will diffract
 the beam to preferred directions similar to a crystal. For Fluctuation EM
 :cite:`Gibson1997`, the standard deviation within this ring is calculated to
-obtain a measure of this local ordering. :cite:`Schubert2018`
+obtain a measure of this local ordering.
 
 GUI use
 -------

--- a/docs/source/changelog/features/stddev.rst
+++ b/docs/source/changelog/features/stddev.rst
@@ -1,4 +1,4 @@
 [Feature] :code:`StdDevUDF` speed-up
 ====================================
 
-* More than 2x speed-up of standard deviation calculation with tiled processing (:pr:`625`)
+* About 10x speed-up of standard deviation calculation for large frames (:pr:`625,640`)

--- a/docs/source/changelog/misc/stddev.rst
+++ b/docs/source/changelog/misc/stddev.rst
@@ -1,5 +1,11 @@
 [Misc] Rename result buffers of StdDevUDF
 =========================================
 
-* Rename result buffers of :class:`~libertem.udf.stddev.StdDevUDF`
-  from :code:`'sum_frame'` to :code:`'sum'`, :code:`'num_frame'` to :code:`'num_frames'` (:pr:`640`)
+* Rename result buffers of :class:`~libertem.udf.stddev.StdDevUDF`,
+  :meth:`~libertem.udf.stddev.run_stddev` and
+  :meth:`~libertem.udf.stddev.consolidate_result` from :code:`'sum_frame'` to
+  :code:`'sum'`, :code:`'num_frame'` to :code:`'num_frames'` (:pr:`640`)
+* Resolve ambiguity between variance and sum of variances in result buffer names of
+  :class:`~libertem.udf.stddev.StdDevUDF`,
+  :meth:`~libertem.udf.stddev.run_stddev` and
+  :meth:`~libertem.udf.stddev.consolidate_result`. (:pr:`640`)

--- a/docs/source/changelog/misc/stddev.rst
+++ b/docs/source/changelog/misc/stddev.rst
@@ -1,0 +1,5 @@
+[Misc] Rename result buffers of StdDevUDF
+=========================================
+
+* Rename result buffers of :class:`~libertem.udf.stddev.StdDevUDF`
+  from :code:`'sum_frame'` to :code:`'sum'`, :code:`'num_frame'` to :code:`'num_frames'` (:pr:`640`)

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -4,7 +4,7 @@ Citing
 To help us spread the word, please credit and cite LiberTEM in publications where it has been significant. 
 Resources for citing LiberTEM are linked through the DOI badge below.
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1478763.svg
-   :target: https://doi.org/10.5281/zenodo.1478763
+.. |zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1477847.svg
+.. _zenodo: https://doi.org/10.5281/zenodo.1477847
 
 Please refer to our :ref:`authorship` for details regarding authorship and credit for contributors.

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -62,7 +62,7 @@ Some generally useful UDFs are included with LiberTEM:
 
 .. _`stddev udf`:
 
-Single-pass standard deviation based on :cite:`Schubert2018`.
+Single-pass standard deviation based on Schubert2018.
 
 .. autoclass:: libertem.udf.stddev.StdDevUDF
     :members:

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -62,8 +62,6 @@ Some generally useful UDFs are included with LiberTEM:
 
 .. _`stddev udf`:
 
-Single-pass standard deviation based on :cite:`Schubert2018`.
-
 .. autoclass:: libertem.udf.stddev.StdDevUDF
     :members:
     :special-members: __init__

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -50,11 +50,17 @@ Some generally useful UDFs are included with LiberTEM:
 
 .. _`sum udf`:
 
+Sum of frames
+#############
+
 .. autoclass:: libertem.udf.sum.SumUDF
     :members:
     :special-members: __init__
 
 .. _`logsum udf`:
+
+Sum of log-scaled frames
+########################
 
 .. autoclass:: libertem.udf.logsum.LogsumUDF
     :members:
@@ -62,11 +68,21 @@ Some generally useful UDFs are included with LiberTEM:
 
 .. _`stddev udf`:
 
+Standard deviation
+##################
+
 .. autoclass:: libertem.udf.stddev.StdDevUDF
     :members:
     :special-members: __init__
 
+.. autofunction:: libertem.udf.stddev.run_stddev
+
+.. autofunction:: libertem.udf.stddev.consolidate_result
+
 .. _`sumsig udf`:
+
+Sum per frame
+#############
 
 .. autoclass:: libertem.udf.sumsigudf.SumSigUDF
     :members:
@@ -74,11 +90,17 @@ Some generally useful UDFs are included with LiberTEM:
 
 .. _`masks udf`:
 
+Apply masks
+###########
+
 .. autoclass:: libertem.udf.masks.ApplyMasksUDF
     :members:
     :special-members: __init__
 
 .. _`pick udf`:
+
+Load data
+#########
 
 .. autoclass:: libertem.udf.raw.PickUDF
     :members:

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -62,7 +62,7 @@ Some generally useful UDFs are included with LiberTEM:
 
 .. _`stddev udf`:
 
-Single-pass standard deviation based on Schubert2018.
+Single-pass standard deviation based on :cite:`Schubert2018`.
 
 .. autoclass:: libertem.udf.stddev.StdDevUDF
     :members:

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -62,6 +62,8 @@ Some generally useful UDFs are included with LiberTEM:
 
 .. _`stddev udf`:
 
+Single-pass standard deviation based on :cite:`Schubert2018`.
+
 .. autoclass:: libertem.udf.stddev.StdDevUDF
     :members:
     :special-members: __init__

--- a/docs/source/references-libertem.bib
+++ b/docs/source/references-libertem.bib
@@ -1117,4 +1117,14 @@
 	pages = {016102},
 	file = {Electron holography—basics and applications - IOPscience:/Users/migunov/Zotero/storage/7C3UUE82/meta\;jsessionid=3F5DA019F9A86C312BFD8889CFC17030.c2.iopscience.cld.iop.html:text/html;Lichte_H,Lehmann_M-E-holog-basics&app(2008).pdf:/Users/migunov/Zotero/storage/WRB52ACC/Lichte_H,Lehmann_M-E-holog-basics&app(2008).pdf:application/pdf}
 }
+
+@InProceedings{Schubert2018,
+  author    = {Erich Schubert and Michael Gertz},
+  title     = {Numerically stable parallel computation of (co-)variance},
+  booktitle = {Proceedings of the 30th International Conference on Scientific and Statistical Database Management - {SSDBM} {\textquotesingle}18},
+  year      = {2018},
+  publisher = {{ACM} Press},
+  doi       = {10.1145/3221269.3223036},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/source/references-libertem.bib
+++ b/docs/source/references-libertem.bib
@@ -1121,7 +1121,7 @@
 @InProceedings{Schubert2018,
   author    = {Erich Schubert and Michael Gertz},
   title     = {Numerically stable parallel computation of (co-)variance},
-  booktitle = {Proceedings of the 30th International Conference on Scientific and Statistical Database Management - {SSDBM} {\textquotesingle}18},
+  booktitle = {Proceedings of the 30th International Conference on Scientific and Statistical Database Management - {SSDBM} 18},
   year      = {2018},
   publisher = {{ACM} Press},
   doi       = {10.1145/3221269.3223036},

--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -446,6 +446,9 @@ the :code:`.data` attribute, or by calling :meth:`numpy.array`:
 
 .. _`udf roi`:
 
+Regions of interest
+-------------------
+
 In addition, you can pass the :code:`roi` (region of interest) parameter, to
 run your UDF on a selected subset of data. :code:`roi` should be a NumPy array
 containing a bool mask, having the shape of the navigation axes of the dataset.

--- a/setup.py
+++ b/setup.py
@@ -144,9 +144,8 @@ setup(
         "pillow",
         "h5py",
         "psutil",
-        # Pinned due to https://github.com/pydata/sparse/issues/257
-        # Ensure compatibility with numpy 1.17
-        "numba>=0.46",
+        # Bounds checking in Numba
+        "numba>=0.47",
         "ncempy>=1.4",
         'pywin32!=226;platform_system=="Windows"',
         # FIXME pull request #259

--- a/src/libertem/analysis/sd.py
+++ b/src/libertem/analysis/sd.py
@@ -14,6 +14,7 @@ class SDAnalysis(BaseAnalysis):
         return get_roi(params=self.parameters, shape=self.dataset.shape.nav)
 
     def get_udf_results(self, udf_results, roi):
+        udf_results = std.consolidate_result(udf_results)
         return AnalysisResultSet([
             AnalysisResult(raw_data=udf_results['var'].data,
                            visualized=visualize_simple(

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -1,118 +1,115 @@
-import collections
-
 import numpy as np
 import numba
 
 from libertem.udf import UDF
 
 
-VariancePart = collections.namedtuple('VariancePart', ['var', 'sum_im', 'N'])
+@numba.njit(fastmath=True)
+def _merge(N, N0, sum_im0, var0, N1, sum_im1, var1):
+    '''
+    Basic function to perform numerically stable merge :cite:`Schubert2018`
+    '''
+    # compute mean for each partitions
+    mean_A = sum_im0 / N0
+    mean_B = sum_im1 / N1
+
+    # compute mean for joint samples
+    delta = mean_B - mean_A
+    mean = mean_A + (N1 * delta) / N
+
+    # compute sum of images for joint samples
+    sum_im_AB = sum_im0 + sum_im1
+
+    # compute sum of variances for joint samples
+    delta_P = mean_B - mean
+    var_AB = var0 + var1 + (N1 * delta * delta_P)
+    return sum_im_AB, var_AB
 
 
-@numba.njit
-def merge(N0, sum_im0, var0, N1, sum_im1, var1):
+@numba.njit(fastmath=True)
+def merge(dest_N, dest_sum, dest_varsum, src_N, src_sum, src_varsum):
     """
     Given two sets of partitions, with sum of frames
-    and sum of variances, compute joint sum of frames
-    and sum of variances using one pass algorithm
+    and sum of variances, aggregate joint sum of frames
+    and sum of variances in destination partition using one pass
+    algorithm :cite:`Schubert2018`
 
     Parameters
     ----------
-    N0, sum_im0, var0
-        Contains information about the first partition:
-        Number of frames used, sum of pixels, sum of variances
+    dest_N : int
+        Number of frames aggregated in dest_sum and dest_varsum
+        The case :code:`dest_N == 0` is handled correctly.
+    dest_sum, dest_varsum
+        Aggregation buffers, will be updated: sum of pixels, sum of variances
+    src_N, src_sum, src_varsum
+        Information about the second partition
 
-    N1, sum_im1, var1
-        Contains information about the second partition:
-        
 
     Returns
     -------
-    N, sum_im, var:
-        Number of frames used, sum of pixels, sum of variances of the merged partitions
+    N:
+        New number of frames aggregated in aggregation buffer
     """
-    if N0 == 0:
-        return N1, sum_im1, var1
-    if N1 == 0:
-        return N0, sum_im0, var0
-    N = N0 + N1
+    if dest_N == 0:
+        dest_sum[:] = src_sum
+        dest_varsum[:] = src_varsum
+        return src_N
+    else:
+        N = dest_N + src_N
 
-    shape = sum_im0.shape
-
-    sum_im0_ = sum_im0.flatten()
-    sum_im1_ = sum_im1.flatten()
-    sum_im_AB = np.zeros_like(sum_im0_)
-    var0_ = var0.flatten()
-    var1_ = var1.flatten()
-    var_AB = np.zeros_like(var0_)
-
-    le = len(sum_im0_)
-    BLOCKSIZE = 16
-    n_blocks = le // BLOCKSIZE
-
-    def _merge(sum_im0, var0, sum_im1, var1):
-        # compute mean for each partitions
-        mean_A = sum_im0 / N0
-        mean_B = sum_im1 / N1
-
-        # compute mean for joint samples
-        delta = mean_B - mean_A
-        mean = mean_A + (N1 * delta) / N
-
-        # compute sum of images for joint samples
-        sum_im_AB = sum_im0 + sum_im1
-
-        # compute sum of variances for joint samples
-        delta_P = mean_B - mean
-        var_AB = var0 + var1 + (N1 * delta * delta_P)
-        return sum_im_AB, var_AB
-
-    for block in range(n_blocks):
-        for i in range(block*BLOCKSIZE, (block+1)*BLOCKSIZE):
-            sum_im_AB[i], var_AB[i] = _merge(
-                sum_im0_[i], var0_[i], sum_im1_[i], var1_[i]
+        le = len(dest_sum)
+        for i in range(le):
+            dest_sum[i], dest_varsum[i] = _merge(
+                N,
+                dest_N, dest_sum[i], dest_varsum[i],
+                src_N, src_sum[i], src_varsum[i]
             )
-    for i in range(n_blocks*BLOCKSIZE, le):
-        sum_im_AB[i], var_AB[i] = _merge(
-            sum_im0_[i], var0_[i], sum_im1_[i], var1_[i]
+    return N
+
+
+@numba.njit(fastmath=True)
+def process_tile(tile, N0, sum_inout, var_inout):
+    '''
+    Compute sum and variance of :code:`tile` along navigation axis
+    and merge into aggregation buffers. Numerical "workhorse" for
+    :meth:`StdDevUDF.process_tile`.
+
+    Parameters
+    ----------
+    tile : numpy.ndarray
+        Tile with flattened signal dimension
+    N0 : int
+        Number of frames already aggegated in partition buffer
+        Cannot be 0 -- the initial case is handled in :meth:`StdDevUDF.process_tile`
+        For unknown reasons, handling the case N0 == 0 in this function degraded performance
+        significantly. Re-check with a newer compiler version!
+    sum_inout, var_inout : numpy.ndarray
+        Aggregation buffers with flattened signal dimension. The tile
+        will be merged into these buffers (call by reference)
+
+    Returns
+    -------
+    N : int
+        New number of frames in aggregation buffer
+    '''
+    N1 = tile.shape[0]
+    le = tile.shape[1]
+    N = N0 + N1
+    for i in range(le):
+        s = 0
+        for j in range(N1):
+            s += tile[j, i]
+        mean = s / N1
+        varsum = 0
+        for j in range(N1):
+            varsum += (tile[j, i] - mean)**2
+
+        sum_inout[i], var_inout[i] = _merge(
+            N,
+            N0, sum_inout[i], var_inout[i],
+            N1, s, varsum
         )
-
-    return N, sum_im_AB.reshape(shape), var_AB.reshape(shape)
-
-
-@numba.njit
-def tile_sum_var(tile):
-    BLOCKSIZE = 16
-    shape = tile.shape[1:]
-    N = tile.shape[0]
-    # Flatten signal dimension
-    tile_ = tile.reshape((N, -1))
-    le = tile_.shape[1]
-    s = np.zeros(le, dtype=tile_.dtype)
-    v = np.zeros(le, dtype=tile_.dtype)
-
-    n_blocks = le // BLOCKSIZE
-
-    means = np.zeros(BLOCKSIZE, dtype=tile_.dtype)
-
-    for block in range(n_blocks):
-        offset = block*BLOCKSIZE
-        for j in range(N):
-            for i in range(offset, offset + BLOCKSIZE):
-                s[i] += tile_[j, i]
-        for i in range(BLOCKSIZE):
-            means[i] = s[i + offset] / N
-        for j in range(N):
-            for i in range(offset, offset + BLOCKSIZE):
-                v[i] += (tile_[j, i] - means[i - offset])**2
-    for i in range(n_blocks*BLOCKSIZE, le):
-        for j in range(N):
-            s[i] += tile_[j, i]
-        mean = s[i] / N
-        for j in range(N):
-            v[i] += (tile_[j, i] - mean)**2
-
-    return s.reshape(shape), v.reshape(shape)
+    return N
 
 
 # Helper function to make sure the frame count
@@ -130,9 +127,8 @@ class StdDevUDF(UDF):
     """
     Compute sum of variances and sum of pixels from the given dataset
 
-    One-pass algorithm used in this code is taken from the following paper:
-    "Numerically Stable Parallel Computation of (Co-) Variance"
-    DOI : https://doi.org/10.1145/3221269.3223036
+    The one-pass algorithm used in this code is taken from the following paper:
+    :cite:`Schubert2018`
 
     Examples
     --------
@@ -157,7 +153,7 @@ class StdDevUDF(UDF):
 
         Returns
         -------
-        A dictionary that maps 'var', 'std', 'mean', 'num_frame', 'sum_frame' to
+        A dictionary that maps 'var',  'num_frame', 'sum_frame' to
         the corresponding BufferWrapper objects
         """
         return {
@@ -192,20 +188,31 @@ class StdDevUDF(UDF):
             Partial results that contains sum of variances, sum of frames, and the
             number of frames used over current iteration of partition
         """
-        N0 = _validate_n(dest['num_frame'][0])
-        sum_im0 = dest['sum_frame'][:]
-        var0 = dest['var'][:]
+        dest_N = _validate_n(dest['num_frame'][0])
+        src_N = _validate_n(src['num_frame'][0])
 
-        N1 = _validate_n(src['num_frame'][0])
-        sum_im1 = src['sum_frame'][:]
-        var1 = src['var'][:]
+        oldshape = dest['sum_frame'][:].shape
 
-        N, sum_im, var = merge(N0, sum_im0, var0, N1, sum_im1, var1)
+        dest['sum_frame'][:].shape = (-1,)
+        dest['var'][:].shape = (-1, )
+        src['sum_frame'][:].shape = (-1,)
+        src['var'][:].shape = (-1, )
 
-        dest['var'][:] = var
-        dest['sum_frame'][:] = sum_im
+        N = merge(
+            dest_N=dest_N,
+            dest_sum=dest['sum_frame'][:],
+            dest_varsum=dest['var'][:],
+            src_N=src_N,
+            src_sum=src['sum_frame'][:],
+            src_varsum=src['var'][:],
+        )
         for key in src['num_frame'][0]:
             dest['num_frame'][0][key] = N
+
+        dest['sum_frame'][:].shape = oldshape
+        dest['var'][:].shape = oldshape
+        src['sum_frame'][:].shape = oldshape
+        src['var'][:].shape = oldshape
 
     def process_tile(self, tile):
         """
@@ -223,22 +230,30 @@ class StdDevUDF(UDF):
         if key not in self.results.num_frame[0]:
             self.results.num_frame[0][key] = 0
 
-        tile_sum, tile_var = tile_sum_var(tile)
-
         N0 = self.results.num_frame[0][key]
-        sum_im0 = self.results.sum_frame
-        var0 = self.results.var
-
         N1 = tile.shape[0]
-        sum_im1 = tile_sum
-        var1 = tile_var
 
-        N, sum_im, var = merge(N0, sum_im0, var0, N1, sum_im1, var1)
+        oldshape = self.results.sum_frame.shape
 
-        self.results.var[:] = var
+        tile.shape = (N1, -1)
 
-        self.results.sum_frame[:] = sum_im
-        self.results.num_frame[0][key] = N
+        self.results.sum_frame.shape = (-1, )
+        self.results.var.shape = (-1, )
+
+        if N0 == 0:
+            self.results.sum_frame[:] = tile.sum(axis=0)
+            self.results.var[:] = np.var(tile, axis=0, ddof=N1-1)
+            self.results.num_frame[0][key] = N1
+        else:
+            self.results.num_frame[0][key] = process_tile(
+                tile=tile,
+                N0=N0,
+                sum_inout=self.results.sum_frame,
+                var_inout=self.results.var
+            )
+        self.results.sum_frame.shape = oldshape
+        self.results.var.shape = oldshape
+        tile.shape = (N1, *oldshape)
 
 
 def consolidate_result(udf_result):

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -7,7 +7,7 @@ from libertem.udf import UDF
 @numba.njit(fastmath=True)
 def _merge(N, N0, sum_im0, var0, N1, sum_im1, var1):
     '''
-    Basic function to perform numerically stable merge :cite:`Schubert2018`
+    Basic function to perform numerically stable merge Schubert2018
     '''
     # compute mean for each partitions
     mean_A = sum_im0 / N0
@@ -32,7 +32,7 @@ def merge(dest_N, dest_sum, dest_varsum, src_N, src_sum, src_varsum):
     Given two sets of partitions, with sum of frames
     and sum of variances, aggregate joint sum of frames
     and sum of variances in destination partition using one pass
-    algorithm. :cite:`Schubert2018`
+    algorithm. Schubert2018
 
     Parameters
     ----------
@@ -128,7 +128,7 @@ class StdDevUDF(UDF):
     Compute sum of variances and sum of pixels from the given dataset
 
     The one-pass algorithm used in this code is taken from the following paper:
-    :cite:`Schubert2018`
+    Schubert2018
 
     Examples
     --------

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -6,8 +6,17 @@ from libertem.udf import UDF
 
 @numba.njit(fastmath=True)
 def _merge(N, N0, sum_im0, var0, N1, sum_im1, var1):
+    # FIXME manual citation due to issues in CI.
+    # Check if :cite:`Schubert2018` works in a future release
     '''
-    Basic function to perform numerically stable merge Schubert2018
+    Basic function to perform numerically stable merge
+
+    Erich Schubert and Michael Gertz. Numerically stable parallel computation of
+    (co-)variance. In `Proceedings of the 30th International Conference on
+    Scientific and Statistical Database Management - SSDBM 18`. ACM Press, 2018.
+    `doi:10.1145/3221269.3223036 <https://doi.org/10.1145/3221269.3223036>`_
+
+    cite:Schubert2018
     '''
     # compute mean for each partitions
     mean_A = sum_im0 / N0
@@ -28,11 +37,20 @@ def _merge(N, N0, sum_im0, var0, N1, sum_im1, var1):
 
 @numba.njit(fastmath=True)
 def merge(dest_N, dest_sum, dest_varsum, src_N, src_sum, src_varsum):
+    # FIXME manual citation due to issues in CI.
+    # Check if :cite:`Schubert2018` works in a future release
     """
     Given two sets of partitions, with sum of frames
     and sum of variances, aggregate joint sum of frames
     and sum of variances in destination partition using one pass
-    algorithm. Schubert2018
+    algorithm.
+
+    Erich Schubert and Michael Gertz. Numerically stable parallel computation of
+    (co-)variance. In `Proceedings of the 30th International Conference on
+    Scientific and Statistical Database Management - SSDBM 18`. ACM Press, 2018.
+    `doi:10.1145/3221269.3223036 <https://doi.org/10.1145/3221269.3223036>`_
+
+    cite:Schubert2018
 
     Parameters
     ----------
@@ -124,11 +142,19 @@ def _validate_n(num_frame):
 
 
 class StdDevUDF(UDF):
+    # FIXME manual citation due to issues in CI.
+    # Check if :cite:`Schubert2018` works in a future release
     """
     Compute sum of variances and sum of pixels from the given dataset
 
     The one-pass algorithm used in this code is taken from the following paper:
-    Schubert2018
+
+    Erich Schubert and Michael Gertz. Numerically stable parallel computation of
+    (co-)variance. In `Proceedings of the 30th International Conference on
+    Scientific and Statistical Database Management - SSDBM 18`. ACM Press, 2018.
+    `doi:10.1145/3221269.3223036 <https://doi.org/10.1145/3221269.3223036>`_
+
+    cite:Schubert2018
 
     Examples
     --------

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -32,7 +32,7 @@ def merge(dest_N, dest_sum, dest_varsum, src_N, src_sum, src_varsum):
     Given two sets of partitions, with sum of frames
     and sum of variances, aggregate joint sum of frames
     and sum of variances in destination partition using one pass
-    algorithm :cite:`Schubert2018`
+    algorithm. :cite:`Schubert2018`
 
     Parameters
     ----------

--- a/tests/udf/test_make_feature_vec.py
+++ b/tests/udf/test_make_feature_vec.py
@@ -19,16 +19,19 @@ def test_simple_example(lt_ctx):
     data[3:6, 2, 4] = 1
     dataset = MemoryDataSet(data=data, tileshape=(1, 5, 5),
                             num_partitions=3, sig_dims=2)
-    result, coordinates = feature.make_feature_vec(ctx=lt_ctx, dataset=dataset,
-    delta=0, n_peaks=5, min_dist=0)
+    result, coordinates = feature.make_feature_vec(
+        ctx=lt_ctx, dataset=dataset, delta=0, n_peaks=4, min_dist=0
+    )
+    print(result['feature_vec'].data)
+    print(coordinates)
     # check if values of feature vectors are zeros for amorphous frames
-    assert np.allclose(result['feature_vec'].data[6:9], np.zeros([3, 4]))
+    assert np.allclose(result['feature_vec'].data[6:9], 0)
     # check if all values of feature vectors are NOT zeros for strong crystalline frames
-    # (at least one peak is recognized)
-    assert (result['feature_vec'].data[0:3] > np.zeros([3, 4])).any()
+    # The strong peaks are listed first
+    assert np.all(result['feature_vec'].data[0:3, 0:2])
     # check if all values of feature vector are NOT zeros for weak crystalline frames
     # (at least one peak is recognized)
-    assert (result['feature_vec'].data[3:6] > np.zeros([3, 4])).any()
+    assert np.all(result['feature_vec'].data[3:6, 2:4])
     # check of feature vectors are NOT equal for strong crystalline frames
     #  than for weak crystalline frames
     # (because of non-zero order diffraction peaks are in different positions)

--- a/tests/udf/test_stddev.py
+++ b/tests/udf/test_stddev.py
@@ -22,10 +22,10 @@ def test_stddev(lt_ctx, use_roi):
     lt_ctx
         Context class for loading dataset and creating jobs on them
     """
-    data = _mk_random(size=(16, 17, 18, 19), dtype="float32")
+    data = _mk_random(size=(30, 2, 1025), dtype="float32")
     # FIXME the tiling in signal dimension can only be tested once MemoryDataSet
     # actually supports it
-    dataset = MemoryDataSet(data=data, tileshape=(3, 2, 16),
+    dataset = MemoryDataSet(data=data, tileshape=(3, 1, 1025),
                             num_partitions=8, sig_dims=2)
     if use_roi:
         roi = np.random.choice([True, False], size=dataset.shape.nav)

--- a/tests/udf/test_stddev.py
+++ b/tests/udf/test_stddev.py
@@ -1,12 +1,26 @@
 import pytest
 import numpy as np
 
-from libertem.udf.stddev import run_stddev
+from libertem.udf.stddev import run_stddev, tile_sum_var
 from libertem.io.dataset.memory import MemoryDataSet
 
 from utils import _mk_random
 
 
+@pytest.mark.with_numba
+def test_tile_sum_var():
+    for i in range(100):
+        x = np.random.randint(1, 42)
+        y = np.random.randint(1, 42)
+        z = np.random.randint(1, 42)
+        data = _mk_random(size=(z, y, x), dtype="float32")
+        s, v = tile_sum_var(data)
+        assert np.allclose(s, np.sum(data, axis=0))
+        assert np.allclose(v, np.var(data, axis=0)*len(data))
+
+
+
+@pytest.mark.with_numba
 @pytest.mark.parametrize(
     "use_roi", [True, False]
 )

--- a/tests/udf/test_stddev.py
+++ b/tests/udf/test_stddev.py
@@ -26,7 +26,7 @@ def test_stddev(lt_ctx, use_roi):
     # FIXME the tiling in signal dimension can only be tested once MemoryDataSet
     # actually supports it
     dataset = MemoryDataSet(data=data, tileshape=(3, 1, 1025),
-                            num_partitions=8, sig_dims=2)
+                            num_partitions=2, sig_dims=2)
     if use_roi:
         roi = np.random.choice([True, False], size=dataset.shape.nav)
         res = run_stddev(lt_ctx, dataset, roi=roi)
@@ -57,13 +57,14 @@ def test_stddev(lt_ctx, use_roi):
     assert np.allclose(std, res['std'])  # check standard deviation
 
 
-@numba.njit
+@numba.njit(boundscheck=True)
 def _stability_workhorse(data):
     # This function imitates the calculation flow of a single pixel for a very big dataset.
     # The partition and tile structure is given by the shape of data
     # data.shape[0]: partitions
     # data.shape[1]: tiles per partition
     # data.shape[2]: frames per tile
+    # data.shape[3]: mock signal shape, can be 1
     # The test uses numba since this allows efficient calculations for small units
     # of data. Running it with JIT disabled is very, very slow!
     s = np.zeros(1, dtype=np.float32)


### PR DESCRIPTION
This version is ~~slightly~~ about 2x faster compared to the version in #625 for the benign case of signal buffers that fit comfortably into the CPU caches.

For the malign case of signal buffers that don't fit the caches well,
it is about 10x faster since it eliminates large intermediate buffers and
calculates ~~each pixel in one pass~~ the result in cache-friendly blocks and CPU -friendly access patterns.

* Added test for numerical stability.
* Added citation in bibtex

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
