### PR TITLE
Run LiberTEM test server in a separate event loop

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,12 +109,10 @@ class ServerThread(threading.Thread):
 
 
 @pytest.fixture(scope="function")
-async def server_port(unused_tcp_port_factory, shared_state):
+def server_port(unused_tcp_port_factory, shared_state):
     """
     start a LiberTEM API server on a unused port
     """
-    loop = asyncio.get_event_loop()
-    loop.set_debug(True)
     port = unused_tcp_port_factory()
 
     print("starting server at port {}".format(port))
@@ -124,7 +122,7 @@ async def server_port(unused_tcp_port_factory, shared_state):
     yield port
     print("stopping server at port {}".format(port))
     thread.stop_event.set()
-    thread.join(timeout=5)
+    thread.join(timeout=15)
     if thread.is_alive():
         raise RuntimeError("thread did not stop in the given timeout")
 

--- a/tests/server/test_browse.py
+++ b/tests/server/test_browse.py
@@ -3,7 +3,7 @@ import pytest
 
 from aio_utils import create_connection
 
-pytestmark = [pytest.mark.functional, pytest.mark.flaky]
+pytestmark = [pytest.mark.functional]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_cancel.py
+++ b/tests/server/test_cancel.py
@@ -11,7 +11,7 @@ from aio_utils import (
 )
 
 
-pytestmark = [pytest.mark.functional, pytest.mark.flaky]
+pytestmark = [pytest.mark.functional]
 
 
 def _get_ds_params():

--- a/tests/server/test_dataset.py
+++ b/tests/server/test_dataset.py
@@ -6,7 +6,7 @@ import websockets
 from utils import assert_msg
 from aio_utils import create_connection
 
-pytestmark = [pytest.mark.functional, pytest.mark.flaky]
+pytestmark = [pytest.mark.functional]
 
 
 def _get_raw_params(path):

--- a/tests/server/test_download.py
+++ b/tests/server/test_download.py
@@ -16,7 +16,7 @@ from libertem.io.writers.results import formats  # NOQA: F401
 from libertem.io.writers.results.base import ResultFormatRegistry
 
 
-pytestmark = [pytest.mark.functional, pytest.mark.flaky]
+pytestmark = [pytest.mark.functional]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_ds_detect.py
+++ b/tests/server/test_ds_detect.py
@@ -6,7 +6,7 @@ import websockets
 from utils import assert_msg
 from aio_utils import create_connection
 
-pytestmark = [pytest.mark.functional, pytest.mark.flaky]
+pytestmark = [pytest.mark.functional]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_job.py
+++ b/tests/server/test_job.py
@@ -10,7 +10,7 @@ from aio_utils import (
 )
 
 
-pytestmark = [pytest.mark.functional, pytest.mark.flaky]
+pytestmark = [pytest.mark.functional]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_startup.py
+++ b/tests/server/test_startup.py
@@ -8,7 +8,7 @@ from aio_utils import (
     create_connection, create_analysis, create_update_compound_analysis,
 )
 
-pytestmark = [pytest.mark.functional, pytest.mark.flaky]
+pytestmark = [pytest.mark.functional]
 
 
 def _get_raw_params(path):

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -4,7 +4,7 @@ import pytest
 from libertem.web.state import JobState, ExecutorState
 
 
-pytestmark = [pytest.mark.flaky]
+pytestmark = []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is needed to properly isolate event loops, and allows to test edge cases, for example shutting down the server.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)