### PR TITLE
Allow running on a vanilla Dask cluster like before

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -66,8 +66,9 @@ LiberTEM can connect to a running dask cluster. To start a cluster, first run a 
 
     (libertem) $ dask-scheduler --host localhost
 
-LiberTEM requires specific resource tags and environment settings on the dask workers.
-The easiest way to start workers with the appropriate settings is
+GPU support in LiberTEM requires specific resource tags and environment settings
+on the dask workers. The easiest way to start workers with the appropriate
+settings is
 
 .. code-block:: shell
 


### PR DESCRIPTION
Makes it easier to integrate LiberTEM in existing clusters
Limits execution to CPU only

CC @jhgee probably relevant for easily running in ipyparallel through https://ipyparallel.readthedocs.io/en/latest/api/ipyparallel.html#ipyparallel.Client.become_distributed

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
