### PR TITLE
Make sure correction handles integer input data correctly

### DIFF
--- a/benchmarks/corrections/test_corrset.py
+++ b/benchmarks/corrections/test_corrset.py
@@ -21,8 +21,12 @@ from libertem.corrections import CorrectionSet
         np.array([
             range(1024),
             range(1024),
+        ]),
+        # Column that prevents tiling in one dimension
+        np.array([
+            range(1024),
+            np.full(1024, 3),
         ])
-
     )
 )
 def test_tileshape_adjustment_bench(benchmark, base_shape, excluded_coords):

--- a/benchmarks/corrections/test_corrset.py
+++ b/benchmarks/corrections/test_corrset.py
@@ -1,0 +1,24 @@
+import numpy as np
+import sparse
+
+from libertem.corrections import CorrectionSet
+
+
+def test_tileshape_adjustment_bench(benchmark):
+    sig_shape = (1014, 1024)
+    tile_shape = (1, 1)
+    base_shape = (1, 1)
+    # These magic numbers are "worst case" to produce collisions
+    # 2*3*4*5*6*7
+    excluded_coords = np.array([
+        (720, 210, 306),
+        (120, 210, 210)
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = benchmark(
+        corr.adjust_tileshape,
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
+    print(adjusted)
+    assert adjusted != (1014, 1024)

--- a/benchmarks/corrections/test_corrset.py
+++ b/benchmarks/corrections/test_corrset.py
@@ -1,24 +1,39 @@
 import numpy as np
 import sparse
 
+import pytest
+
 from libertem.corrections import CorrectionSet
 
 
-def test_tileshape_adjustment_bench(benchmark):
+@pytest.mark.parametrize(
+    "base_shape", ((1, 1), (2, 2))
+)
+@pytest.mark.parametrize(
+    "excluded_coords", (
+        # These magic numbers are "worst case" to produce collisions
+        # 2*3*4*5*6*7
+        np.array([
+            (720, 210, 306),
+            (120, 210, 210)
+        ]),
+        # Diagonal that prevents any tiling
+        np.array([
+            range(1024),
+            range(1024),
+        ])
+
+    )
+)
+def test_tileshape_adjustment_bench(benchmark, base_shape, excluded_coords):
     sig_shape = (1014, 1024)
-    tile_shape = (1, 1)
-    base_shape = (1, 1)
-    # These magic numbers are "worst case" to produce collisions
-    # 2*3*4*5*6*7
-    excluded_coords = np.array([
-        (720, 210, 306),
-        (120, 210, 210)
-    ])
+    tile_shape = base_shape
     excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
     corr = CorrectionSet(excluded_pixels=excluded_pixels)
     adjusted = benchmark(
         corr.adjust_tileshape,
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
-    print(adjusted)
-    assert adjusted != (1014, 1024)
+    print("Base shape", base_shape)
+    print("Excluded coords", excluded_coords)
+    print("Adjusted", adjusted)

--- a/benchmarks/test_smoke.py
+++ b/benchmarks/test_smoke.py
@@ -1,0 +1,24 @@
+import pytest
+import numba
+
+first = False
+
+@numba.njit
+def hello():
+    return "world"
+
+
+@pytest.mark.compilation
+@pytest.mark.benchmark(
+    group="compilation"
+)
+def test_numba_compilation(benchmark):
+    benchmark.extra_info["mark"] = "compilation"
+    benchmark.pedantic(hello, warmup_rounds=0, rounds=2, iterations=1)
+
+
+@pytest.mark.benchmark(
+    group="smoke"
+)
+def test_numba_performance(benchmark):
+    benchmark(hello)

--- a/benchmarks/test_smoke.py
+++ b/benchmarks/test_smoke.py
@@ -1,7 +1,6 @@
 import pytest
 import numba
 
-first = False
 
 @numba.njit
 def hello():

--- a/docs/source/changelog/features/corrections.rst
+++ b/docs/source/changelog/features/corrections.rst
@@ -1,5 +1,5 @@
 [Feature] configurable corrections
 ==================================
 
-* Corrections can now be specified by the user when running a UDF (:pr:`778`) 
+* Corrections can now be specified by the user when running a UDF (:pr:`778,831`) 
 * Support for loading dark frame and gaim map that are sometimes shipped with SEQ data sets

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,8 @@ setup(
         # FIXME remove in 0.7.0 after blobfinder deprecation
         # Ensure compatibility with numba>=0.50
         'libertem-blobfinder>=0.4.1',
-        'threadpoolctl'
+        'threadpoolctl',
+        'primesieve'
     ],
     extras_require={
         'torch': 'torch',

--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -137,7 +137,6 @@ class COMAnalysis(BaseMasksAnalysis):
             transform = identity()
         # Transformations are applied right to left
         transform = rotate_deg(self.parameters["scan_rotation"]) @ transform
-        print("Transform:", transform)
         y_centers, x_centers = transform @ (y_centers_raw.reshape(-1), x_centers_raw.reshape(-1))
 
         y_centers = y_centers.reshape(shape)

--- a/src/libertem/corrections/corrset.py
+++ b/src/libertem/corrections/corrset.py
@@ -24,10 +24,10 @@ def factorizations(n, primes):
 
 def min_disjunct_multiplier(excluded, size):
     '''
-    Calculate minimum integer i for which i * n not in "excluded" for any n > 0
+    Calculate a small integer i for which i * n not in "excluded" for any n > 0
 
     To make sure that the tile shape negotiation retains as much flexibility as possible,
-    it is important to find the smallest integer and not just any integer that fulfills
+    it is important to find a small integer and not just any integer that fulfills
     this condition.
     '''
     # This is guaranteed to include "size" for realistic dimension sizes

--- a/src/libertem/corrections/corrset.py
+++ b/src/libertem/corrections/corrset.py
@@ -134,7 +134,6 @@ class CorrectionSet:
         # swith to full frames while preserving tile size if possible.
         # FIXME may have to be adjusted to be balenced to real data and excluded pixel
         # incidence
-        # FIXME benchmark to gauge performance impact
         for repeat in range(32):
             clean = True
             for dim in range(0, len(adjusted_shape)):

--- a/src/libertem/corrections/corrset.py
+++ b/src/libertem/corrections/corrset.py
@@ -23,9 +23,25 @@ def factorizations(n, primes):
 
 
 def min_disjunct_multiplier(excluded, size):
-    # Unless size => inf, this is guaranteed to include "size"
+    '''
+    Calculate minimum integer i for which i * n not in "excluded" for any n > 0
+
+    To make sure that the tile shape negotiation retains as much flexibility as possible,
+    it is important to find the smallest integer and not just any integer that fulfills
+    this condition.
+    '''
+    # This is guaranteed to include "size" for realistic dimension sizes
     primes = np.array(primesieve.primes(size*2))
     if len(excluded):
+        # If two integers are equal, their prime factor decompositions
+        # are equal, too.
+        # We find the global maximum power for each of the prime factors
+        # that construct the elements of "excluded".
+        # By choosing a number that has one power more, we make sure
+        # that multiples of that number can never be equal to one of the excluded
+        # elements: The prime factor decompositions of any multiple of that number
+        # will always contain that additional power and thus never be equal the prime
+        # factor decomposition of an excluded pixel.
         fac = factorizations(np.array(excluded), primes)
         ceiling = primes ** (np.max(fac, axis=0) + 1)
         return int(np.min(ceiling))

--- a/src/libertem/corrections/corrset.py
+++ b/src/libertem/corrections/corrset.py
@@ -132,8 +132,6 @@ class CorrectionSet:
         # This may fail in case of many excluded pixels or full excluded rows/columns,
         # depending on the tiling scheme. In that case,
         # swith to full frames while preserving tile size if possible.
-        # FIXME may have to be adjusted to be balenced to real data and excluded pixel
-        # incidence
         for repeat in range(32):
             clean = True
             for dim in range(0, len(adjusted_shape)):
@@ -143,10 +141,12 @@ class CorrectionSet:
                 # Nothing to adjust, could trip downstream logic
                 if stop <= 1:
                     continue
-                if step == 1:
+                if step == 1 and base_shape[dim] == 1:
                     forbidden = np.concatenate((excluded_list[dim], excluded_list[dim] + 1))
+                    forbidden = forbidden[forbidden < stop]
                     nonzero_filter = forbidden != 0
                     m = min(stop, min_disjunct_multiplier(forbidden[nonzero_filter], stop))
+                    # In case we have a zero where the existing logic doesn't work
                     if not np.all(nonzero_filter):
                         m = max(m, 2)
                     if adjusted_shape[dim] != m:

--- a/src/libertem/corrections/detector.py
+++ b/src/libertem/corrections/detector.py
@@ -181,9 +181,12 @@ def correct(
     nav_shape = s[0:-len(sig_shape)]
 
     if inplace:
+        if buffer.dtype.kind not in ('f', 'c'):
+            raise TypeError("In-place correction only supported for floating point data.")
         out = buffer
     else:
-        out = buffer.copy()
+        # astype() is always a copy even if it is the same dtype
+        out = buffer.astype(np.result_type(np.float32, buffer))
 
     if excluded_pixels is None:
         excluded_pixels = np.zeros((len(sig_shape), 0), dtype=np.int)

--- a/src/libertem/corrections/detector.py
+++ b/src/libertem/corrections/detector.py
@@ -134,10 +134,8 @@ def flatten_filter(excluded_pixels, repairs, sig_shape):
 
 
 def correct(
-    buffer,
-    dark_image=None, gain_map=None, excluded_pixels=None,
-    inplace=False, sig_shape=None,
-):
+        buffer, dark_image=None, gain_map=None, excluded_pixels=None,
+        inplace=False, sig_shape=None):
     '''
     Function to perform detector corrections
 

--- a/src/libertem/io/dataset/base/backend.py
+++ b/src/libertem/io/dataset/base/backend.py
@@ -147,7 +147,7 @@ class LocalFSMMapBackend(IOBackend):
         _r_n_d_cache[key] = r_n_d
         return r_n_d
 
-    def preprocess(self, data, tile_slice, decoder):
+    def preprocess(self, data, tile_slice):
         if self._corrections is None:
             return
         self._corrections.apply(data, tile_slice)
@@ -204,7 +204,7 @@ class LocalFSMMapBackend(IOBackend):
                     shape=Shape(shape, sig_dims=sig_dims)
                 )
                 data = data.reshape(shape)
-                self.preprocess(data, tile_slice, decoder)
+                self.preprocess(data, tile_slice)
                 yield DataTile(
                     data,
                     tile_slice=tile_slice,

--- a/src/libertem/io/dataset/base/partition.py
+++ b/src/libertem/io/dataset/base/partition.py
@@ -105,6 +105,10 @@ class Partition(object):
         raise NotImplementedError()
 
     def adjust_tileshape(self, tileshape):
+        """
+        Final veto of the Partition in the tileshape negotiation process,
+        make sure that corrections are taken into account!
+        """
         raise NotImplementedError()
 
     def get_locations(self):

--- a/src/libertem/io/dataset/memory.py
+++ b/src/libertem/io/dataset/memory.py
@@ -50,11 +50,15 @@ class MemBackend(LocalFSMMapBackend):
             # support arbitrary tiling in case of no roi
             with fileset:
                 for tile in self._get_tiles_straight(tiling_scheme, fileset, read_ranges):
-                    yield tile.astype(read_dtype)
+                    data = tile.astype(read_dtype)
+                    self.preprocess(data, tile.tile_slice)
+                    yield data
         else:
             with fileset:
                 for tile in self._get_tiles_roi(tiling_scheme, fileset, read_ranges, roi):
-                    yield tile.astype(read_dtype)
+                    data = tile.astype(read_dtype)
+                    self.preprocess(data, tile.tile_slice)
+                    yield data
 
 
 class MemDatasetParams(MessageConverter):
@@ -228,7 +232,7 @@ class MemPartition(BasePartition):
         return None
 
     def _get_io_backend(self):
-        return MemBackend(decoder=self._get_decoder())
+        return MemBackend(decoder=self._get_decoder(), corrections=self._corrections)
 
     def get_macrotile(self, *args, **kwargs):
         self._force_tileshape = False

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -237,9 +237,10 @@ class SERPartition(BasePartition):
                 data, metadata = f.getDataset(int(idx))
                 if data.dtype != np.dtype(dest_dtype):
                     data = data.astype(dest_dtype)
+                data = data.reshape(shape)
                 self._preprocess(data, tile_slice)
                 yield DataTile(
-                    data.reshape(shape),
+                    data,
                     tile_slice=tile_slice,
                     scheme_idx=0,
                 )

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -212,6 +212,11 @@ class SERPartition(BasePartition):
     def get_base_shape(self):
         return (1,) + tuple(self.shape.sig)
 
+    def _preprocess(self, tile_data, tile_slice):
+        if self._corrections is None:
+            return
+        self._corrections.apply(tile_data, tile_slice)
+
     def get_tiles(self, tiling_scheme, dest_dtype="float32", roi=None):
         shape = Shape((1,) + tuple(self.shape.sig), sig_dims=self.shape.sig.dims)
 
@@ -232,6 +237,7 @@ class SERPartition(BasePartition):
                 data, metadata = f.getDataset(int(idx))
                 if data.dtype != np.dtype(dest_dtype):
                     data = data.astype(dest_dtype)
+                self._preprocess(data, tile_slice)
                 yield DataTile(
                     data.reshape(shape),
                     tile_slice=tile_slice,

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -964,6 +964,7 @@ class UDFRunner:
             partition=partition,
             read_dtype=dtype,
             roi=roi,
+            corrections=corrections,
         )
 
         # FIXME: don't fully re-create?

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -914,8 +914,11 @@ class UDFRunner:
         self._udfs = udfs
         self._debug = debug
 
-    def _get_dtype(self, dtype):
-        tmp_dtype = dtype
+    def _get_dtype(self, dtype, corrections):
+        if corrections is not None:
+            tmp_dtype = np.result_type(np.float32, dtype)
+        else:
+            tmp_dtype = dtype
         for udf in self._udfs:
             tmp_dtype = np.result_type(
                 udf.get_preferred_input_dtype(),
@@ -924,7 +927,7 @@ class UDFRunner:
         return tmp_dtype
 
     def _init_udfs(self, numpy_udfs, cupy_udfs, partition, roi, corrections, device_class):
-        dtype = self._get_dtype(partition.dtype)
+        dtype = self._get_dtype(partition.dtype, corrections)
         meta = UDFMeta(
             partition_shape=partition.slice.adjust_for_roi(roi).shape,
             dataset_shape=partition.meta.shape,
@@ -1113,7 +1116,7 @@ class UDFRunner:
             dataset_shape=dataset.shape,
             roi=roi,
             dataset_dtype=dataset.dtype,
-            input_dtype=self._get_dtype(dataset.dtype),
+            input_dtype=self._get_dtype(dataset.dtype, corrections),
             corrections=corrections,
         )
         for udf in self._udfs:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -915,7 +915,7 @@ class UDFRunner:
         self._debug = debug
 
     def _get_dtype(self, dtype, corrections):
-        if corrections is not None:
+        if corrections is not None and corrections.have_corrections():
             tmp_dtype = np.result_type(np.float32, dtype)
         else:
             tmp_dtype = dtype

--- a/tests/corrections/test_corrset.py
+++ b/tests/corrections/test_corrset.py
@@ -65,3 +65,82 @@ def test_patch_pixels_only_excluded_pixels(lt_ctx, default_raw, default_raw_data
         corrections=corr
     )
     assert np.allclose(res['intensity'], np.sum(default_raw_data, axis=(0, 1)))
+
+
+def test_tileshape_adjustment_1():
+    sig_shape = (123, 456)
+    tile_shape = (23, 17, 42)
+    excluded_coords = np.array([
+        (17, ),
+        (42, )
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    assert adjusted == (23, 16, 41)
+
+
+def test_tileshape_adjustment_2():
+    sig_shape = (123, 456)
+    tile_shape = (23, 17, 42)
+    excluded_coords = np.array([
+        (17*2 - 1, ),
+        (42, )
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    assert adjusted == (23, 15, 41)
+
+
+def test_tileshape_adjustment_3():
+    sig_shape = (123, 456)
+    tile_shape = (23, 17, 42)
+    excluded_coords = np.array([
+        (122, ),
+        (23, )
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    assert adjusted == (23, 17, 42)
+
+
+def test_tileshape_adjustment_4():
+    sig_shape = (123, 456)
+    tile_shape = (23, 17, 1)
+    excluded_coords = np.array([
+        (122, ),
+        (0, )
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    assert adjusted == (23, 17, 2)
+
+
+def test_tileshape_adjustment_5():
+    sig_shape = (123, 1)
+    tile_shape = (23, 17, 1)
+    excluded_coords = np.array([
+        (122, ),
+        (0, )
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    assert adjusted == (23, 17, 1)
+
+
+def test_tileshape_adjustment_6():
+    sig_shape = (123, 456)
+    tile_shape = (23, 17, 1)
+    excluded_coords = np.array([
+        range(123),
+        np.zeros(123, dtype=int)
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    # Switch to full frames since there's no tiling solution
+    assert adjusted == (1, 123, 456)

--- a/tests/corrections/test_corrset.py
+++ b/tests/corrections/test_corrset.py
@@ -178,3 +178,22 @@ def test_tileshape_adjustment_7():
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
     assert adjusted == (21, 41)
+
+
+def test_tileshape_adjustment_8():
+    sig_shape = (1014, 1024)
+    tile_shape = (1, 1)
+    base_shape = (1, 1)
+    # These magic numbers are "worst case" to produce collisions
+    # 2*3*4*5*6*7
+    excluded_coords = np.array([
+        (720, 210, 306),
+        (120, 210, 210)
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
+    print(adjusted)
+    assert adjusted != (1014, 1024)

--- a/tests/corrections/test_corrset.py
+++ b/tests/corrections/test_corrset.py
@@ -70,77 +70,111 @@ def test_patch_pixels_only_excluded_pixels(lt_ctx, default_raw, default_raw_data
 def test_tileshape_adjustment_1():
     sig_shape = (123, 456)
     tile_shape = (23, 17, 42)
+    base_shape = (1, 1, 1)
     excluded_coords = np.array([
         (17, ),
         (42, )
     ])
     excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
     corr = CorrectionSet(excluded_pixels=excluded_pixels)
-    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
     assert adjusted == (23, 16, 41)
 
 
 def test_tileshape_adjustment_2():
     sig_shape = (123, 456)
     tile_shape = (23, 17, 42)
+    base_shape = (1, 1, 1)
     excluded_coords = np.array([
         (17*2 - 1, ),
         (42, )
     ])
     excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
     corr = CorrectionSet(excluded_pixels=excluded_pixels)
-    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
     assert adjusted == (23, 15, 41)
 
 
 def test_tileshape_adjustment_3():
     sig_shape = (123, 456)
     tile_shape = (23, 17, 42)
+    base_shape = (1, 1, 1)
     excluded_coords = np.array([
         (122, ),
         (23, )
     ])
     excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
     corr = CorrectionSet(excluded_pixels=excluded_pixels)
-    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
     assert adjusted == (23, 17, 42)
 
 
 def test_tileshape_adjustment_4():
     sig_shape = (123, 456)
     tile_shape = (23, 17, 1)
+    base_shape = (1, 1, 1)
     excluded_coords = np.array([
         (122, ),
         (0, )
     ])
     excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
     corr = CorrectionSet(excluded_pixels=excluded_pixels)
-    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
     assert adjusted == (23, 17, 2)
 
 
 def test_tileshape_adjustment_5():
     sig_shape = (123, 1)
     tile_shape = (23, 17, 1)
+    base_shape = (1, 1, 1)
     excluded_coords = np.array([
         (122, ),
         (0, )
     ])
     excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
     corr = CorrectionSet(excluded_pixels=excluded_pixels)
-    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
     assert adjusted == (23, 17, 1)
 
 
 def test_tileshape_adjustment_6():
     sig_shape = (123, 456)
     tile_shape = (23, 17, 1)
+    base_shape = (1, 1, 1)
     excluded_coords = np.array([
-        range(123),
+        (range(123)),
         np.zeros(123, dtype=int)
     ])
     excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
     corr = CorrectionSet(excluded_pixels=excluded_pixels)
-    adjusted = corr.adjust_tileshape(tile_shape=tile_shape, sig_shape=sig_shape)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
     # Switch to full frames since there's no tiling solution
     assert adjusted == (1, 123, 456)
+
+
+def test_tileshape_adjustment_7():
+    sig_shape = (123, 456)
+    tile_shape = (23, 14, 42)
+    base_shape = (1, 7, 1)
+    excluded_coords = np.array([
+        (14, ),
+        (42, )
+    ])
+    excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
+    corr = CorrectionSet(excluded_pixels=excluded_pixels)
+    adjusted = corr.adjust_tileshape(
+        tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
+    )
+    assert adjusted == (23, 21, 41)

--- a/tests/corrections/test_corrset.py
+++ b/tests/corrections/test_corrset.py
@@ -69,8 +69,8 @@ def test_patch_pixels_only_excluded_pixels(lt_ctx, default_raw, default_raw_data
 
 def test_tileshape_adjustment_1():
     sig_shape = (123, 456)
-    tile_shape = (23, 17, 42)
-    base_shape = (1, 1, 1)
+    tile_shape = (17, 42)
+    base_shape = (1, 1)
     excluded_coords = np.array([
         (17, ),
         (42, )
@@ -80,13 +80,13 @@ def test_tileshape_adjustment_1():
     adjusted = corr.adjust_tileshape(
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
-    assert adjusted == (23, 16, 41)
+    assert adjusted == (16, 41)
 
 
 def test_tileshape_adjustment_2():
     sig_shape = (123, 456)
-    tile_shape = (23, 17, 42)
-    base_shape = (1, 1, 1)
+    tile_shape = (17, 42)
+    base_shape = (1, 1)
     excluded_coords = np.array([
         (17*2 - 1, ),
         (42, )
@@ -96,13 +96,13 @@ def test_tileshape_adjustment_2():
     adjusted = corr.adjust_tileshape(
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
-    assert adjusted == (23, 15, 41)
+    assert adjusted == (15, 41)
 
 
 def test_tileshape_adjustment_3():
     sig_shape = (123, 456)
-    tile_shape = (23, 17, 42)
-    base_shape = (1, 1, 1)
+    tile_shape = (17, 42)
+    base_shape = (1, 1)
     excluded_coords = np.array([
         (122, ),
         (23, )
@@ -112,13 +112,13 @@ def test_tileshape_adjustment_3():
     adjusted = corr.adjust_tileshape(
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
-    assert adjusted == (23, 17, 42)
+    assert adjusted == (17, 42)
 
 
 def test_tileshape_adjustment_4():
     sig_shape = (123, 456)
-    tile_shape = (23, 17, 1)
-    base_shape = (1, 1, 1)
+    tile_shape = (17, 1)
+    base_shape = (1, 1)
     excluded_coords = np.array([
         (122, ),
         (0, )
@@ -128,13 +128,13 @@ def test_tileshape_adjustment_4():
     adjusted = corr.adjust_tileshape(
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
-    assert adjusted == (23, 17, 2)
+    assert adjusted == (17, 2)
 
 
 def test_tileshape_adjustment_5():
     sig_shape = (123, 1)
-    tile_shape = (23, 17, 1)
-    base_shape = (1, 1, 1)
+    tile_shape = (17, 1)
+    base_shape = (1, 1)
     excluded_coords = np.array([
         (122, ),
         (0, )
@@ -144,13 +144,13 @@ def test_tileshape_adjustment_5():
     adjusted = corr.adjust_tileshape(
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
-    assert adjusted == (23, 17, 1)
+    assert adjusted == (17, 1)
 
 
 def test_tileshape_adjustment_6():
     sig_shape = (123, 456)
-    tile_shape = (23, 17, 1)
-    base_shape = (1, 1, 1)
+    tile_shape = (17, 1)
+    base_shape = (1, 1)
     excluded_coords = np.array([
         (range(123)),
         np.zeros(123, dtype=int)
@@ -161,13 +161,13 @@ def test_tileshape_adjustment_6():
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
     # Switch to full frames since there's no tiling solution
-    assert adjusted == (1, 123, 456)
+    assert adjusted == (123, 456)
 
 
 def test_tileshape_adjustment_7():
     sig_shape = (123, 456)
-    tile_shape = (23, 14, 42)
-    base_shape = (1, 7, 1)
+    tile_shape = (14, 42)
+    base_shape = (7, 1)
     excluded_coords = np.array([
         (14, ),
         (42, )
@@ -177,4 +177,4 @@ def test_tileshape_adjustment_7():
     adjusted = corr.adjust_tileshape(
         tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
     )
-    assert adjusted == (23, 21, 41)
+    assert adjusted == (21, 41)

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -136,6 +136,7 @@ def test_correction(default_blo, lt_ctx, with_roi):
     else:
         roi = None
 
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx, exclude=[(55, 92), (61, 31)])
     dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -12,6 +12,8 @@ from libertem.io.dataset.blo import BloDataSet
 from libertem.io.dataset.base import TilingScheme
 from libertem.common import Shape
 
+from utils import dataset_correction_verification
+
 BLO_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'default.blo')
 HAVE_BLO_TESTDATA = os.path.exists(BLO_TESTDATA_PATH)
 
@@ -120,6 +122,21 @@ def test_pick_analysis(default_blo, lt_ctx, TYPE):
     analysis.TYPE = TYPE
     results = lt_ctx.run(analysis)
     assert results[0].raw_data.shape == (144, 144)
+
+
+@pytest.mark.parametrize(
+    "with_roi", (True, False)
+)
+def test_correction(default_blo, lt_ctx, with_roi):
+    ds = default_blo
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 
 def test_cache_key_json_serializable(default_blo):

--- a/tests/io/datasets/test_cluster_ds.py
+++ b/tests/io/datasets/test_cluster_ds.py
@@ -7,6 +7,9 @@ import numpy as np
 from libertem.io.dataset.base import PartitionStructure, DataSetException
 from libertem.io.dataset.cluster import ClusterDataSet
 
+# FIXME test on actual data structure, including correction
+# from utils import dataset_correction_verification
+
 
 @pytest.fixture(scope='function')
 def draw_directory(tmpdir_factory):

--- a/tests/io/datasets/test_dm.py
+++ b/tests/io/datasets/test_dm.py
@@ -7,6 +7,8 @@ import pytest
 
 from libertem.io.dataset.dm import DMDataSet
 
+from utils import dataset_correction_verification
+
 
 DM_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'dm')
 HAVE_DM_TESTDATA = os.path.exists(DM_TESTDATA_PATH)
@@ -37,6 +39,21 @@ def test_read_roi(default_dm, lt_ctx):
     sha1 = hashlib.sha1()
     sha1.update(sumres.intensity.raw_data)
     assert sha1.hexdigest() == "e94ed671e20ccce33d288fbcadd0f54691a29b9c"
+
+
+@pytest.mark.parametrize(
+    "with_roi", (True, False)
+)
+def test_correction(default_dm, lt_ctx, with_roi):
+    ds = default_dm
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 
 def test_detect_1(lt_ctx):

--- a/tests/io/datasets/test_empad.py
+++ b/tests/io/datasets/test_empad.py
@@ -14,6 +14,8 @@ from libertem.io.dataset.empad import EMPADDataSet
 from libertem.common import Slice, Shape
 from utils import _mk_random
 
+from utils import dataset_correction_verification
+
 EMPAD_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'EMPAD')
 EMPAD_RAW = os.path.join(EMPAD_TESTDATA_PATH, 'scan_11_x4_y4.raw')
 EMPAD_XML = os.path.join(EMPAD_TESTDATA_PATH, 'acquisition_12_pretty.xml')
@@ -152,6 +154,21 @@ def test_pick_analysis(default_empad, lt_ctx, TYPE):
     results = lt_ctx.run(analysis)
     assert results[0].raw_data.shape == (128, 128)
     assert np.count_nonzero(results[0].raw_data) > 0
+
+
+@pytest.mark.parametrize(
+    "with_roi", (True, False)
+)
+def test_correction(default_empad, lt_ctx, with_roi):
+    ds = default_empad
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 
 def test_invalid_size():

--- a/tests/io/datasets/test_frms6.py
+++ b/tests/io/datasets/test_frms6.py
@@ -14,6 +14,8 @@ from libertem.io.dataset.base import TilingScheme
 from libertem.common import Shape
 from libertem.udf.raw import PickUDF
 
+from utils import dataset_correction_verification
+
 FRMS6_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..',
                                  'data', 'frms6', 'C16_15_24_151203_019.hdr')
 HAVE_FRMS6_TESTDATA = os.path.exists(FRMS6_TESTDATA_PATH)
@@ -78,6 +80,22 @@ def test_pick_analysis(default_frms6, lt_ctx, TYPE):
     analysis.TYPE = TYPE
     results = lt_ctx.run(analysis)
     assert results[0].raw_data.shape == (264, 264)
+
+
+@pytest.mark.parametrize(
+    # Default is too large for test without ROI
+    "with_roi", (True, )
+)
+def test_correction(default_frms6, lt_ctx, with_roi):
+    ds = default_frms6
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 
 def test_pickle_is_small(default_frms6):

--- a/tests/io/datasets/test_hdf5.py
+++ b/tests/io/datasets/test_hdf5.py
@@ -15,6 +15,7 @@ from libertem.io.dataset.base import TilingScheme
 from libertem.common import Shape
 
 from utils import _naive_mask_apply, _mk_random, PixelsumUDF
+from utils import dataset_correction_verification
 
 
 @pytest.mark.parametrize(
@@ -69,6 +70,21 @@ def test_hdf5_5d_apply_masks(lt_ctx, hdf5_ds_5d):
         results.mask_0.raw_data,
         expected
     )
+
+
+@pytest.mark.parametrize(
+    "with_roi", (True, False)
+)
+def test_correction(hdf5_ds_1, lt_ctx, with_roi):
+    ds = hdf5_ds_1
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 
 def test_read_1(lt_ctx, hdf5):

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -14,6 +14,8 @@ from libertem.udf import UDF
 from libertem.io.dataset.base import TilingScheme
 from libertem.common import Shape
 
+from utils import dataset_correction_verification
+
 K2IS_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..',
                                   'data', 'Capture52', 'Capture52_.gtg')
 HAVE_K2IS_TESTDATA = os.path.exists(K2IS_TESTDATA_PATH)
@@ -179,6 +181,22 @@ def test_pick_analysis(default_k2is, lt_ctx, TYPE):
     analysis.TYPE = TYPE
     results = lt_ctx.run(analysis)
     assert results[0].raw_data.shape == (1860, 2048)
+
+
+@pytest.mark.parametrize(
+    # Default is too large for test without ROI
+    "with_roi", (True, )
+)
+def test_correction(default_k2is, lt_ctx, with_roi):
+    ds = default_k2is
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 
 def test_dataset_is_picklable(default_k2is):

--- a/tests/io/datasets/test_mem.py
+++ b/tests/io/datasets/test_mem.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 
 from libertem.io.dataset.memory import MemoryDataSet
 
 from utils import _mk_random
+from utils import dataset_correction_verification
 
 
 def test_get_macrotile():
@@ -16,3 +18,23 @@ def test_get_macrotile():
     p = next(dataset.get_partitions())
     mt = p.get_macrotile()
     assert tuple(mt.shape) == (128, 16, 16)
+
+
+@pytest.mark.parametrize(
+    "with_roi", (True, False)
+)
+def test_correction(lt_ctx, with_roi):
+    data = _mk_random(size=(16, 16, 16, 16))
+    ds = MemoryDataSet(
+        data=data,
+        tileshape=(16, 16, 16),
+        num_partitions=2,
+    )
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -14,6 +14,8 @@ from libertem.analysis.raw import PickFrameAnalysis
 from libertem.common import Slice, Shape
 from libertem.io.dataset.base import TilingScheme
 
+from utils import dataset_correction_verification
+
 MIB_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'default.mib')
 HAVE_MIB_TESTDATA = os.path.exists(MIB_TESTDATA_PATH)
 
@@ -169,6 +171,21 @@ def test_pick_analysis(default_mib, lt_ctx, TYPE):
     analysis.TYPE = TYPE
     results = lt_ctx.run(analysis)
     assert results[0].raw_data.shape == (256, 256)
+
+
+@pytest.mark.parametrize(
+    "with_roi", (True, False)
+)
+def test_correction(default_mib, lt_ctx, with_roi):
+    ds = default_mib
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 
 @pytest.mark.with_numba

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -184,7 +184,7 @@ def test_correction(default_mib, lt_ctx, with_roi):
         roi[:1] = True
     else:
         roi = None
-
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx, exclude=[(45, 144), (124, 30)])
     dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)
 
 

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -1,6 +1,10 @@
 from libertem.executor.inline import InlineJobExecutor
 from libertem.io.dataset.seq import SEQDataSet
 
+# from utils import dataset_correction_verification
+# FIXME test with actual test file
+
+
 def test_detect_unicode_error(raw_with_zeros, lt_ctx):
     path = raw_with_zeros._path
     SEQDataSet.detect_params(path, InlineJobExecutor())

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -7,6 +7,8 @@ from libertem.udf.sum import SumUDF
 from libertem.io.dataset.base import TilingScheme
 from libertem.common import Shape
 
+from utils import dataset_correction_verification
+
 SER_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'default.ser')
 HAVE_SER_TESTDATA = os.path.exists(SER_TESTDATA_PATH)
 
@@ -75,3 +77,18 @@ def test_with_udf(lt_ctx):
             result[tile.tile_slice.get(sig_only=True)] += np.sum(tile.data, axis=0)
 
     assert np.allclose(udf_results['intensity'].data, result)
+
+
+@pytest.mark.parametrize(
+    "with_roi", (True, False)
+)
+def test_correction(lt_ctx, with_roi):
+    ds = lt_ctx.load("ser", path=SER_TESTDATA_PATH)
+
+    if with_roi:
+        roi = np.zeros(ds.shape.nav, dtype=bool)
+        roi[:1] = True
+    else:
+        roi = None
+
+    dataset_correction_verification(ds=ds, roi=roi, lt_ctx=lt_ctx)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,7 +141,7 @@ class DebugDeviceUDF(UDF):
 
 
 def dataset_correction_verification(ds, roi, lt_ctx):
-    for i in range(10):
+    for i in range(1):
         shape = (-1, *tuple(ds.shape.sig))
         uncorr = CorrectionSet()
         data = lt_ctx.run_udf(udf=PickUDF(), dataset=ds, roi=roi, corrections=uncorr)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -174,24 +174,11 @@ def dataset_correction_verification(ds, roi, lt_ctx):
             inplace=False
         )
 
-        corrected_inplace = correct(
-            buffer=data['intensity'].raw_data.reshape(shape).copy(),
-            dark_image=dark,
-            gain_map=gain,
-            excluded_pixels=exclude,
-            inplace=True
-        )
-
         print("Exclude: ", exclude)
 
         print(pick_res['intensity'].raw_data.dtype)
         print(mask_res['intensity'].raw_data.dtype)
         print(corrected.dtype)
-
-        assert np.allclose(
-            corrected_inplace,
-            corrected
-        )
 
         assert np.allclose(
             pick_res['intensity'].raw_data.reshape(shape),


### PR DESCRIPTION
Closes #818 

Correction only makes sense for floating point data.

* Inplace: Throws TypeError for non-float data
* Copy: Cast to matching floating point type.

@sk1p How is it handled in the dataset corrections code? Do we make sure it is float when correction is turned on?

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated test cases
