### PR TITLE
Make sure the sum of the mask is not close to zero

### DIFF
--- a/tests/corrections/test_detector.py
+++ b/tests/corrections/test_detector.py
@@ -354,7 +354,7 @@ def test_mask_patch():
         print("Sig dims:", sig_dims)
         print("Exclude: ", exclude)
 
-        masks = (np.random.random((2, ) + sig_dims) - 0.5).astype(np.float64)
+        masks = (np.random.random((2, ) + sig_dims) - 0.3).astype(np.float64)
         data_flat = data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
         damaged_flat = damaged_data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
 


### PR DESCRIPTION
Otherwise it heavily accumulates numerical errors.

For that reason, make the distribution asymmetric around zero.

Closes #761 

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added/updated test cases
