### PR TITLE
Add alias to cmd line options

### DIFF
--- a/docs/source/changelog/misc/cli_alias.rst
+++ b/docs/source/changelog/misc/cli_alias.rst
@@ -1,0 +1,4 @@
+[Misc] Added alias for cmd line options
+=======================================
+
+* Command line options can also be accessed with shorter alternatives (:pr:`757`)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -32,9 +32,9 @@ There are a few command line options available::
     Usage: libertem-server [OPTIONS]
 
     Options:
-      --port INTEGER  port on which the server should listen on
-      --local-directory TEXT    local directory to manage dask-worker-space files
-      --browser / --no-browser  enable/disable opening the browser
+      -p, --port INTEGER  port on which the server should listen on
+      -l, --local-directory TEXT    local directory to manage dask-worker-space files
+      -b, --browser / -n, --no-browser  enable/disable opening the browser
       --help          Show this message and exit.
 
 .. versionadded:: 0.4.0

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -2,11 +2,12 @@ import click
 
 
 @click.command()
-@click.option('--port', help='port on which the server should listen on',
+@click.option('-p', '--port', help='port on which the server should listen on',
               default=9000, type=int)
-@click.option('--local-directory', help='local directory to manage dask-worker-space files',
+@click.option('-l', '--local-directory', help='local directory to manage dask-worker-space files',
               default='dask-worker-space', type=str)
-@click.option('--browser/--no-browser', help='enable/disable opening the browser', default='True')
+@click.option('-b/-n', '--browser/--no-browser',
+              help='enable/disable opening the browser', default='True')
 # FIXME: the host parameter is currently disabled, as it poses a security risk
 # as long as there is no authentication
 # see also: https://github.com/LiberTEM/LiberTEM/issues/67


### PR DESCRIPTION
cmd line options can be accessed with shorter alternatives

## Contributor Checklist:

* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
