### PR TITLE
Pin pytest-asyncio to <0.11

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 pytest>=5,<6
 pytest-cov
-pytest-asyncio
+pytest-asyncio<0.11
 pytest-xdist
 aiohttp
 websockets


### PR DESCRIPTION
Works around bug in latest version (https://github.com/pytest-dev/pytest-asyncio/issues/154)

```_____________________ test_start_server __________________________________________________________________

base_url = 'http://127.0.0.1:45153', http_client = <aiohttp.client.ClientSession object at 0x7f2cfedb1e90>

    @pytest.mark.asyncio
    async def test_start_server(base_url, http_client):
        """
        start the server and HTTP GET '/', which should
        return a 200 status code
        """
        url = base_url
>       async with http_client.get(url) as response:

tests/server/test_startup.py:36:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py37/lib/python3.7/site-packages/aiohttp/client.py:1012: in __aenter__
    self._resp = await self._coro
.tox/py37/lib/python3.7/site-packages/aiohttp/client.py:426: in _request
    with timer:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <aiohttp.helpers.TimerContext object at 0x7f2cfefefd10>

    def __enter__(self) -> BaseTimerContext:
        task = current_task(loop=self._loop)

        if task is None:
>           raise RuntimeError('Timeout context manager should be used '
                               'inside a task')
E           RuntimeError: Timeout context manager should be used inside a task

.tox/py37/lib/python3.7/site-packages/aiohttp/helpers.py:579: RuntimeError
```

Another workaround is adding `event_loop` to all asyncio test cases as a fixture.