### PR TITLE
Fix performance issue w/ large tiles

### DIFF
--- a/docs/source/changelog/misc/raw_perf_large_tiles.rst
+++ b/docs/source/changelog/misc/raw_perf_large_tiles.rst
@@ -1,0 +1,5 @@
+[Misc] Improve performance with large tiles
+===========================================
+
+* When reading with large tiles from raw files with a roi,
+  there were some unnecessary and slow allocations triggered (:pr:`649`)

--- a/tests/io/test_raw.py
+++ b/tests/io/test_raw.py
@@ -239,6 +239,7 @@ def test_missing_detector_size(lt_ctx, default_raw):
     assert e.match("missing 1 required argument: 'detector_size'")
 
 
+@pytest.mark.skipif(os.name == 'nt')
 def test_load_direct(lt_ctx, default_raw):
     ds_direct = lt_ctx.load(
         "raw",

--- a/tests/io/test_raw.py
+++ b/tests/io/test_raw.py
@@ -239,7 +239,7 @@ def test_missing_detector_size(lt_ctx, default_raw):
     assert e.match("missing 1 required argument: 'detector_size'")
 
 
-@pytest.mark.skipif(os.name == 'nt')
+@pytest.mark.skipif(os.name == 'nt', reason='No direct IO on windows')
 def test_load_direct(lt_ctx, default_raw):
     ds_direct = lt_ctx.load(
         "raw",

--- a/tests/io/test_raw.py
+++ b/tests/io/test_raw.py
@@ -237,3 +237,16 @@ def test_missing_detector_size(lt_ctx, default_raw):
             dtype="float32",
             )
     assert e.match("missing 1 required argument: 'detector_size'")
+
+
+def test_load_direct(lt_ctx, default_raw):
+    ds_direct = lt_ctx.load(
+        "raw",
+        path=default_raw._path,
+        scan_size=(16, 16),
+        detector_size=(16, 16),
+        dtype="float32",
+        enable_direct=True,
+    )
+    analysis = lt_ctx.create_sum_analysis(dataset=ds_direct)
+    results = lt_ctx.run(analysis)


### PR DESCRIPTION
Allocating large buffers with zeros_aligned is slower
than using np.zeros, but is still needed for direct I/O.
This change only enables `zeros_aligned` for direct I/O and also
implements a shortcut in `_get_tiles_with_roi` if the roi is all-zeros

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases