### PR TITLE
Better test to trigger UnicodeDecodeError

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -262,6 +262,24 @@ def uint16_raw(tmpdir_factory):
     yield ds
 
 
+@pytest.fixture(scope='session')
+def raw_with_zeros(tmpdir_factory):
+    datadir = tmpdir_factory.mktemp('data')
+    filename = datadir + '/raw-with-zeros'
+    data = np.zeros((16, 16, 128, 128), dtype='float32')
+    data.tofile(str(filename))
+    del data
+    ds = RawFileDataSet(
+        path=str(filename),
+        scan_size=(16, 16),
+        dtype="float32",
+        detector_size=(128, 128),
+    )
+    ds.set_num_cores(2)
+    ds = ds.initialize(InlineJobExecutor())
+    yield ds
+
+
 @pytest.fixture
 def dist_ctx():
     """

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -1,6 +1,6 @@
 from libertem.executor.inline import InlineJobExecutor
 from libertem.io.dataset.seq import SEQDataSet
 
-def test_detect_unicode_error(default_raw, lt_ctx):
-    path = default_raw._path
+def test_detect_unicode_error(raw_with_zeros, lt_ctx):
+    path = raw_with_zeros._path
     SEQDataSet.detect_params(path, InlineJobExecutor())


### PR DESCRIPTION
> The way _mk_random currently generates test data means we get only the values from the set {0.0, 1.0, 288.0, 2880.0} for default_raw. The binary representation of those float values all start with a '\x00' - so the first string value, which is at offset 4, will always be truncated to zero length and trigger the error. If we do change the function to generate values that have a larger fractional value in the binary representation (which we might want to do!), this assumption will no longer hold.

Thanks for the explanation :)

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added/updated test cases