### PR TITLE
JIT caching updates

### DIFF
--- a/docs/source/changelog/features/cache-warmup.rst
+++ b/docs/source/changelog/features/cache-warmup.rst
@@ -1,0 +1,4 @@
+[Feature] Cache warmup when opening a data set
+==============================================
+
+* Precompiles jit-ed functions on a single process per node, in a controlled manner, preventing CPU oversubscription. This should further improve once numba can cache functions which capture other functions in their closure (:pr:`886`, :issue:`798`)

--- a/src/libertem/corrections/detector.py
+++ b/src/libertem/corrections/detector.py
@@ -8,7 +8,7 @@ from libertem.common.numba import (
 )
 
 
-@numba.njit
+@numba.njit(cache=True)
 def _correct_numba_inplace(buffer, dark_image, gain_map, exclude_pixels, repair_environments,
         repair_counts):
     '''

--- a/src/libertem/executor/base.py
+++ b/src/libertem/executor/base.py
@@ -101,6 +101,11 @@ class JobExecutor(object):
 
         **kwargs
             Keyword arguments for fn
+
+        Returns
+        -------
+        dict
+            Return values keyed by worker name (executor-specific)
         """
         raise NotImplementedError()
 

--- a/src/libertem/executor/base.py
+++ b/src/libertem/executor/base.py
@@ -25,7 +25,7 @@ class JobExecutor(object):
 
     def run_function(self, fn, *args, **kwargs):
         """
-        run a callable `fn`
+        run a callable `fn` on any worker
         """
         raise NotImplementedError()
 
@@ -73,6 +73,26 @@ class JobExecutor(object):
         Parameters
         ----------
 
+        fn : callable
+            Function to call
+
+        *args
+            Arguments for fn
+
+        **kwargs
+            Keyword arguments for fn
+        """
+        raise NotImplementedError()
+
+    def run_each_worker(self, fn, *args, **kwargs):
+        """
+        Run `fn` on each worker process, and pass *args, **kwargs to it.
+
+        Useful, for example, if you need to prepare the environment of
+        each Python interpreter, warm up per-process caches etc.
+
+        Parameters
+        ----------
         fn : callable
             Function to call
 
@@ -135,7 +155,7 @@ class AsyncJobExecutor(object):
 
     async def run_function(self, fn, *args, **kwargs):
         """
-        Run a callable `fn`
+        Run a callable `fn` on any worker
         """
         raise NotImplementedError()
 
@@ -158,6 +178,26 @@ class AsyncJobExecutor(object):
         raise NotImplementedError()
 
     async def run_each_host(self, fn, *args, **kwargs):
+        raise NotImplementedError()
+
+    async def run_each_worker(self, fn, *args, **kwargs):
+        """
+        Run `fn` on each worker process, and pass *args, **kwargs to it.
+
+        Useful, for example, if you need to prepare the environment of
+        each Python interpreter, warm up per-process caches etc.
+
+        Parameters
+        ----------
+        fn : callable
+            Function to call
+
+        *args
+            Arguments for fn
+
+        **kwargs
+            Keyword arguments for fn
+        """
         raise NotImplementedError()
 
     async def close(self):
@@ -282,6 +322,10 @@ class AsyncAdapter(AsyncJobExecutor):
 
     async def run_each_host(self, fn, *args, **kwargs):
         fn_with_args = functools.partial(self._wrapped.run_each_host, fn, *args, **kwargs)
+        return await sync_to_async(fn_with_args, self._pool)
+
+    async def run_each_worker(self, fn, *args, **kwargs):
+        fn_with_args = functools.partial(self._wrapped.run_each_worker, fn, *args, **kwargs)
         return await sync_to_async(fn_with_args, self._pool)
 
     async def close(self):

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -361,8 +361,8 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
 
     def run_each_worker(self, fn, *args, **kwargs):
         fn = functools.partial(fn, *args, **kwargs)
-        # FIXME: translate return value?
-        self.client.run(fn)
+        # FIXME: normalize worker names somehow?
+        return self.client.run(fn)
 
     def close(self):
         if self.is_local:

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -359,6 +359,11 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         }
         return result_map
 
+    def run_each_worker(self, fn, *args, **kwargs):
+        fn = functools.partial(fn, *args, **kwargs)
+        # FIXME: translate return value?
+        self.client.run(fn)
+
     def close(self):
         if self.is_local:
             if self.client.cluster is not None:

--- a/src/libertem/executor/inline.py
+++ b/src/libertem/executor/inline.py
@@ -42,6 +42,9 @@ class InlineJobExecutor(JobExecutor):
             cloudpickle.loads(cloudpickle.dumps((fn, args, kwargs)))
         return {"localhost": fn(*args, **kwargs)}
 
+    def run_each_worker(self, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
     def get_available_workers(self):
         resources = {"compute": 1, "CPU": 1}
         if get_use_cuda() is not None:

--- a/src/libertem/executor/inline.py
+++ b/src/libertem/executor/inline.py
@@ -43,7 +43,7 @@ class InlineJobExecutor(JobExecutor):
         return {"localhost": fn(*args, **kwargs)}
 
     def run_each_worker(self, fn, *args, **kwargs):
-        return fn(*args, **kwargs)
+        return {"inline": fn(*args, **kwargs)}
 
     def get_available_workers(self):
         resources = {"compute": 1, "CPU": 1}

--- a/src/libertem/io/dataset/base/backend.py
+++ b/src/libertem/io/dataset/base/backend.py
@@ -27,10 +27,13 @@ def _make_mmap_reader_and_decoder(decode):
     """
     decode: from inp, in bytes, possibly interpreted as native_dtype, to out.dtype
     """
-    @numba.njit(boundscheck=False)
+    @numba.njit(boundscheck=False, cache=True)
     def _tilereader_w_copy(outer_idx, mmaps, sig_dims, tile_read_ranges,
                            out_decoded, native_dtype, do_zero,
                            origin, shape, ds_shape):
+        """
+        Read and decode a single tile
+        """
         if do_zero:
             out_decoded[:] = 0
         for rr_idx in range(tile_read_ranges.shape[0]):

--- a/src/libertem/io/dataset/base/decode.py
+++ b/src/libertem/io/dataset/base/decode.py
@@ -4,14 +4,14 @@ import numpy as np
 import numba
 
 
-@numba.jit(inline='always')
+@numba.jit(inline='always', cache=True)
 def byteswap_2_straight(inp, out):
     for i in range(inp.shape[0] // 2):
         out[i * 2 + 0] = inp[i * 2 + 1]
         out[i * 2 + 1] = inp[i * 2 + 0]
 
 
-@numba.jit(inline='always')
+@numba.jit(inline='always', cache=True)
 def byteswap_2_decode(inp, out):
     for i in range(inp.shape[0] // 2):
         o0 = inp[i * 2 + 0] << 8
@@ -19,7 +19,7 @@ def byteswap_2_decode(inp, out):
         out[i] = o0 | o1
 
 
-@numba.jit(inline='always')
+@numba.jit(inline='always', cache=True)
 def byteswap_4_straight(inp, out):
     for i in range(inp.shape[0] // 4):
         out[i * 4 + 3] = inp[i * 4 + 0]
@@ -28,7 +28,7 @@ def byteswap_4_straight(inp, out):
         out[i * 4 + 0] = inp[i * 4 + 3]
 
 
-@numba.jit(inline='always')
+@numba.jit(inline='always', cache=True)
 def byteswap_4_decode(inp, out):
     for i in range(inp.shape[0] // 4):
         o0 = inp[i * 4 + 0] << 24
@@ -38,7 +38,7 @@ def byteswap_4_decode(inp, out):
         out[i] = o0 + o1 + o2 + o3
 
 
-@numba.jit(inline='always')
+@numba.jit(inline='always', cache=True)
 def byteswap_8_straight(inp, out):
     for i in range(inp.shape[0] // 8):
         out[i * 8 + 7] = inp[i * 8 + 0]
@@ -51,7 +51,7 @@ def byteswap_8_straight(inp, out):
         out[i * 8 + 0] = inp[i * 8 + 7]
 
 
-@numba.jit(inline='always')
+@numba.jit(inline='always', cache=True)
 def byteswap_8_decode(inp, out):
     for i in range(inp.shape[0] // 8):
         o0 = inp[i * 8 + 0] << 56
@@ -65,37 +65,37 @@ def byteswap_8_decode(inp, out):
         out[i] = o0 + o1 + o2 + o3 + o4 + o5 + o6 + o7
 
 
-@numba.njit(inline='always')
+@numba.njit(inline='always', cache=True)
 def default_decode(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
     out[idx, :] = inp.view(native_dtype)
 
 
-@numba.njit(inline='always')
+@numba.njit(inline='always', cache=True)
 def decode_swap_2(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
     byteswap_2_decode(inp, out=out[idx])
 
 
-@numba.njit(inline='always')
+@numba.njit(inline='always', cache=True)
 def decode_swap_4(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
     byteswap_4_decode(inp, out=out[idx])
 
 
-@numba.njit(inline='always')
+@numba.njit(inline='always', cache=True)
 def decode_swap_8(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
     byteswap_8_decode(inp, out=out[idx])
 
 
-@numba.njit(inline='always')
+@numba.njit(inline='always', cache=True)
 def decode_swap_only_2(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
     byteswap_2_straight(inp, out=out[idx].view(np.uint8))
 
 
-@numba.njit(inline='always')
+@numba.njit(inline='always', cache=True)
 def decode_swap_only_4(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
     byteswap_4_straight(inp, out=out[idx].view(np.uint8))
 
 
-@numba.njit(inline='always')
+@numba.njit(inline='always', cache=True)
 def decode_swap_only_8(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
     byteswap_8_straight(inp, out=out[idx].view(np.uint8))
 

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -262,7 +262,7 @@ def make_get_read_ranges(
         where the last dimension contains: file index, start_byte, stop_byte
     """
 
-    @numba.njit(boundscheck=True)
+    @numba.njit(boundscheck=True, cache=True)
     def _get_read_ranges_inner(
         start_at_frame, stop_before_frame, roi, depth,
         slices_arr, fileset_arr, sig_shape,

--- a/src/libertem/udf/holography.py
+++ b/src/libertem/udf/holography.py
@@ -117,6 +117,8 @@ class HoloReconstructUDF(UDF):
             Defines precision of the reconstruction, True for complex128 for the resulting
             complex wave, otherwise results will be complex64
         """
+        if len(sb_position) != 2:
+            raise ValueError("invalid sb_position %r, must be tuple of length 2" % (sb_position,))
         super().__init__(out_shape=out_shape,
                          sb_position=sb_position,
                          sb_size=sb_size,

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -7,7 +7,7 @@ from libertem.udf import UDF
 from libertem.common.buffers import reshaped_view
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, cache=True)
 def merge_single(n, n_0, sum_0, varsum_0, n_1, sum_1, varsum_1, mean_1):
     '''
     Basic function to perform numerically stable merge.

--- a/src/libertem/web/dataset.py
+++ b/src/libertem/web/dataset.py
@@ -33,12 +33,6 @@ class DataSetDetailHandler(CORSMixin, tornado.web.RequestHandler):
     async def prime_numba_caches(self, ds):
         executor = self.state.executor_state.get_executor()
 
-        def log_stuff(fn):
-            def _inner(dask_worker):
-                print(f"running on {dask_worker}")
-                return fn()
-            return _inner
-
         def _prime_cache():
             import numpy as np
             dtypes = (np.float32, np.float64, None)
@@ -70,7 +64,7 @@ class DataSetDetailHandler(CORSMixin, tornado.web.RequestHandler):
 
         # second: make sure each worker *process* has the jited functions
         # loaded from the cache
-        await executor.run_each_worker(log_stuff(_prime_cache))
+        await executor.run_each_worker(_prime_cache)
 
     async def put(self, uuid):
         request_data = tornado.escape.json_decode(self.request.body)

--- a/src/libertem/web/dataset.py
+++ b/src/libertem/web/dataset.py
@@ -43,7 +43,7 @@ class DataSetDetailHandler(CORSMixin, tornado.web.RequestHandler):
             import numpy as np
             dtypes = (np.float32, np.float64, None)
             for dtype in dtypes:
-                roi = np.zeros(ds.shape, dtype=np.bool).reshape((-1,))
+                roi = np.zeros(ds.shape.nav, dtype=np.bool).reshape((-1,))
                 roi[0] = 1
 
                 from libertem.udf.sum import SumUDF

--- a/tests/executor/test_dask.py
+++ b/tests/executor/test_dask.py
@@ -135,3 +135,14 @@ def test_multiple_clients(local_cluster_url, default_raw):
 
     cx1 = Context(executor=ex1)
     cx1.run_udf(dataset=default_raw, udf=udf)
+
+
+def test_run_each_worker_1(dask_executor):
+    def fn1():
+        return "some result"
+    results = dask_executor.run_each_worker(fn1)
+    assert len(results.keys()) >= 1
+    assert len(results.keys()) == len(dask_executor.get_available_workers())
+    k = next(iter(results))
+    result0 = results[k]
+    assert result0 == "some result"

--- a/tests/executor/test_inline.py
+++ b/tests/executor/test_inline.py
@@ -1,0 +1,18 @@
+from libertem.executor.inline import InlineJobExecutor
+
+
+def test_run_each_worker_1():
+    def fn1():
+        return "some result"
+
+    executor = InlineJobExecutor()
+
+    results = executor.run_each_worker(fn1)
+    assert len(results.keys()) == 1
+    assert len(results.keys()) == len(executor.get_available_workers())
+
+    k = next(iter(results))
+    result0 = results[k]
+    assert result0 == "some result"
+    assert k == "inline"
+

--- a/tests/udf/test_holography.py
+++ b/tests/udf/test_holography.py
@@ -73,3 +73,12 @@ def test_holo_reconstruction(lt_ctx, backend):
     phase = np.angle(w)
 
     assert np.allclose(phase_ref[slice_crop], phase[slice_crop], rtol=0.12)
+
+
+def test_sb_pos_invalid(lt_ctx):
+    with pytest.raises(ValueError) as e:
+        holo_job = HoloReconstructUDF(out_shape=(128, 128),
+                                      sb_position=(0, 1, 2),
+                                      sb_size=(0, 1, 2))
+
+    assert e.match(r"invalid sb_position \(0, 1, 2\), must be tuple of length 2")


### PR DESCRIPTION
Fixes #798 once numba properly caches functions with w/ closures over other functions. Independent from this, we can decide if we want to add a work-around to make these functions cacheable. 

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)