### PR TITLE
Detect discrepancies in `Buffer` cache use

### DIFF
--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -345,7 +345,7 @@ class BufferWrapper(object):
                 # See if the signal dimension can be flattened
                 # https://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html
                 if not view.flags.c_contiguous:
-                    assert disjoint(key, self._contiguous_cache.iterkeys())
+                    assert disjoint(key, self._contiguous_cache.keys())
                     view = view.copy()
                     self._contiguous_cache[key] = view
             return view

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -1,6 +1,9 @@
+from typing import Iterable
 import mmap
 import math
 import numpy as np
+
+from libertem.common.slice import Slice
 
 
 def _alloc_aligned(size):
@@ -67,12 +70,8 @@ def reshaped_view(a: np.ndarray, shape):
     return res
 
 
-def slice_to_tuple(sl: slice):
-    return (sl.start, sl.stop, sl.step)
-
-
-def tuple_to_slice(tup: tuple):
-    return slice(tup[0], tup[1], tup[2])
+def disjoint(sl: Slice, slices: Iterable[Slice]):
+    return all(sl.intersection_with(s2).is_null() for s2 in slices)
 
 
 class BufferWrapper(object):
@@ -337,15 +336,16 @@ class BufferWrapper(object):
 
         '''
         if self._kind == "sig":
-            sl = tile.tile_slice.get(sig_only=True)
-            key = tuple(map(slice_to_tuple, sl))
+            key = tile.tile_slice.discard_nav()
             if key in self._contiguous_cache:
                 view = self._contiguous_cache[key]
             else:
+                sl = key.get(sig_only=True)
                 view = self._data[sl]
                 # See if the signal dimension can be flattened
                 # https://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html
                 if not view.flags.c_contiguous:
+                    assert disjoint(key, self._contiguous_cache.iterkeys())
                     view = view.copy()
                     self._contiguous_cache[key] = view
             return view
@@ -358,10 +358,14 @@ class BufferWrapper(object):
 
         .. versionadded:: 0.5.0
         '''
-        for key, view in self._contiguous_cache.items():
-            sl = tuple(map(tuple_to_slice, key))
-            self._data[sl] = view
-        self._contiguous_cache = dict()
+        if self._kind == "sig":
+            for key, view in self._contiguous_cache.items():
+                sl = key.get(sig_only=True)
+                self._data[sl] = view
+            self._contiguous_cache = dict()
+        else:
+            # Cache flushing not implemented for other kinds
+            assert not self._contiguous_cache
 
     def __repr__(self):
         return "<BufferWrapper kind=%s dtype=%s extra_shape=%s>" % (


### PR DESCRIPTION
* Use `Slice` objects as keys, which are hashable
* Assert that they don't overlap
* Make sure we only flush correctly and trigger an error otherwise

We only have to check once when a new key is created for the cache,
which means it shouldn't noticeably impact performance. Plus, we can
deactivate asserts for production.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
