### PR TITLE
Support for loading stacks of 3D DM files

### DIFF
--- a/docs/source/changelog/features/dm-stacks-of-3d.rst
+++ b/docs/source/changelog/features/dm-stacks-of-3d.rst
@@ -1,0 +1,4 @@
+[Feature] Support for loading stacks of 3D DM files
+===================================================
+
+* Before, we only supported loading stacks of 2D images, where each image was in its own file. This adds support for the case where there is more than one 2D image per file (as a 3D stack), stacking the images of all files along the Z axis (:pr:`877`)

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -221,10 +221,6 @@ class DMDataSet(DataSet):
         try:
             with fileDM(first_fn, on_memory=True):
                 pass
-            # FIXME: read_stacks
-            if (self._scan_size is not None
-                    and np.prod(self._scan_size) != len(self._get_files())):
-                raise DataSetException("incompatible scan_size")
             return True
         except (IOError, OSError) as e:
             raise DataSetException("invalid dataset: %s" % e)


### PR DESCRIPTION
Before, we only supported loading stacks of 2D images, where each image
was in its own file. This adds support for the case where there is more
than one 2D image per file, stacking the images along the Z axis.

@AnandBaburajan I plan to merge this PR (and possibly also #873) before your GSoC PR is merged, would that be OK? It will probably result in a small conflict, that should be easy enough to resolve.

/cc @FENGSHAN95

## TODO

* [x] Update the `scan_size` check in `check_valid` 
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases