### PR TITLE
Set thread count dynamically for each UDF run

### DIFF
--- a/docs/source/changelog/misc/threading.rst
+++ b/docs/source/changelog/misc/threading.rst
@@ -1,0 +1,6 @@
+[Misc] Set thread count at run time
+===================================
+
+* No need to set thread count environment variables anymore since the thread count
+  for OpenBLAS, OpenMP, Intel MKL and pyFFTW is now set on the workers at run-time.
+  Numba support will be added as soon as Numba 0.49 is released. (:pr:`685`).

--- a/docs/source/gsoc.rst
+++ b/docs/source/gsoc.rst
@@ -217,20 +217,7 @@ LiberTEM can work as well.
     *Primary contact:* Alex (@sk1p)
 
 
-5. **Beginner/Intermediate**: Set number of threads and workers dynamically for UDFs :issue:`546`.
-    Your task is to implement, document and validate methods to set the thread
-    count for all relevant numerics back-ends in LiberTEM dynamically on a
-    case-by-case basis on the worker processes and main node. Furthermore, you
-    can implement an interface for UDFs to specify their preferred number of
-    threads. This can improve L3 cache efficiency for UDFs that can use a
-    multi-threaded back-end and at the same time avoids oversubscription of the
-    CPU.
-
-    *Skills:* Python programming, using Goole.
-
-    *Domain knowledge:* None
-
-    *Primary contact:* Alex (@sk1p), Dieter (@uellue)
+5. (*Removed since being implemented*: Set number of threads and workers dynamically for UDFs :issue:`546`.)
 
 6. **Beginner/Intermediate/Advanced**: Compression survey :issue:`387`.
     Analyze high-throughput compression techniques, dive into lz4/zstd, blosc

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,13 +1,7 @@
-import os
 import sys
 import logging
-# Disable threading, we already use multiprocessing
-# to saturate the CPUs
-# The variables have to be set before any numerics
-# libraries are loaded.
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
+# Changed in 0.5.0.dev0: The thread count ist set dynamically
+# on the workers. No need for setting environment variables anymore.
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/center_of_mass.ipynb
+++ b/examples/center_of_mass.ipynb
@@ -15,34 +15,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We disable threading in OpenBLAS because it would interfere with the dask multiprocessing and because OpenBLAS likes to call ``sched_yield`` for no discernable reason"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: OMP_NUM_THREADS=1\n",
-      "env: OPENBLAS_NUM_THREADS=1\n",
-      "env: OPENBLAS_NUM_THREADS=1\n"
-     ]
-    }
-   ],
-   "source": [
-    "%env OMP_NUM_THREADS=1\n",
-    "%env OPENBLAS_NUM_THREADS=1\n",
-    "%env OPENBLAS_NUM_THREADS=1"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},

--- a/examples/digital-micrograph-basic.py
+++ b/examples/digital-micrograph-basic.py
@@ -1,7 +1,3 @@
-import os
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
 import sys
 import multiprocessing
 

--- a/examples/pcmclustering.ipynb
+++ b/examples/pcmclustering.ipynb
@@ -17,18 +17,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.environ[\"OMP_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"MKL_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"OPENBLAS_NUM_THREADS\"] = \"1\""
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/examples/peak_selector.ipynb
+++ b/examples/peak_selector.ipynb
@@ -32,21 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set up the environment and import libraries\n",
-    "\n",
-    "We disable threading in any numerics libraries because we already saturate the CPU with multiprocessing. Additional threads would get in each other's way and slow things down rather than speed them up. The environment variables have to be set as early as possible before any of the libraries are loaded."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.environ[\"OMP_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"MKL_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"OPENBLAS_NUM_THREADS\"] = \"1\""
+    "## Import libraries"
    ]
   },
   {

--- a/examples/radialfourier.ipynb
+++ b/examples/radialfourier.ipynb
@@ -16,18 +16,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.environ[\"OMP_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"MKL_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"OPENBLAS_NUM_THREADS\"] = \"1\""
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/examples/simple libertem API.ipynb
+++ b/examples/simple libertem API.ipynb
@@ -2,18 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.environ[\"OMP_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"MKL_NUM_THREADS\"] = \"1\"\n",
-    "os.environ[\"OPENBLAS_NUM_THREADS\"] = \"1\""
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/prototypes/set-threadcount.ipynb
+++ b/prototypes/set-threadcount.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib nbagg\n",
+    "%load_ext line_profiler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import distributed as dd\n",
+    "\n",
+    "from libertem import api\n",
+    "\n",
+    "from libertem.udf.stddev import StdDevUDF, process_tile\n",
+    "from libertem.executor.inline import InlineJobExecutor\n",
+    "from libertem.executor.dask import DaskJobExecutor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# client = dd.Client('localhost:31314', set_as_default=False)\n",
+    "# ctx = api.Context(executor=InlineJobExecutor())\n",
+    "ctx = api.Context()\n",
+    "# ctx = api.Context(executor=DaskJobExecutor(client))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = ctx.load(\n",
+    "    'auto',\n",
+    "#     path='/Users/weber/cachedata/data/thibaud/2018-10-26_SiGe-transistor/Capture93_.gtg',\n",
+    "     path='/Users/weber/cachedata/data/Glasgow/10 um 110.blo',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis = ctx.create_ring_analysis(dataset=ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "195 ms ± 6.69 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "ctx.run(analysis)\n",
+    "%timeit ctx.run(analysis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "udf = StdDevUDF()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "141 ms ± 11.7 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "ctx.run_udf(udf=udf, dataset=ds)\n",
+    "%timeit ctx.run_udf(udf=udf, dataset=ds)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (libertem-uellue)",
+   "language": "python",
+   "name": "libertem-uellue"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,8 @@ setup(
         "pillow",
         "h5py",
         "psutil",
+        # FIXME numba>=0.49 as soon as released for thread count control #685, #546
+        # See also src/libertem/utils/threading.py
         # Bounds checking in Numba
         "numba>=0.47",
         "ncempy>=1.4",
@@ -158,6 +160,7 @@ setup(
         'tqdm',
         # FIXME remove in 0.7.0 after blobfinder deprecation
         'libertem-blobfinder',
+        'threadpoolctl'
     ],
     extras_require={
         'torch': 'torch',

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -639,69 +639,69 @@ class UDFRunner:
         return np.result_type(self._udf.get_preferred_input_dtype(), dtype)
 
     def run_for_partition(self, partition, roi):
-        set_num_threads(1)
-        dtype = self._get_dtype(partition.dtype)
-        meta = UDFMeta(
-            partition_shape=partition.slice.adjust_for_roi(roi).shape,
-            dataset_shape=partition.meta.shape,
-            roi=roi,
-            dataset_dtype=partition.dtype,
-            input_dtype=dtype,
-        )
-        self._udf.set_meta(meta)
-        self._udf.init_result_buffers()
-        self._udf.allocate_for_part(partition, roi)
-        self._udf.init_task_data()
-        if hasattr(self._udf, 'preprocess'):
-            self._udf.clear_views()
-            self._udf.preprocess()
-        method = self._udf.get_method()
-        if method == 'tile':
-            tiles = partition.get_tiles(full_frames=False, roi=roi, dest_dtype=dtype, mmap=True)
-        elif method == 'frame':
-            tiles = partition.get_tiles(full_frames=True, roi=roi, dest_dtype=dtype, mmap=True)
-        elif method == 'partition':
-            tiles = [partition.get_macrotile(roi=roi, dest_dtype=dtype, mmap=True)]
-
-        for tile in tiles:
+        with set_num_threads(1):
+            dtype = self._get_dtype(partition.dtype)
+            meta = UDFMeta(
+                partition_shape=partition.slice.adjust_for_roi(roi).shape,
+                dataset_shape=partition.meta.shape,
+                roi=roi,
+                dataset_dtype=partition.dtype,
+                input_dtype=dtype,
+            )
+            self._udf.set_meta(meta)
+            self._udf.init_result_buffers()
+            self._udf.allocate_for_part(partition, roi)
+            self._udf.init_task_data()
+            if hasattr(self._udf, 'preprocess'):
+                self._udf.clear_views()
+                self._udf.preprocess()
+            method = self._udf.get_method()
             if method == 'tile':
-                self._udf.set_views_for_tile(partition, tile)
-                self._udf.set_slice(tile.tile_slice)
-                self._udf.process_tile(tile.data)
+                tiles = partition.get_tiles(full_frames=False, roi=roi, dest_dtype=dtype, mmap=True)
             elif method == 'frame':
-                tile_slice = tile.tile_slice
-                for frame_idx, frame in enumerate(tile.data):
-                    frame_slice = Slice(
-                        origin=(tile_slice.origin[0] + frame_idx,) + tile_slice.origin[1:],
-                        shape=Shape((1,) + tuple(tile_slice.shape)[1:],
-                                    sig_dims=tile_slice.shape.sig.dims),
-                    )
-                    self._udf.set_slice(frame_slice)
-                    self._udf.set_views_for_frame(partition, tile, frame_idx)
-                    self._udf.process_frame(frame)
+                tiles = partition.get_tiles(full_frames=True, roi=roi, dest_dtype=dtype, mmap=True)
             elif method == 'partition':
-                self._udf.set_views_for_tile(partition, tile)
-                self._udf.set_slice(partition.slice)
-                self._udf.process_partition(tile.data)
+                tiles = [partition.get_macrotile(roi=roi, dest_dtype=dtype, mmap=True)]
 
-        if hasattr(self._udf, 'postprocess'):
+            for tile in tiles:
+                if method == 'tile':
+                    self._udf.set_views_for_tile(partition, tile)
+                    self._udf.set_slice(tile.tile_slice)
+                    self._udf.process_tile(tile.data)
+                elif method == 'frame':
+                    tile_slice = tile.tile_slice
+                    for frame_idx, frame in enumerate(tile.data):
+                        frame_slice = Slice(
+                            origin=(tile_slice.origin[0] + frame_idx,) + tile_slice.origin[1:],
+                            shape=Shape((1,) + tuple(tile_slice.shape)[1:],
+                                        sig_dims=tile_slice.shape.sig.dims),
+                        )
+                        self._udf.set_slice(frame_slice)
+                        self._udf.set_views_for_frame(partition, tile, frame_idx)
+                        self._udf.process_frame(frame)
+                elif method == 'partition':
+                    self._udf.set_views_for_tile(partition, tile)
+                    self._udf.set_slice(partition.slice)
+                    self._udf.process_partition(tile.data)
+
+            if hasattr(self._udf, 'postprocess'):
+                self._udf.clear_views()
+                self._udf.postprocess()
+
+            self._udf.cleanup()
             self._udf.clear_views()
-            self._udf.postprocess()
 
-        self._udf.cleanup()
-        self._udf.clear_views()
+            if self._debug:
+                try:
+                    cloudpickle.loads(cloudpickle.dumps(partition))
+                except TypeError:
+                    raise TypeError("could not pickle partition")
+                try:
+                    cloudpickle.loads(cloudpickle.dumps(self._udf.results))
+                except TypeError:
+                    raise TypeError("could not pickle results")
 
-        if self._debug:
-            try:
-                cloudpickle.loads(cloudpickle.dumps(partition))
-            except TypeError:
-                raise TypeError("could not pickle partition")
-            try:
-                cloudpickle.loads(cloudpickle.dumps(self._udf.results))
-            except TypeError:
-                raise TypeError("could not pickle results")
-
-        return self._udf.results, partition
+            return self._udf.results, partition
 
     def _debug_task_pickling(self, tasks):
         if self._debug:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from libertem.common.buffers import BufferWrapper, AuxBufferWrapper
 from libertem.common import Shape, Slice
+from libertem.utils.threading import set_num_threads
 
 
 class UDFMeta:
@@ -638,6 +639,7 @@ class UDFRunner:
         return np.result_type(self._udf.get_preferred_input_dtype(), dtype)
 
     def run_for_partition(self, partition, roi):
+        set_num_threads(1)
         dtype = self._get_dtype(partition.dtype)
         meta = UDFMeta(
             partition_shape=partition.slice.adjust_for_roi(roi).shape,

--- a/src/libertem/utils/threading.py
+++ b/src/libertem/utils/threading.py
@@ -1,0 +1,31 @@
+import os
+import logging
+from pathlib import Path
+from ctypes.util import find_library
+import ctypes
+
+log = logging.getLogger(__name__)
+
+def get_numpy_openblas_dll_path():
+    import numpy
+    numpy_dir = os.path.dirname(numpy.__file__)
+    dll_dir = os.path.join(numpy_dir, '.libs')
+    files = Path(dll_dir).rglob('libopenblas*.dll')
+    return str(next(files))
+
+try:
+    if os.name == 'nt':
+        lib_str = get_numpy_openblas_dll_path()
+    else:
+        lib_str = find_library('openblas')
+    openblas = ctypes.cdll.LoadLibrary(lib_str)
+
+    openblas_set_num_threads = openblas.openblas_set_num_threads
+    log.debug("Found OpenBLAS library")
+except Exception as e:
+    log.warning("Didn't find OpenBLAS library", exc_info=e)
+    def openblas_set_num_threads(n):
+        pass
+    
+def set_num_threads(n):
+    openblas_set_num_threads(n)

--- a/src/libertem/utils/threading.py
+++ b/src/libertem/utils/threading.py
@@ -6,26 +6,33 @@ import ctypes
 
 log = logging.getLogger(__name__)
 
-def get_numpy_openblas_dll_path():
-    import numpy
-    numpy_dir = os.path.dirname(numpy.__file__)
-    dll_dir = os.path.join(numpy_dir, '.libs')
-    files = Path(dll_dir).rglob('libopenblas*.dll')
-    return str(next(files))
 
-try:
-    if os.name == 'nt':
-        lib_str = get_numpy_openblas_dll_path()
-    else:
-        lib_str = find_library('openblas')
-    openblas = ctypes.cdll.LoadLibrary(lib_str)
-
-    openblas_set_num_threads = openblas.openblas_set_num_threads
-    log.debug("Found OpenBLAS library")
-except Exception as e:
-    log.warning("Didn't find OpenBLAS library", exc_info=e)
-    def openblas_set_num_threads(n):
-        pass
-    
 def set_num_threads(n):
+    # The library has to be loaded for each call
+    # through ctypes
+    # and not once during import of this module
+    # for this to work with dask.distributed workers
+
+    def get_numpy_openblas_dll_path():
+        import numpy
+        numpy_dir = os.path.dirname(numpy.__file__)
+        dll_dir = os.path.join(numpy_dir, '.libs')
+        files = Path(dll_dir).rglob('libopenblas*.dll')
+        return str(next(files))
+
+    try:
+        if os.name == 'nt':
+            lib_str = get_numpy_openblas_dll_path()
+        else:
+            lib_str = find_library('openblas')
+        openblas = ctypes.cdll.LoadLibrary(lib_str)
+
+        openblas_set_num_threads = openblas.openblas_set_num_threads
+        log.debug("Found OpenBLAS library")
+    except Exception as e:
+        log.warning("Didn't find OpenBLAS library", exc_info=e)
+
+        def openblas_set_num_threads(n):
+            pass
+
     openblas_set_num_threads(n)


### PR DESCRIPTION
Having to set the thread count through environment variables can be problematic in some situations #546 and is an error source with severe performance penalties from over-subscription on machines with many cores #602.

In this PR I am planning to include support for setting the thread count to 1 on the workers, i.e. not having to set environment variables anymore. Allowing multi-threaded UDFs should likely be implemented in a follow-up PR later.

With this feature in mind, I am already setting the thread count in `run_for_partition()`.

- [x] Basic proof of concept for OpenBLAS
- [x] Try `threadpoolctl`
- [ ] Intel MKL -- Should be covered by `threadpoolctl`, but couldn't get LiberTEM installed in their Python distribution.
- [x] PyFFTW -- not tested if effective yet, but default thread count is 1 anyway
- [ ] Numba will have a convenient interface in the 0.49 release: https://numba.pydata.org/numba-doc/dev/user/threading-layer.html#setting-the-number-of-threads

Getting the previous number of threads is not always reliable, as it turns out. For that reason I am just setting the number and not trying to restore it after.

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
