### PR TITLE
Add a warning if a MIB data set is saved in an inefficient way

### DIFF
--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1,7 +1,7 @@
 import re
 import io
 import os
-import glob
+from glob import glob
 import typing
 import logging
 import warnings
@@ -565,7 +565,13 @@ class MIBDataSet(DataSet):
         if self._disable_glob:
             fns = [self._path]
         else:
-            fns = glob.glob(pattern)
+            fns = glob(pattern)
+        if len(fns) > 16384:
+            warnings.warn(
+                "Saving data in many small files (here: %d) is not efficient, please increase "
+                "the \"Images Per File\" parameter when acquiring data",
+                RuntimeWarning
+            )
         self._filename_cache = fns
         return fns
 


### PR DESCRIPTION
Refs #837

## Contributor Checklist:

* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases