### PR TITLE
Limit default merge to kind='nav' buffers

### DIFF
--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -195,7 +195,8 @@ Examples of buffer declarations:
 .. testcleanup:: getresultbuffers
 
    class TestUDF(UDF):
-      pass
+      def merge(self, dest, src):
+         pass
 
    TestUDF.get_result_buffers = get_result_buffers
 

--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -146,6 +146,24 @@ class BufferWrapper(object):
         """
         return self._data
 
+    @property
+    def kind(self):
+        """
+        Get the kind of this buffer.
+
+        .. versionadded:: 0.5.0
+        """
+        return self._kind
+
+    @property
+    def extra_shape(self):
+        """
+        Get the :code:`extra_shape` of this buffer.
+
+        .. versionadded:: 0.5.0
+        """
+        return self._extra_shape
+
     def __array__(self):
         """
         returns the "wrapped"/reshaped array, see above

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -494,8 +494,9 @@ class UDF(UDFBase):
     def requires_custom_merge(self):
         if self._requires_custom_merge is None:
             self._requires_custom_merge = False
-            for name, content in self.get_result_buffers().items():
-                if content.kind != 'nav':
+            buffers = self.get_result_buffers()
+            for buffer in buffers.values():
+                if buffer.kind != 'nav':
                     self._requires_custom_merge = True
                     break
         return self._requires_custom_merge

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -493,12 +493,8 @@ class UDF(UDFBase):
     @property
     def requires_custom_merge(self):
         if self._requires_custom_merge is None:
-            self._requires_custom_merge = False
             buffers = self.get_result_buffers()
-            for buffer in buffers.values():
-                if buffer.kind != 'nav':
-                    self._requires_custom_merge = True
-                    break
+            self._requires_custom_merge = any(buffer.kind != 'nav' for buffer in buffers.values())
         return self._requires_custom_merge
 
     def merge(self, dest: Dict[str, np.array], src: Dict[str, np.array]):

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -558,7 +558,7 @@ class UDF(UDFBase):
 
         If you prefer to always use the dataset's native dtype instead of
         floats, you can override this method to return
-        :attr:`UDF.USE_NATIVE_DTYPE`, which is curently identical to
+        :attr:`UDF.USE_NATIVE_DTYPE`, which is currently identical to
         :code:`numpy.bool` and behaves as a neutral element in
         :func:`numpy.result_type`.
 

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -492,6 +492,12 @@ class UDF(UDFBase):
 
     @property
     def requires_custom_merge(self):
+        """
+        Determine if buffers with :code:`kind != 'nav'` are present where
+        the default merge doesn't work
+
+        .. versionadded:: 0.5.0
+        """
         if self._requires_custom_merge is None:
             buffers = self.get_result_buffers()
             self._requires_custom_merge = any(buffer.kind != 'nav' for buffer in buffers.values())


### PR DESCRIPTION
The default merge function throws a NotImplementedError when used
for kinds other than 'nav'

## Contributor Checklist:

* [x] I have added myself to [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added/updated test cases
