### PR TITLE
More robust support for EMPAD acquisitions

### DIFF
--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -40,8 +40,11 @@ def get_params_from_xml(path):
         if elem.getAttribute("mode") == "acquire"
     ]
 
-    scan_y = int(xml_get_text(scan_parameters[0].getElementsByTagName("scan_resolution_y")[0].childNodes))
-    scan_x = int(xml_get_text(scan_parameters[0].getElementsByTagName("scan_resolution_x")[0].childNodes))
+    node_scan_y = scan_parameters[0].getElementsByTagName("scan_resolution_y")[0]
+    node_scan_x = scan_parameters[0].getElementsByTagName("scan_resolution_x")[0]
+
+    scan_y = int(xml_get_text(node_scan_y.childNodes))
+    scan_x = int(xml_get_text(node_scan_x.childNodes))
     scan_size = (scan_y, scan_x)
     return path_raw, scan_size
     # TODO: read more metadata

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -125,8 +125,10 @@ class EMPADDataSet(DataSet):
                 self._init_from_xml, self._path
             )
         else:
-            assert lowpath.endswith(".raw")
-            assert self._scan_size is not None
+            if not lowpath.endswith(".raw"):
+                raise DataSetException("path should either be .xml or .raw")
+            if self._scan_size is None:
+                raise DataSetException("need to set or detect scan_size!")
             self._path_raw = self._path
 
         try:

--- a/tests/io/datasets/test_empad.py
+++ b/tests/io/datasets/test_empad.py
@@ -19,6 +19,7 @@ from utils import dataset_correction_verification
 EMPAD_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'EMPAD')
 EMPAD_RAW = os.path.join(EMPAD_TESTDATA_PATH, 'scan_11_x4_y4.raw')
 EMPAD_XML = os.path.join(EMPAD_TESTDATA_PATH, 'acquisition_12_pretty.xml')
+EMPAD_XML_2 = os.path.join(EMPAD_TESTDATA_PATH, 'acquisition_12_pretty.xml')
 HAVE_EMPAD_TESTDATA = os.path.exists(EMPAD_RAW) and os.path.exists(EMPAD_XML)
 
 pytestmark = pytest.mark.skipif(not HAVE_EMPAD_TESTDATA, reason="need EMPAD testdata")  # NOQA
@@ -32,6 +33,14 @@ def default_empad():
     )
     ds = ds.initialize(executor)
     yield ds
+
+
+def test_new_empad_xml():
+    executor = InlineJobExecutor()
+    ds = EMPADDataSet(
+        path=EMPAD_XML_2,
+    )
+    ds = ds.initialize(executor)
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
The lazy way of using `pix_x`, `pix_y` doesn't work anymore with current EMPAD files, so do the sensible thing and read from `scan_parameters > scan_resolution_y`

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)