### PR TITLE
Handle empty rect ROI

### DIFF
--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -387,6 +387,11 @@ def rectangular(X, Y, Width, Height, imageSizeX, imageSizeY):
         xmin = X
         ymax = Y
         xmax = X+Width
+    else:
+        ymin = 0
+        xmin = 0
+        ymax = -1
+        xmax = -1
     ymin = int(ymin)
     xmin = int(xmin)
     ymax = int(ymax)

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -100,3 +100,9 @@ def test_rectmask():
     assert np.allclose(m.rectangular(2, 2, -3, 3, 5, 5), rect3)
     assert np.allclose(m.rectangular(2, 2, 3, -3, 5, 5), rect2)
     assert np.allclose(m.rectangular(2, 2, -3, -3, 5, 5), rect1)
+
+
+def test_empty_rectmask():
+    assert not np.all(m.rectangular(2, 2, 0, 3, 5, 5))
+    assert not np.all(m.rectangular(2, 2, 3, 0, 5, 5))
+    assert not np.all(m.rectangular(2, 2, 0, 0, 5, 5))

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -103,6 +103,6 @@ def test_rectmask():
 
 
 def test_empty_rectmask():
-    assert not np.all(m.rectangular(2, 2, 0, 3, 5, 5))
-    assert not np.all(m.rectangular(2, 2, 3, 0, 5, 5))
-    assert not np.all(m.rectangular(2, 2, 0, 0, 5, 5))
+    assert not np.any(m.rectangular(2, 2, 0, 3, 5, 5))
+    assert not np.any(m.rectangular(2, 2, 3, 0, 5, 5))
+    assert not np.any(m.rectangular(2, 2, 0, 0, 5, 5))


### PR DESCRIPTION
Fix for empty rectangular ROI in the GUI throwing `UnboundLocalError: local variable 'ymin' referenced before assignment`

## Contributor Checklist:

* [x] I have added/updated test cases
