### PR TITLE
Exception for Direct I/O for raw files on Windows

### DIFF
--- a/docs/source/changelog/bugfix/raw_direct_io_windows.rst
+++ b/docs/source/changelog/bugfix/raw_direct_io_windows.rst
@@ -1,0 +1,4 @@
+[Feature] Exception for Direct I/O for raw files on Windows
+============================================================
+
+* Exception is raised when Direct I/O is enabled for raw files on Windows (:pr:`659`)

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -101,11 +101,8 @@ class RawFile(File3D):
 
     def open(self):
         if self._enable_direct:
-            try:
-                fh = os.open(self._path, os.O_RDONLY | os.O_DIRECT)
-                f = open(fh, "rb", buffering=0)
-            except AttributeError:
-                raise DataSetException("LiberTEM currently does not support Direct I/O on Windows")
+            fh = os.open(self._path, os.O_RDONLY | os.O_DIRECT)
+            f = open(fh, "rb", buffering=0)
         else:
             f = open(self._path, "rb")
         self._file = f
@@ -261,6 +258,8 @@ class RawFileDataSet(DataSet):
         ])
 
     def check_valid(self):
+        if self._enable_direct and not hasattr(os, 'O_DIRECT'):
+            raise DataSetException("LiberTEM currently does not support Direct I/O on Windows")
         try:
             fileset = self._get_fileset()
             with fileset:

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -101,8 +101,11 @@ class RawFile(File3D):
 
     def open(self):
         if self._enable_direct:
-            fh = os.open(self._path, os.O_RDONLY | os.O_DIRECT)
-            f = open(fh, "rb", buffering=0)
+            try:
+                fh = os.open(self._path, os.O_RDONLY | os.O_DIRECT)
+                f = open(fh, "rb", buffering=0)
+            except AttributeError:
+                raise DataSetException("LiberTEM currently does not support Direct I/O on Windows")
         else:
             f = open(self._path, "rb")
         self._file = f

--- a/tests/io/test_raw.py
+++ b/tests/io/test_raw.py
@@ -251,3 +251,16 @@ def test_load_direct(lt_ctx, default_raw):
     )
     analysis = lt_ctx.create_sum_analysis(dataset=ds_direct)
     results = lt_ctx.run(analysis)
+
+@pytest.mark.skipif(os.name != 'nt', reason='No direct IO only on windows')
+def test_direct_io_enabled_windows(lt_ctx, default_raw):
+    with pytest.raises(Exception) as e:
+        lt_ctx.load(
+            "raw",
+            path=default_raw._path,
+            scan_size=(16, 16),
+            detector_size=(16, 16),
+            dtype="float32",
+            enable_direct=True,
+    )
+    assert e.match("LiberTEM currently does not support Direct I/O on Windows")


### PR DESCRIPTION
Fixes #658 

An exception is raised when Direct I/O is enabled for raw files on Windows and a user-friendly error message is shown on the GUI.

## Contributor Checklist:

* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases
