### PR TITLE
Limit to distributed < 2.9

### DIFF
--- a/prototypes/reproducers/test-dask-remote.ipynb
+++ b/prototypes/reproducers/test-dask-remote.ipynb
@@ -1,0 +1,323 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"OMP_NUM_THREADS\"] = \"1\"\n",
+    "os.environ[\"MKL_NUM_THREADS\"] = \"1\"\n",
+    "os.environ[\"OPENBLAS_NUM_THREADS\"] = \"1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib nbagg\n",
+    "%load_ext line_profiler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import distributed as dd\n",
+    "\n",
+    "from libertem import api\n",
+    "from libertem.udf.stddev import StdDevUDF, merge, process_tile\n",
+    "from libertem.udf.sum import SumUDF\n",
+    "from libertem.udf.masks import ApplyMasksUDF\n",
+    "from libertem.executor.inline import InlineJobExecutor\n",
+    "from libertem.executor.dask import DaskJobExecutor, AsyncDaskJobExecutor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote_client = dd.Client('localhost:31314', set_as_default=False)\n",
+    "local_ctx = api.Context()\n",
+    "remote_ctx = api.Context(executor=DaskJobExecutor(remote_client))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_ds = local_ctx.load(\n",
+    "    'auto',\n",
+    "    path=r'/Users/weber/cachedata/data/Glasgow/10 um 110.blo',\n",
+    "    tileshape=(8,64,144)\n",
+    ")\n",
+    "remote_ds = remote_ctx.load(\n",
+    "    'auto',\n",
+    "    path=r'/Users/weber/cachedata/data/Glasgow/10 um 110.blo',\n",
+    "    tileshape=(8,64,144)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_analysis = local_ctx.create_ring_analysis(dataset=local_ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 170 ms, sys: 4.18 ms, total: 174 ms\n",
+      "Wall time: 192 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "local_ctx.run(local_analysis)\n",
+    "%time local_ctx.run(local_analysis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote_analysis = remote_ctx.create_ring_analysis(dataset=remote_ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 149 ms, sys: 12.1 ms, total: 161 ms\n",
+      "Wall time: 180 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<AnalysisResult: intensity>]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote_ctx.run(remote_analysis)\n",
+    "%time remote_ctx.run(remote_analysis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_shape = tuple(local_ds.shape.sig)\n",
+    "def mask():\n",
+    "    return np.ones(mask_shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "udf = ApplyMasksUDF(mask_factories=[mask])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 247 ms, sys: 11.7 ms, total: 259 ms\n",
+      "Wall time: 285 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'intensity': <BufferWrapper kind=nav dtype=float64 extra_shape=(1,)>}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "local_ctx.run_udf(dataset=local_ds, udf=udf)\n",
+    "%time local_ctx.run_udf(dataset=local_ds, udf=udf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 215 ms, sys: 17.4 ms, total: 232 ms\n",
+      "Wall time: 267 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'intensity': <BufferWrapper kind=nav dtype=float64 extra_shape=(1,)>}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote_ctx.run_udf(dataset=remote_ds, udf=udf)\n",
+    "%time remote_ctx.run_udf(dataset=remote_ds, udf=udf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "udf_2 = StdDevUDF()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 127 ms, sys: 16 ms, total: 143 ms\n",
+      "Wall time: 168 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'varsum': <BufferWrapper kind=sig dtype=float64 extra_shape=()>,\n",
+       " 'num_frames': <BufferWrapper kind=single dtype=object extra_shape=()>,\n",
+       " 'sum': <BufferWrapper kind=sig dtype=float64 extra_shape=()>}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "local_ctx.run_udf(dataset=local_ds, udf=udf_2)\n",
+    "%time local_ctx.run_udf(dataset=local_ds, udf=udf_2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 80 ms, sys: 7.39 ms, total: 87.4 ms\n",
+      "Wall time: 118 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'varsum': <BufferWrapper kind=sig dtype=float64 extra_shape=()>,\n",
+       " 'num_frames': <BufferWrapper kind=single dtype=object extra_shape=()>,\n",
+       " 'sum': <BufferWrapper kind=sig dtype=float64 extra_shape=()>}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote_ctx.run_udf(dataset=remote_ds, udf=udf_2)\n",
+    "%time remote_ctx.run_udf(dataset=remote_ds, udf=udf_2)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (libertem-debug)",
+   "language": "python",
+   "name": "libertem-debug"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup(
         "numpy",
         "scipy",
         "sparse",
-        "distributed>=2.2.0",
+        "distributed>=2.2.0,<2.9",
         "click",
         "tornado>=5",
         "matplotlib",


### PR DESCRIPTION
The notebook prototypes/reproducers/test-dask-remote.ipynb
reliably locked up or errored when using it with a remote dask
cluster of version 2.9.0 or newer.

Tested on moellenstedt in a new clean conda environment with LiberTEM
master, Python 3.7.

@sk1p could you perhaps test if you can reproduce it locally on your machine? I couldn't reproduce it on my Windows machine.