### PR TITLE
SEQ: UnicodeDecodeError exception

### DIFF
--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -240,7 +240,7 @@ class SEQDataSet(DataSet):
                     "scan_size": str(image_count),
                 }
             }
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             return False
 
     @classmethod

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -1,0 +1,6 @@
+from libertem.executor.inline import InlineJobExecutor
+from libertem.io.dataset.seq import SEQDataSet
+
+def test_detect_unicode_error(default_raw, lt_ctx):
+    path = default_raw._path
+    SEQDataSet.detect_params(path, InlineJobExecutor())


### PR DESCRIPTION
Exception for the following error which can be reproduced by loading a raw file:
`UnicodeDecodeError: 'utf-16-le' codec can't decode bytes in position 452-453: il
legal encoding`

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added/updated test cases