### PR TITLE
Coordinate transform support for COM Analysis

### DIFF
--- a/docs/source/changelog/features/com.rst
+++ b/docs/source/changelog/features/com.rst
@@ -1,0 +1,5 @@
+[Feature] Coordinate transforms for center of mass analysis
+===========================================================
+
+* :meth:`libertem.api.Context.create_com_analysis` now allows to specify a flipped y axis
+  and a scan rotation angle to deal with MIB files and scan rotation correctly. (:issue:`325`, :pr:`786`)

--- a/docs/source/changelog/features/coordinates.rst
+++ b/docs/source/changelog/features/coordinates.rst
@@ -1,0 +1,6 @@
+[Feature] Coordinate transforms
+===============================
+
+* Infrastructure for consistent coordinate transforms are added in
+  :mod:`libertem.corrections.coordinates` and :mod:`libertem.utils`. See also a
+  description of coordinate systems in :ref:`concepts`.

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -14,6 +14,9 @@ corresponds to the batch axis in machine learning frameworks.
 
 The "detector" axes are also called "signal axes", and a single 2D image is also called a frame.
 
+Axis order
+==========
+
 We generally follow the numpy convention for axis order, so for a 4D data set,
 you could have a :code:`(ny, nx, sy, sx)` tuple describing the shape.
 
@@ -27,6 +30,33 @@ In Python, the indices increase linearly with the row. A 3x3 Python matrix is re
     [6,7,8]]
 	
 `The official "NumPy for Matlab users" documentation`_ might be helpful for Matlab users.
+
+Coordinate system
+=================
+
+LiberTEM works in pixel coordinates corresponding to array indices. That means
+(0, 0) is on the top left corner, the x axis points to the right and the y axis
+points to the bottom. This follows the usual plotting conventions for pixel
+data.
+
+LiberTEM uses a right-handed coordinate system, which means the z axis points away and positive
+rotations are therefore clock-wise.
+
+.. note::
+    Please note that the data can be saved with different relation of physical coordinates and
+    pixel coordinates. Notably, MIB reference files from Quantum Detectors Merlin cameras have their
+    y axis inverted when displayed with LiberTEM. LiberTEM generally
+    doesn't deal with such transformations in the numerical back-end.
+
+    In :meth:`~libertem.api.Context.create_com_analysis`, a capability to flip the y axis and rotate
+    the shift coordinates is added in version 0.6.0.dev0 to support processing MIB files and
+    calculate results with physical meaning in electron microscopy, such as the curl and divergence.
+    See also :issue:`325`.
+
+    Discussion regarding full support for physical units can be found in :issue:`121`.
+
+Multidimensional data
+=====================
 
 While our GUI is currently limited to 4D data sets, the Python API does not
 have that limitation. You can load data of arbitraty dimensionality, provided our I/O

--- a/src/libertem/corrections/coordinates.py
+++ b/src/libertem/corrections/coordinates.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+
+def scale(factor):
+    '''
+    .. versionadded:: 0.6.0.dev0
+    '''
+    return np.eye(2) * factor
+
+
+def rotate(radians):
+    '''
+    .. versionadded:: 0.6.0.dev0
+    '''
+    # https://en.wikipedia.org/wiki/Rotation_matrix
+    # y, x instead of x, y
+    return np.array([
+        (np.cos(radians), np.sin(radians)),
+        (-np.sin(radians), np.cos(radians))
+    ])
+
+
+def rotate_deg(degrees):
+    '''
+    .. versionadded:: 0.6.0.dev0
+    '''
+    return rotate(np.pi/180*degrees)
+
+
+def flip_y():
+    '''
+    .. versionadded:: 0.6.0.dev0
+    '''
+    return np.array([
+        (-1, 0),
+        (0, 1)
+    ])
+
+
+def flip_x():
+    '''
+    .. versionadded:: 0.6.0.dev0
+    '''
+    return np.array([
+        (1, 0),
+        (0, -1)
+    ])
+
+
+def identity():
+    '''
+    .. versionadded:: 0.6.0.dev0
+    '''
+    return np.eye(2)

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -328,13 +328,14 @@ def radial_bins(centerX, centerY, imageSizeX, imageSizeY,
     if radius_inner < 0.5:
         yy = int(np.round(centerY))
         xx = int(np.round(centerX))
-        if use_sparse:
-            index = yy * imageSizeX + xx
-            diff = 1 - slices[0][index] - radius_inner
-            patch = sparse.COO(shape=len(r), data=[diff], coords=[index])
-            slices[0] += patch
-        else:
-            slices[0][yy, xx] = 1 - radius_inner
+        if yy >= 0 and yy < imageSizeY and xx >= 0 and xx < imageSizeX:
+            if use_sparse:
+                index = yy * imageSizeX + xx
+                diff = 1 - slices[0][index] - radius_inner
+                patch = sparse.COO(shape=len(r), data=[diff], coords=[index])
+                slices[0] += patch
+            else:
+                slices[0][yy, xx] = 1 - radius_inner
     if use_sparse:
         return sparse.stack(slices).reshape((-1, imageSizeY, imageSizeX))
     else:

--- a/tests/corrections/test_coordinates.py
+++ b/tests/corrections/test_coordinates.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+import libertem.corrections.coordinates as c
+from libertem.utils import rotate_deg
+
+
+def test_scale():
+    y, x = np.random.random((2, 7))
+    factor = np.pi
+    r_y, r_x = c.scale(factor) @ (y, x)
+    assert np.allclose(r_y, y * factor)
+    assert np.allclose(r_x, x * factor)
+
+
+def test_rotate():
+    y, x = np.random.random((2, 7))
+    radians = np.pi/180*23
+    r_y, r_x = c.identity() @ c.rotate(radians) @ (y, x)
+    r_y2, r_x2 = rotate_deg(y, x, 23)
+    assert np.allclose(r_y, r_y2)
+    assert np.allclose(r_x, r_x2)
+
+
+def test_rotate_deg():
+    y, x = np.random.random((2, 7))
+    degrees = 23
+    r_y, r_x = c.rotate_deg(degrees) @ (y, x)
+    r_y2, r_x2 = rotate_deg(y, x, degrees)
+    assert np.allclose(r_y, r_y2)
+    assert np.allclose(r_x, r_x2)
+
+
+def test_flip_y():
+    y, x = np.random.random((2, 7))
+    r_y, r_x = c.flip_y() @ (y, x)
+    assert np.allclose(r_y, -y)
+    assert np.allclose(r_x, x)
+
+
+def test_flip_x():
+    y, x = np.random.random((2, 7))
+    r_y, r_x = c.flip_x() @ (y, x)
+    assert np.allclose(r_y, y)
+    assert np.allclose(r_x, -x)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,50 @@ def test_conversion(points):
     assert(np.allclose(points, ut.make_cartesian(ut.make_polar(points))))
 
 
+def test_rotation():
+    y, x = -1, 2
+    r_y, r_x = ut.rotate_deg(y, x, 90)
+    # Clock-wise with y pointing down
+    assert np.allclose(r_y, 2)
+    assert np.allclose(r_x, 1)
+
+
+def test_rotate_multi():
+    y, x = np.random.random(2) - 0.5
+    angle = 30
+    cos_angle = np.cos(np.pi*angle/180)
+    sin_angle = np.sin(np.pi*angle/180)
+    assert 360 % angle == 0
+    r_y = y
+    r_x = x
+    for i in range(360//angle):
+        r_y2, r_x2 = ut.rotate_deg(
+            y=r_y,
+            x=r_x,
+            degrees=angle
+        )
+        r_y, r_x = ut.rotate_precalc(
+            y=r_y,
+            x=r_x,
+            cos_angle=cos_angle,
+            sin_angle=sin_angle
+        )
+        assert np.allclose(r_y, r_y2)
+        assert np.allclose(r_x, r_x2)
+    print(r_y, r_x)
+    assert np.allclose(r_y, y)
+    assert np.allclose(r_x, x)
+
+
+def test_polar_rotate():
+    y, x, radians = np.random.random(3)
+    ((r, phi),) = ut.make_polar(np.array([(y, x)]))
+    ((r_y, r_x),) = ut.make_cartesian(np.array([(r, phi + radians)]))
+    r_y2, r_x2 = ut.rotate_rad(y, x, radians)
+    assert np.allclose(r_y, r_y2)
+    assert np.allclose(r_x, r_x2)
+
+
 @pytest.mark.parametrize('counts, sampling, visibility, f_angle, gauss, poisson, rtol1, rtol2',
                          [(None, None, None, None, None, None, 1e-5, 2e-2),
                           (500., 6.2, 0.5, 66., 0.7, 1e-4, 6e-2, .3)])


### PR DESCRIPTION
Replaces #789 as a clean version

* Support flipping y axis (MIB) and adjusting scan rotation in COM analysis. Refs #325 #121
* Set of validated functions to do transformations, for consistent use within LiberTEM
* Additional description in concepts.rst
* Allow center outside of field of view for radial_bins

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
