### PR TITLE
Add OS X tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   - pip
   - directories:
     - client/node_modules/
-    - $HOME/.cache/pyenv
 
 install:
   - pip install tox
@@ -31,21 +30,29 @@ jobs:
       os: osx
       env: TOXENV=py36
       before_install:
+        - eval "$(pyenv init -)"
         - pyenv install -l
         - pyenv install --skip-existing 3.6.9
         - pyenv global 3.6.9
         - pyenv rehash
         - python --version
+        - python3 --version
+        - pip3 --version
+        - pip --version
       language: shell
     - stage: test
       os: osx
       env: TOXENV=py37
       before_install:
+        - eval "$(pyenv init -)"
         - pyenv install -l
         - pyenv install --skip-existing 3.7.5
         - pyenv global 3.7.5
         - pyenv rehash
         - python --version
+        - python3 --version
+        - pip3 --version
+        - pip --version
       language: shell
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ jobs:
       os: osx
       env: TOXENV=py36
       before_install:
+        - ulimit -n
+        - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
         - pyenv install --skip-existing 3.6.9
@@ -45,6 +47,8 @@ jobs:
       os: osx
       env: TOXENV=py37
       before_install:
+        - ulimit -n
+        - ulimit -n 4096
         - eval "$(pyenv init -)"
         - pyenv install -l
         - pyenv install --skip-existing 3.7.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,17 @@ jobs:
 
     # OSX tests:
     - stage: test
+      os: osx
       env: TOXENV=py36
-      python: 3.6
-      os: osx
+      before_install:
+        - pyenv global 3.6
+      language: shell
     - stage: test
-      env: TOXENV=py37
-      python: 3.7
       os: osx
+      env: TOXENV=py37
+      before_install:
+        - pyenv global 3.7
+      language: shell
 
     - stage: test
       env: TOXENV=numba_coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   - pip
   - directories:
     - client/node_modules/
+    - $HOME/.cache/pyenv
 
 install:
   - pip install tox
@@ -31,16 +32,20 @@ jobs:
       env: TOXENV=py36
       before_install:
         - pyenv install -l
-        - pyenv install 3.6.9
+        - pyenv install --skip-existing 3.6.9
         - pyenv global 3.6.9
+        - pyenv rehash
+        - python --version
       language: shell
     - stage: test
       os: osx
       env: TOXENV=py37
       before_install:
         - pyenv install -l
-        - pyenv install 3.7.5
+        - pyenv install --skip-existing 3.7.5
         - pyenv global 3.7.5
+        - pyenv rehash
+        - python --version
       language: shell
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,14 @@ jobs:
       os: osx
       env: TOXENV=py36
       before_install:
+        - pyenv versions
         - pyenv global 3.6
       language: shell
     - stage: test
       os: osx
       env: TOXENV=py37
       before_install:
+        - pyenv versions
         - pyenv global 3.7
       language: shell
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   - pip
   - directories:
     - client/node_modules/
+    - $HOME/.pyenv/versions/
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,7 @@ jobs:
         - tox -e py37 -- tests/ -m dist
     - stage: test
       language: node_js
-      node_js:
-        - 8
+      node_js: 8
       install:
         - (cd client && npm install)
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
       env: TOXENV=py36
       before_install:
         - pyenv versions
+        - pyenv install 3.6
         - pyenv global 3.6
       language: shell
     - stage: test
@@ -38,6 +39,7 @@ jobs:
       env: TOXENV=py37
       before_install:
         - pyenv versions
+        - pyenv install 3.7
         - pyenv global 3.7
       language: shell
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,11 @@ jobs:
     - stage: packaging
       env: TOXENV=docs-deploy
       python: 3.7
-      sudo: true
       install:
         - pip install tox
         - sudo apt-get install -y pandoc
 
     - stage: packaging
-      sudo: require
       python: 3.7
       install:
         - pip install -r scripts/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,17 @@ jobs:
       os: osx
       env: TOXENV=py36
       before_install:
-        - pyenv versions
-        - pyenv install 3.6
-        - pyenv global 3.6
+        - pyenv install -l
+        - pyenv install 3.6.9
+        - pyenv global 3.6.9
       language: shell
     - stage: test
       os: osx
       env: TOXENV=py37
       before_install:
-        - pyenv versions
-        - pyenv install 3.7
-        - pyenv global 3.7
+        - pyenv install -l
+        - pyenv install 3.7.5
+        - pyenv global 3.7.5
       language: shell
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+os: linux
+dist: xenial
 cache:
   - pip
   - directories:
@@ -15,46 +17,45 @@ after_success:
 
 jobs:
   include:
+    # Linux tests:
     - stage: test
       env: TOXENV=py36
       python: 3.6
     - stage: test
       env: TOXENV=py37
       python: 3.7
-      dist: xenial
-      sudo: true
+
+    # OSX tests:
+    - stage: test
+      env: TOXENV=py36
+      python: 3.6
+      os: osx
+    - stage: test
+      env: TOXENV=py37
+      python: 3.7
+      os: osx
+
     - stage: test
       env: TOXENV=numba_coverage
       python: 3.7
-      dist: xenial
-      sudo: true
     - stage: test
       env: TOXENV=mypy
       python: 3.7
-      dist: xenial
-      sudo: true
     - stage: test
       env: TOXENV=flake8
       python: 3.7
-      dist: xenial
-      sudo: true
     - stage: test
       env: TOXENV=qa
-      dist: xenial
       python: 3.7
-      sudo: true
     - stage: test
       env: TOXENV=docs-check
       python: 3.7
-      dist: xenial
-      sudo: true
       install:
         - pip install tox
         - sudo apt-get install -y pandoc
     - stage: test
       env: DASK_SCHEDULER_ADDRESS=tcp://localhost:8786
       python: 3.7
-      dist: xenial
       services:
         - docker
       install:
@@ -76,7 +77,6 @@ jobs:
     - stage: packaging
       env: TOXENV=docs-deploy
       python: 3.7
-      dist: xenial
       sudo: true
       install:
         - pip install tox
@@ -85,7 +85,6 @@ jobs:
     - stage: packaging
       sudo: require
       python: 3.7
-      dist: xenial
       install:
         - pip install -r scripts/requirements.txt
       script:

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -259,7 +259,7 @@ class RawFileDataSet(DataSet):
 
     def check_valid(self):
         if self._enable_direct and not hasattr(os, 'O_DIRECT'):
-            raise DataSetException("LiberTEM currently does not support Direct I/O on Windows")
+            raise DataSetException("LiberTEM currently only support Direct I/O on Linux")
         try:
             fileset = self._get_fileset()
             with fileset:

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -259,7 +259,7 @@ class RawFileDataSet(DataSet):
 
     def check_valid(self):
         if self._enable_direct and not hasattr(os, 'O_DIRECT'):
-            raise DataSetException("LiberTEM currently only support Direct I/O on Linux")
+            raise DataSetException("LiberTEM currently only supports Direct I/O on Linux")
         try:
             fileset = self._get_fileset()
             with fileset:

--- a/tests/executor/test_dask.py
+++ b/tests/executor/test_dask.py
@@ -56,7 +56,7 @@ async def test_run_job(async_executor):
 
 
 @pytest.mark.skipif(os.name == 'nt',
-                    reason="doesnt run on windows")
+                    reason="Doesn't run on windows")
 @pytest.mark.asyncio
 async def test_fd_limit(async_executor):
     import resource

--- a/tests/io/test_raw.py
+++ b/tests/io/test_raw.py
@@ -17,6 +17,7 @@ def test_simple_open(default_raw):
     assert tuple(default_raw.shape) == (16, 16, 128, 128)
 
 
+@pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No general sparse support on OS X")
 @pytest.mark.parametrize(
     'TYPE', ['JOB', 'UDF']
 )

--- a/tests/io/test_raw.py
+++ b/tests/io/test_raw.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 import pickle
 
@@ -239,7 +240,7 @@ def test_missing_detector_size(lt_ctx, default_raw):
     assert e.match("missing 1 required argument: 'detector_size'")
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='No direct IO on windows')
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason='Direct I/O only implemented on Linux')
 def test_load_direct(lt_ctx, default_raw):
     ds_direct = lt_ctx.load(
         "raw",
@@ -252,8 +253,8 @@ def test_load_direct(lt_ctx, default_raw):
     analysis = lt_ctx.create_sum_analysis(dataset=ds_direct)
     results = lt_ctx.run(analysis)
 
-@pytest.mark.skipif(os.name != 'nt', reason='No direct IO only on windows')
-def test_direct_io_enabled_windows(lt_ctx, default_raw):
+@pytest.mark.skipif(sys.platform.startswith('linux'), reason='No direct IO only on non-Linux')
+def test_direct_io_enabled_non_linux(lt_ctx, default_raw):
     with pytest.raises(Exception) as e:
         lt_ctx.load(
             "raw",
@@ -263,4 +264,4 @@ def test_direct_io_enabled_windows(lt_ctx, default_raw):
             dtype="float32",
             enable_direct=True,
     )
-    assert e.match("LiberTEM currently does not support Direct I/O on Windows")
+    assert e.match("LiberTEM currently only supports Direct I/O on Linux")

--- a/tests/test_analysis_radialfourier.py
+++ b/tests/test_analysis_radialfourier.py
@@ -148,9 +148,10 @@ def test_symmetries(lt_ctx, TYPE):
     assert np.all(np.abs(c_1_2[0, 0]) > 0)
     assert np.all(np.abs(c_1_2[0, 1]) > 0)
     assert np.all(np.abs(c_1_2[1, 0]) > 0)
-    assert np.allclose(np.angle(c_1_2[0, 0]), np.pi)
-    assert np.allclose(np.angle(c_1_2[0, 1]), -np.pi)
-    assert np.allclose(np.angle(c_1_2[1, 0]), np.pi)
+    # Discontinuity at this point, can be pi or -pi
+    assert np.allclose(np.abs(np.angle(c_1_2[0, 0])), np.pi)
+    assert np.allclose(np.abs(np.angle(c_1_2[0, 1])), np.pi)
+    assert np.allclose(np.abs(np.angle(c_1_2[1, 0])), np.pi)
 
     c_0_3 = results.complex_0_3.raw_data
     c_1_3 = results.complex_1_3.raw_data

--- a/tests/udf/test_make_feature_vec.py
+++ b/tests/udf/test_make_feature_vec.py
@@ -12,10 +12,10 @@ def test_simple_example(lt_ctx):
     # adding high intensity zero order peak for all frames
     data[:, 2, 2] = 7
     # adding strong non-zero order diffraction peaks for 0:3 frames
-    data[0:3, 0, 0] = 2
+    data[0:3, 0, 0] = 2.5
     data[0:3, 4, 4] = 2
     # adding weak non-zero order diffraction peaks for 0:3 frames
-    data[3:6, 2, 0] = 1
+    data[3:6, 2, 0] = 1.5
     data[3:6, 2, 4] = 1
     dataset = MemoryDataSet(data=data, tileshape=(1, 5, 5),
                             num_partitions=3, sig_dims=2)

--- a/tests/udf/test_make_feature_vec.py
+++ b/tests/udf/test_make_feature_vec.py
@@ -10,7 +10,11 @@ def test_simple_example(lt_ctx):
     #  6:9 frames are amourphous
     data = np.zeros([3*3, 7, 7]).astype(np.float32)
     # adding high intensity zero order peak for all frames
-    data[:, 3, 3] = 7
+    # The first one different to make sure it shows up weakly in the standard deviation map
+    # This makes sure that we have more peaks than n_peaks, but this one
+    # is intentionally the weakest
+    data[0, 3, 3] = 7.1
+    data[1:, 3, 3] = 7
     # adding strong non-zero order diffraction peaks for 0:3 frames
     data[0:3, 1, 1] = 2.5
     data[0:3, 5, 5] = 2

--- a/tests/udf/test_make_feature_vec.py
+++ b/tests/udf/test_make_feature_vec.py
@@ -8,16 +8,16 @@ from libertem.io.dataset.memory import MemoryDataSet
 def test_simple_example(lt_ctx):
     # creating a dataset where 0:3 frames are strong crystalline, 3:6 frames are weak crystalline,
     #  6:9 frames are amourphous
-    data = np.zeros([3*3, 5, 5]).astype(np.float32)
+    data = np.zeros([3*3, 7, 7]).astype(np.float32)
     # adding high intensity zero order peak for all frames
-    data[:, 2, 2] = 7
+    data[:, 3, 3] = 7
     # adding strong non-zero order diffraction peaks for 0:3 frames
-    data[0:3, 0, 0] = 2.5
-    data[0:3, 4, 4] = 2
+    data[0:3, 1, 1] = 2.5
+    data[0:3, 5, 5] = 2
     # adding weak non-zero order diffraction peaks for 0:3 frames
-    data[3:6, 2, 0] = 1.5
-    data[3:6, 2, 4] = 1
-    dataset = MemoryDataSet(data=data, tileshape=(1, 5, 5),
+    data[3:6, 3, 1] = 1.5
+    data[3:6, 3, 5] = 1
+    dataset = MemoryDataSet(data=data, tileshape=(1, 7, 7),
                             num_partitions=3, sig_dims=2)
     result, coordinates = feature.make_feature_vec(
         ctx=lt_ctx, dataset=dataset, delta=0, n_peaks=4, min_dist=0


### PR DESCRIPTION
See also: #679

TODO:
- [x] `large_raw` fixture: creating sparse files doesn't work like this on OS X, or the stat call works differently
- [x] asyncio failures: 
  - [x] `RuntimeError: There is no current event loop in thread 'ThreadPoolExecutor-34_0'`
  - [x] `OSError: [Errno 24] Too many open files`
- [x] numerics fixes:
  - [x] radial fourier
  - [x] feature vector: misses half the peaks?

Radial fourier, both for `JOB` and `UDF`:
```
>       assert np.allclose(np.angle(c_1_2[1, 0]), np.pi)
E       assert False
E        +  where False = <function allclose at 0x10e45d6a8>(-3.141592653589793, 3.141592653589793)
E        +    where <function allclose at 0x10e45d6a8> = np.allclose
E        +    and   -3.141592653589793 = <function angle at 0x10e58dd90>((-0.981522951893353-9.77719708014513e-19j))
E        +      where <function angle at 0x10e58dd90> = np.angle
E        +    and   3.141592653589793 = np.pi
```

Feature vector: 

```
>       assert np.all(result['feature_vec'].data[0:3, 0:2])
E       assert False
E        +  where False = <function all at 0x10e445510>(array([[ True, False],\n       [ True, False],\n       [ True, False]]))
E        +    where <function all at 0x10e445510> = np.all
```

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases