### PR TITLE
Overflow fix for np.prod

### DIFF
--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -33,7 +33,7 @@ def bytes_aligned(size):
 
 
 def empty_aligned(size, dtype):
-    size_flat = np.product(size)
+    size_flat = np.prod(size, dtype=np.int64)
     dtype = np.dtype(dtype)
     buf = _alloc_aligned(dtype.itemsize * size_flat)
     # _alloc_aligned may give us more memory (for alignment reasons), so crop it off the end:
@@ -42,7 +42,7 @@ def empty_aligned(size, dtype):
 
 
 def zeros_aligned(size, dtype):
-    if dtype == np.object or np.product(size) == 0:
+    if dtype == np.object or np.prod(size, dtype=np.int64) == 0:
         res = np.zeros(size, dtype=dtype)
     else:
         res = empty_aligned(size, dtype)
@@ -105,7 +105,7 @@ class BufferPool:
 
     @contextmanager
     def zeros(self, size, dtype):
-        if dtype == np.object or np.product(size) == 0:
+        if dtype == np.object or np.prod(size, dtype=np.int64) == 0:
             yield np.zeros(size, dtype=dtype)
         else:
             with self.empty(size, dtype) as res:
@@ -114,7 +114,7 @@ class BufferPool:
 
     @contextmanager
     def empty(self, size, dtype):
-        size_flat = np.product(size)
+        size_flat = np.prod(size, dtype=np.int64)
         dtype = np.dtype(dtype)
         with self.bytes(dtype.itemsize * size_flat) as buf:
             # self.bytes may give us more memory (for alignment reasons), so
@@ -302,7 +302,7 @@ class BufferWrapper(object):
 
     @property
     def roi_is_zero(self):
-        return np.product(self._shape) == 0
+        return np.prod(self._shape) == 0
 
     def _slice_for_partition(self, partition):
         """
@@ -483,7 +483,7 @@ class AuxBufferWrapper(BufferWrapper):
             new_data = self._data[ps]
         buf.set_buffer(new_data, is_global=False)
         buf.set_roi(roi)
-        assert np.product(new_data.shape) > 0
+        assert np.prod(new_data.shape) > 0
         assert not buf._data_coords_global
         return buf
 

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -282,7 +282,7 @@ def make_get_read_ranges(
     ):
         result = NumbaList()
 
-        sig_size = np.prod(np.array(sig_shape))
+        sig_size = np.prod(np.array(sig_shape).astype(np.int64))
 
         if roi is None:
             frame_indices = np.arange(start_at_frame, stop_before_frame)
@@ -300,7 +300,7 @@ def make_get_read_ranges(
         # this should be `np.prod(..., axis=-1)``, which is not supported by numba yet:
         # slices that divide the signal dimensions:
         slice_sig_sizes = np.array([
-            np.prod(slices_arr[slice_idx, 1, :])
+            np.prod(slices_arr[slice_idx, 1, :].astype(np.int64))
             for slice_idx in range(slices_arr.shape[0])
         ])
 

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -425,9 +425,11 @@ class Negotiator:
         size_px = size // itemsize
         if any(s > ps for s, ps in zip(shape, partition_shape)):
             raise ValueError("generated tileshape does not fit the partition")
-        if np.prod(shape) > size_px:
+        if np.prod(shape, dtype=np.uint64) > size_px:
             raise ValueError(
-                "shape %r (%d) does not fit into size %d" % (shape, np.prod(shape), size_px)
+                "shape %r (%d) does not fit into size %d" % (
+                    shape, np.prod(shape, dtype=np.uint64), size_px
+                )
             )
         for dim in range(len(base_shape)):
             if shape[dim] % base_shape[dim] != 0:
@@ -480,7 +482,7 @@ class Negotiator:
         if need_decode:
             io_max_size = 1*2**20
         else:
-            io_max_size = itemsize * np.prod(partition.shape)
+            io_max_size = itemsize * np.prod(partition.shape, dtype=np.uint64)
 
         depths = [
             self._get_min_depth(udf, partition)
@@ -523,7 +525,7 @@ class Negotiator:
         min_base_shape = self._scale_base_shape(base_shape, min_factors)
 
         # considering the min size, calculate the max depth:
-        max_depth = size_px // np.prod(min_base_shape)
+        max_depth = size_px // np.prod(min_base_shape, dtype=np.uint64)
         if depth > max_depth:
             depth = max_depth
 
@@ -572,7 +574,7 @@ class Negotiator:
             for s, cs in zip(shape, containing_shape)
         )
         prelim_shape = self._scale_base_shape(shape, factors)
-        rest = size / np.prod(prelim_shape)
+        rest = size / np.prod(prelim_shape, dtype=np.uint64)
         if rest < 1:
             rest = 1
         for idx in range(len(shape)):
@@ -584,7 +586,7 @@ class Negotiator:
                 factor = max_factor
             factors[idx] = factor
             prelim_shape = self._scale_base_shape(shape, factors)
-            rest = max(1, math.floor(size / np.prod(prelim_shape)))
+            rest = max(1, math.floor(size / np.prod(prelim_shape, dtype=np.uint64)))
         return factors
 
     def _scale_base_shape(self, base_shape, factors):
@@ -611,8 +613,8 @@ class Negotiator:
         Calculate the maximum tile size in bytes
         """
         udf_method = udf.get_method()
-        partition_size = itemsize * np.prod(partition.shape)
-        partition_size_sig = itemsize * np.prod(partition.shape.sig)
+        partition_size = itemsize * np.prod(partition.shape, dtype=np.uint64)
+        partition_size_sig = itemsize * np.prod(partition.shape.sig, dtype=np.uint64)
         if udf_method == "frame":
             size = max(self._get_default_size(), partition_size_sig)
         elif udf_method == "partition":
@@ -626,7 +628,7 @@ class Negotiator:
 
             # if the base_shape is larger than the current maximum size,
             # we need to increase the size:
-            base_size = itemsize * np.prod(base_shape)
+            base_size = itemsize * np.prod(base_shape, dtype=np.uint64)
             size = max(base_size, size)
         return size
 

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -425,10 +425,10 @@ class Negotiator:
         size_px = size // itemsize
         if any(s > ps for s, ps in zip(shape, partition_shape)):
             raise ValueError("generated tileshape does not fit the partition")
-        if np.prod(shape, dtype=np.uint64) > size_px:
+        if np.prod(shape, dtype=np.int64) > size_px:
             raise ValueError(
                 "shape %r (%d) does not fit into size %d" % (
-                    shape, np.prod(shape, dtype=np.uint64), size_px
+                    shape, np.prod(shape, dtype=np.int64), size_px
                 )
             )
         for dim in range(len(base_shape)):
@@ -482,7 +482,7 @@ class Negotiator:
         if need_decode:
             io_max_size = 1*2**20
         else:
-            io_max_size = itemsize * np.prod(partition.shape, dtype=np.uint64)
+            io_max_size = itemsize * np.prod(partition.shape, dtype=np.int64)
 
         depths = [
             self._get_min_depth(udf, partition)
@@ -525,7 +525,7 @@ class Negotiator:
         min_base_shape = self._scale_base_shape(base_shape, min_factors)
 
         # considering the min size, calculate the max depth:
-        max_depth = size_px // np.prod(min_base_shape, dtype=np.uint64)
+        max_depth = size_px // np.prod(min_base_shape, dtype=np.int64)
         if depth > max_depth:
             depth = max_depth
 
@@ -574,7 +574,7 @@ class Negotiator:
             for s, cs in zip(shape, containing_shape)
         )
         prelim_shape = self._scale_base_shape(shape, factors)
-        rest = size / np.prod(prelim_shape, dtype=np.uint64)
+        rest = size / np.prod(prelim_shape, dtype=np.int64)
         if rest < 1:
             rest = 1
         for idx in range(len(shape)):
@@ -586,7 +586,7 @@ class Negotiator:
                 factor = max_factor
             factors[idx] = factor
             prelim_shape = self._scale_base_shape(shape, factors)
-            rest = max(1, math.floor(size / np.prod(prelim_shape, dtype=np.uint64)))
+            rest = max(1, math.floor(size / np.prod(prelim_shape, dtype=np.int64)))
         return factors
 
     def _scale_base_shape(self, base_shape, factors):
@@ -613,8 +613,8 @@ class Negotiator:
         Calculate the maximum tile size in bytes
         """
         udf_method = udf.get_method()
-        partition_size = itemsize * np.prod(partition.shape, dtype=np.uint64)
-        partition_size_sig = itemsize * np.prod(partition.shape.sig, dtype=np.uint64)
+        partition_size = itemsize * np.prod(partition.shape, dtype=np.int64)
+        partition_size_sig = itemsize * np.prod(partition.shape.sig, dtype=np.int64)
         if udf_method == "frame":
             size = max(self._get_default_size(), partition_size_sig)
         elif udf_method == "partition":
@@ -628,7 +628,7 @@ class Negotiator:
 
             # if the base_shape is larger than the current maximum size,
             # we need to increase the size:
-            base_size = itemsize * np.prod(base_shape, dtype=np.uint64)
+            base_size = itemsize * np.prod(base_shape, dtype=np.int64)
             size = max(base_size, size)
         return size
 

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -184,7 +184,7 @@ class BloDataSet(DataSet):
         """
         # let's try to aim for 512MB (converted float data) per partition
         partition_size_px = 512 * 1024 * 1024 // 4
-        total_size_px = np.prod(self.shape)
+        total_size_px = np.prod(self.shape, dtype=np.int64)
         res = max(self._cores, total_size_px // partition_size_px)
         return res
 

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -27,7 +27,9 @@ class StackedDMFile(LocalFile):
     def _mmap_to_array(self, raw_mmap, start, stop):
         res = np.frombuffer(raw_mmap, dtype="uint8")
         cutoff = 0
-        cutoff += np.dtype(self._native_dtype).itemsize * int(np.prod(self._sig_shape))
+        cutoff += (
+            np.dtype(self._native_dtype).itemsize * int(np.prod(self._sig_shape, dtype=np.int64))
+        )
         res = res[:cutoff]
         return res.view(dtype=self._native_dtype).reshape(
             (self.num_frames, -1)
@@ -203,7 +205,7 @@ class DMDataSet(DataSet):
             with fileDM(first_fn, on_memory=True):
                 pass
             if (self._scan_size is not None
-                    and np.product(self._scan_size) != len(self._get_files())):
+                    and np.prod(self._scan_size) != len(self._get_files())):
                 raise DataSetException("incompatible scan_size")
             return True
         except (IOError, OSError) as e:

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -180,8 +180,8 @@ class EMPADDataSet(DataSet):
     def check_valid(self):
         try:
             # check filesize:
-            framesize = int(np.product(EMPAD_DETECTOR_SIZE_RAW))
-            num_frames = int(np.product(self._scan_size))
+            framesize = int(np.prod(EMPAD_DETECTOR_SIZE_RAW, dtype=np.int64))
+            num_frames = int(np.prod(self._scan_size))
             expected_filesize = num_frames * framesize * int(np.dtype("float32").itemsize)
             if expected_filesize != self._filesize:
                 raise DataSetException("invalid filesize; expected %d, got %d" % (

--- a/src/libertem/io/dataset/frms6.py
+++ b/src/libertem/io/dataset/frms6.py
@@ -563,7 +563,7 @@ class FRMS6DataSet(DataSet):
         """
         # let's try to aim for 512MB (converted float data) per partition
         partition_size_px = 512 * 1024 * 1024 // 4
-        total_size_px = np.prod(self.shape)
+        total_size_px = np.prod(self.shape, dtype=np.int64)
         res = max(self._cores, total_size_px // partition_size_px)
         return res
 

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -662,7 +662,7 @@ class K2ISDataSet(DataSet):
         """
         # let's try to aim for 512MB (converted float data) per partition
         partition_size_px = 512 * 1024 * 1024 // 4
-        total_size_px = np.prod(self.shape)
+        total_size_px = np.prod(self.shape, dtype=np.int64)
         res = max(self._cores, total_size_px // partition_size_px)
         return res
 

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -645,7 +645,7 @@ class MIBDataSet(DataSet):
         """
         # let's try to aim for 512MB (converted float data) per partition
         partition_size_px = 512 * 1024 * 1024 // 4
-        total_size_px = np.prod(self.shape)
+        total_size_px = np.prod(self.shape, dtype=np.int64)
         res = max(self._cores, total_size_px // partition_size_px)
         return res
 

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -189,7 +189,7 @@ class RawFileDataSet(DataSet):
         """
         # let's try to aim for 1024MB (converted float data) per partition
         partition_size_px = 1024 * 1024 * 1024 // 4
-        total_size_px = np.prod(self.shape)
+        total_size_px = np.prod(self.shape, dtype=np.int64)
         res = max(self._cores, total_size_px // partition_size_px)
         return res
 

--- a/src/libertem/io/utils.py
+++ b/src/libertem/io/utils.py
@@ -38,7 +38,7 @@ def get_partition_shape(dataset_shape: Shape, target_size_items: int, min_num: i
 
     for dim in reversed(dataset_shape.nav):
         proposed_shape = (dim,) + current_p_shape
-        proposed_size = np.prod(proposed_shape, dtype=np.uint64) * sig_size
+        proposed_size = np.prod(proposed_shape, dtype=np.int64) * sig_size
         if proposed_size <= target_size_items:
             current_p_shape = proposed_shape
         else:

--- a/src/libertem/io/utils.py
+++ b/src/libertem/io/utils.py
@@ -38,7 +38,7 @@ def get_partition_shape(dataset_shape: Shape, target_size_items: int, min_num: i
 
     for dim in reversed(dataset_shape.nav):
         proposed_shape = (dim,) + current_p_shape
-        proposed_size = np.product(proposed_shape) * sig_size
+        proposed_size = np.prod(proposed_shape, dtype=np.uint64) * sig_size
         if proposed_size <= target_size_items:
             current_p_shape = proposed_shape
         else:

--- a/src/libertem/udf/raw.py
+++ b/src/libertem/udf/raw.py
@@ -31,9 +31,9 @@ class PickUDF(UDF):
         if self.meta.roi is not None:
             navsize = np.count_nonzero(self.meta.roi)
         else:
-            navsize = np.prod(self.meta.dataset_shape.nav)
+            navsize = np.prod(self.meta.dataset_shape.nav, dtype=np.int64)
         warn_limit = 2**28
-        loaded_size = np.prod(sigshape) * navsize * np.dtype(dtype).itemsize
+        loaded_size = np.prod(sigshape, dtype=np.int64) * navsize * np.dtype(dtype).itemsize
         if loaded_size > warn_limit:
             log.warning("PickUDF is loading %s bytes, exceeding warning limit %s. "
                 "Consider using or implementing an UDF to process data on the worker "

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -333,3 +333,18 @@ def test_k2is_dist(dist_ctx):
     analysis = dist_ctx.create_sum_analysis(dataset=ds)
     results = dist_ctx.run(analysis, roi=roi)
     assert results[0].raw_data.shape == (1860, 2048)
+
+
+def test_no_integer_overflow(default_k2is):
+    p0 = next(default_k2is.get_partitions())
+
+    tileshape = Shape(
+        (16, 930, 16),
+        sig_dims=2,
+    )
+    tiling_scheme = TilingScheme.make_for_shape(
+        tileshape=tileshape,
+        dataset_shape=default_k2is.shape,
+    )
+
+    t0 = next(p0.get_tiles(tiling_scheme))

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -333,18 +333,3 @@ def test_k2is_dist(dist_ctx):
     analysis = dist_ctx.create_sum_analysis(dataset=ds)
     results = dist_ctx.run(analysis, roi=roi)
     assert results[0].raw_data.shape == (1860, 2048)
-
-
-def test_no_integer_overflow(default_k2is):
-    p0 = next(default_k2is.get_partitions())
-
-    tileshape = Shape(
-        (16, 930, 16),
-        sig_dims=2,
-    )
-    tiling_scheme = TilingScheme.make_for_shape(
-        tileshape=tileshape,
-        dataset_shape=default_k2is.shape,
-    )
-
-    t0 = next(p0.get_tiles(tiling_scheme))


### PR DESCRIPTION
Added `dtype=np.int64` to `np.prod` to fix the `RuntimeWarning: overflow encountered in long_scalars` error while negotiating a tiling scheme.

## Contributor Checklist:

* [x] I have added/updated test cases