### PR TITLE
Lazily import some dependencies

### DIFF
--- a/src/libertem/analysis/apply_fft_mask.py
+++ b/src/libertem/analysis/apply_fft_mask.py
@@ -1,4 +1,3 @@
-from libertem.viz import visualize_simple
 from .base import BaseAnalysis, AnalysisResult, AnalysisResultSet
 import libertem.udf.crystallinity as crystal
 from .helper import GeneratorHelper
@@ -43,6 +42,7 @@ class ApplyFFTMask(BaseAnalysis, id_="APPLY_FFT_MASK"):
          real_rad=real_rad)
 
     def get_udf_results(self, udf_results, roi):
+        from libertem.viz import visualize_simple
         data = udf_results['intensity'].data
         return AnalysisResultSet([
             AnalysisResult(raw_data=data,

--- a/src/libertem/analysis/base.py
+++ b/src/libertem/analysis/base.py
@@ -2,8 +2,6 @@ import typing
 
 import numpy as np
 
-from libertem.viz import encode_image, visualize_simple, CMAP_CIRCULAR_DEFAULT
-
 
 class AnalysisResult:
     """
@@ -45,6 +43,7 @@ class AnalysisResult:
         return np.array(self.raw_data)
 
     def get_image(self, save_kwargs=None):
+        from libertem.viz import encode_image
         return encode_image(self.visualized, save_kwargs=save_kwargs)
 
     @property
@@ -278,6 +277,7 @@ class BaseAnalysis(Analysis):
         return None
 
     def get_complex_results(self, job_result, key_prefix, title, desc):
+        from libertem.viz import visualize_simple, CMAP_CIRCULAR_DEFAULT
         magn = np.abs(job_result)
         angle = np.angle(job_result)
         wheel = CMAP_CIRCULAR_DEFAULT.rgb_from_vector((job_result.real, job_result.imag, 0))

--- a/src/libertem/analysis/clust.py
+++ b/src/libertem/analysis/clust.py
@@ -1,13 +1,9 @@
-from skimage.feature import peak_local_max
-from sklearn.cluster import AgglomerativeClustering
-from sklearn.feature_extraction.image import grid_to_graph
 import numpy as np
 import sparse
 import inspect
 import re
 from textwrap import dedent
 
-from libertem.viz import visualize_simple
 from .base import BaseAnalysis, AnalysisResult, AnalysisResultSet
 from libertem.utils.async_utils import run_blocking
 from libertem.executor.base import JobCancelledError
@@ -105,6 +101,9 @@ class ClusterAnalysis(BaseAnalysis, id_="CLUST"):
         return None
 
     def get_udf_results(self, udf_results, roi):
+        from libertem.viz import visualize_simple
+        from sklearn.cluster import AgglomerativeClustering
+        from sklearn.feature_extraction.image import grid_to_graph
         n_clust = self.parameters["n_clust"]
         y, x = tuple(self.dataset.shape.nav)
         connectivity = grid_to_graph(
@@ -144,7 +143,7 @@ class ClusterAnalysis(BaseAnalysis, id_="CLUST"):
         return self.run_sd_udf(roi, stddev_udf, executor, cancel_id, job_is_cancelled)
 
     def get_cluster_udf(self, sd_udf_results):
-
+        from skimage.feature import peak_local_max
         center = (self.parameters["cy"], self.parameters["cx"])
         rad_in = self.parameters["ri"]
         rad_out = self.parameters["ro"]

--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -3,7 +3,6 @@ import inspect
 import numpy as np
 
 from libertem import masks
-from libertem.viz import CMAP_CIRCULAR_DEFAULT, visualize_simple
 from .base import AnalysisResult, AnalysisResultSet
 from .masks import BaseMasksAnalysis
 from libertem.corrections.coordinates import rotate_deg, flip_y, identity
@@ -187,6 +186,7 @@ class COMAnalysis(BaseMasksAnalysis, id_="CENTER_OF_MASS"):
         return self.get_generic_results(img_sum, img_y, img_x)
 
     def get_generic_results(self, img_sum, img_y, img_x):
+        from libertem.viz import CMAP_CIRCULAR_DEFAULT, visualize_simple
         ref_x = self.parameters["cx"]
         ref_y = self.parameters["cy"]
         y_centers_raw, x_centers_raw = center_shifts(img_sum, img_y, img_x, ref_y, ref_x)

--- a/src/libertem/analysis/fem.py
+++ b/src/libertem/analysis/fem.py
@@ -1,5 +1,4 @@
 import inspect
-from libertem.viz import visualize_simple
 
 from .base import BaseAnalysis, AnalysisResult, AnalysisResultSet
 from .helper import GeneratorHelper
@@ -57,7 +56,7 @@ class FEMAnalysis(BaseAnalysis, id_="FEM"):
         return FEM.FEMUDF(center=center, rad_in=rad_in, rad_out=rad_out)
 
     def get_udf_results(self, udf_results, roi):
-
+        from libertem.viz import visualize_simple
         return AnalysisResultSet([
             AnalysisResult(raw_data=udf_results['intensity'].data,
                            visualized=visualize_simple(

--- a/src/libertem/analysis/masks.py
+++ b/src/libertem/analysis/masks.py
@@ -1,4 +1,3 @@
-from libertem.viz import visualize_simple
 from .base import BaseAnalysis, AnalysisResultSet, AnalysisResult
 from libertem.job.masks import ApplyMasksJob
 from libertem.udf.masks import ApplyMasksUDF
@@ -70,6 +69,7 @@ class SingleMaskAnalysis(BaseMasksAnalysis):
         raise NotImplementedError
 
     def get_generic_results(self, data):
+        from libertem.viz import visualize_simple
         if data.dtype.kind == 'c':
             return SingleMaskResultSet(
                 self.get_complex_results(
@@ -155,6 +155,7 @@ class MasksAnalysis(BaseMasksAnalysis):
         return self.parameters['factories']
 
     def get_generic_results(self, data):
+        from libertem.viz import visualize_simple
         if data.dtype.kind == 'c':
             results = []
             for idx in range(data.shape[-1]):

--- a/src/libertem/analysis/radialfourier.py
+++ b/src/libertem/analysis/radialfourier.py
@@ -4,10 +4,8 @@ from functools import partial
 
 import numpy as np
 import sparse
-import matplotlib.cm as cm
 
 from libertem import masks
-from libertem.viz import CMAP_CIRCULAR_DEFAULT, visualize_simple, cmaps
 from .base import AnalysisResult, AnalysisResultSet
 from .masks import BaseMasksAnalysis
 from .helper import GeneratorHelper
@@ -145,6 +143,8 @@ class RadialFourierAnalysis(BaseMasksAnalysis, id_="RADIAL_FOURIER"):
         job_results = job_results.reshape((n_bins, orders, *shape))
 
         def resultlist():
+            from libertem.viz import CMAP_CIRCULAR_DEFAULT, visualize_simple, cmaps
+            import matplotlib.cm as cm
             sets = []
             absolute = np.absolute(job_results)
             normal = np.maximum(1, absolute[:, 0])

--- a/src/libertem/analysis/raw.py
+++ b/src/libertem/analysis/raw.py
@@ -1,6 +1,5 @@
 import numpy as np
 import inspect
-from libertem.viz import visualize_simple
 from libertem.common import Slice, Shape
 from libertem.job.raw import PickFrameJob
 from libertem.udf.raw import PickUDF
@@ -149,6 +148,7 @@ class PickFrameAnalysis(BaseAnalysis, id_="PICK_FRAME"):
         return " ".join(coords)
 
     def get_generic_results(self, data):
+        from libertem.viz import visualize_simple
         coords = self.get_coords()
 
         if data.dtype.kind == 'c':

--- a/src/libertem/analysis/sd.py
+++ b/src/libertem/analysis/sd.py
@@ -1,5 +1,4 @@
 import inspect
-from libertem.viz import visualize_simple
 from .base import BaseAnalysis, AnalysisResult, AnalysisResultSet
 import libertem.udf.stddev as std
 from libertem.analysis.getroi import get_roi
@@ -59,6 +58,7 @@ class SDAnalysis(BaseAnalysis, id_="SD_FRAMES"):
         return get_roi(params=self.parameters, shape=self.dataset.shape.nav)
 
     def get_udf_results(self, udf_results, roi):
+        from libertem.viz import visualize_simple
         udf_results = std.consolidate_result(udf_results)
         return AnalysisResultSet([
             AnalysisResult(raw_data=udf_results['var'].data,

--- a/src/libertem/analysis/sum.py
+++ b/src/libertem/analysis/sum.py
@@ -1,6 +1,5 @@
 import numpy as np
 import inspect
-from libertem.viz import visualize_simple
 from .base import BaseAnalysis, AnalysisResult, AnalysisResultSet
 from libertem.analysis.getroi import get_roi
 from libertem.udf.sum import SumUDF
@@ -95,6 +94,7 @@ class SumAnalysis(BaseAnalysis, id_="SUM_FRAMES"):
         return get_roi(params=self.parameters, shape=self.dataset.shape.nav)
 
     def get_udf_results(self, udf_results, roi):
+        from libertem.viz import visualize_simple
         if udf_results['intensity'].data.dtype.kind == 'c':
             return AnalysisResultSet(
                 self.get_complex_results(

--- a/src/libertem/analysis/sumfft.py
+++ b/src/libertem/analysis/sumfft.py
@@ -1,4 +1,3 @@
-from libertem.viz import visualize_simple
 from libertem.analysis.sum import SumAnalysis
 from libertem.masks import _make_circular_mask
 from .base import AnalysisResult, AnalysisResultSet
@@ -41,6 +40,7 @@ class SumfftAnalysis(SumAnalysis, id_="FFTSUM_FRAMES"):
     TYPE = 'UDF'
 
     def get_udf_results(self, udf_results, roi):
+        from libertem.viz import visualize_simple
         job_results = np.array(udf_results['intensity'])
         real_rad = self.parameters.get("real_rad")
         real_center = (self.parameters.get("real_centery"), self.parameters.get("real_centerx"))

--- a/src/libertem/analysis/sumsig.py
+++ b/src/libertem/analysis/sumsig.py
@@ -1,4 +1,3 @@
-from libertem.viz import visualize_simple
 from .base import BaseAnalysis, AnalysisResult, AnalysisResultSet
 import libertem.udf.sumsigudf as sumsigudf
 from .helper import GeneratorHelper
@@ -37,6 +36,7 @@ class SumSigAnalysis(BaseAnalysis, id_="SUM_SIG"):
         return sumsigudf.SumSigUDF()
 
     def get_udf_results(self, udf_results, roi):
+        from libertem.viz import visualize_simple
         return AnalysisResultSet([
             AnalysisResult(raw_data=udf_results['intensity'],
                            visualized=visualize_simple(

--- a/src/libertem/common/container.py
+++ b/src/libertem/common/container.py
@@ -1,10 +1,6 @@
 import functools
 import logging
 
-try:
-    import torch
-except ImportError:
-    torch = None
 import sparse
 import scipy.sparse
 import numpy as np

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -8,7 +8,6 @@ from dask import distributed as dd
 from .base import JobExecutor, JobCancelledError, sync_to_async, AsyncAdapter
 from .scheduler import Worker, WorkerSet
 from libertem.common.backend import set_use_cpu, set_use_cuda
-from libertem.utils.devices import detect
 
 
 log = logging.getLogger(__name__)
@@ -389,6 +388,7 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
             the connected JobExecutor
         """
         if spec is None:
+            from libertem.utils.devices import detect
             spec = cluster_spec(**detect())
         if client_kwargs is None:
             client_kwargs = {}

--- a/src/libertem/job/masks.py
+++ b/src/libertem/job/masks.py
@@ -1,9 +1,5 @@
 import logging
 
-try:
-    import torch
-except ImportError:
-    torch = None
 import sparse
 import scipy.sparse
 import numpy as np
@@ -112,6 +108,10 @@ class ApplyMasksTask(Task):
         self.read_dtype = self._input_dtype(self.partition.dtype)
         self.mask_dtype = self._input_dtype(self.masks.dtype)
         self.tiling_scheme = tiling_scheme
+        try:
+            import torch
+        except ImportError:
+            torch = None
         if torch is None or self.dtype.kind != 'f' or self.read_dtype != self.mask_dtype:
             self.use_torch = False
 
@@ -191,6 +191,10 @@ class ApplyMasksTask(Task):
         )
 
         with set_num_threads(1):
+            try:
+                import torch
+            except ImportError:
+                torch = None
             for data_tile in tiles:
                 flat_data = data_tile.flat_data
                 masks = self.masks.get(data_tile, self.mask_dtype)

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -3,7 +3,6 @@ from typing import Dict
 import logging
 import uuid
 
-import tqdm
 import cloudpickle
 import numpy as np
 
@@ -1139,6 +1138,7 @@ class UDFRunner:
         self._debug_task_pickling(tasks)
 
         if progress:
+            import tqdm
             t = tqdm.tqdm(total=len(tasks))
         for part_results, task in executor.run_tasks(tasks, cancel_id):
             if progress:

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -1,7 +1,3 @@
-try:
-    import torch
-except ImportError:
-    torch = None
 import numpy as np
 
 from libertem.udf import UDF
@@ -117,6 +113,10 @@ class ApplyMasksUDF(UDF):
 
     def get_task_data(self):
         ''
+        try:
+            import torch
+        except ImportError:
+            torch = None
         m = self.meta
         use_torch = self.params.use_torch
         if (torch is None or m.input_dtype.kind != 'f' or m.input_dtype != self.get_mask_dtype()
@@ -144,6 +144,10 @@ class ApplyMasksUDF(UDF):
         ''
         flat_data = tile.reshape((tile.shape[0], -1))
         if self.task_data.use_torch:
+            try:
+                import torch
+            except ImportError:
+                torch = None
             masks = self.task_data.masks.get(self.meta.slice, transpose=True)
             # CuPy back-end disables torch in get_task_data
             # FIXME use GPU torch with CuPy array?

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -144,10 +144,7 @@ class ApplyMasksUDF(UDF):
         ''
         flat_data = tile.reshape((tile.shape[0], -1))
         if self.task_data.use_torch:
-            try:
-                import torch
-            except ImportError:
-                torch = None
+            import torch
             masks = self.task_data.masks.get(self.meta.slice, transpose=True)
             # CuPy back-end disables torch in get_task_data
             # FIXME use GPU torch with CuPy array?

--- a/src/libertem/utils/threading.py
+++ b/src/libertem/utils/threading.py
@@ -27,11 +27,13 @@ else:
     def set_fftw_threads(n):
         yield
 
+
 @contextmanager
 def set_torch_threads(n):
     try:
         import torch
     except ImportError:
+        yield
         return
     torch_threads = torch.get_num_threads()
     # See also https://pytorch.org/docs/stable/torch.html#parallelism

--- a/src/libertem/utils/threading.py
+++ b/src/libertem/utils/threading.py
@@ -6,10 +6,6 @@ try:
     import pyfftw
 except ImportError:
     pyfftw = None
-try:
-    import torch
-except ImportError:
-    torch = None
 
 import numba
 
@@ -31,27 +27,26 @@ else:
     def set_fftw_threads(n):
         yield
 
-if torch:
-    @contextmanager
-    def set_torch_threads(n):
-        torch_threads = torch.get_num_threads()
-        # See also https://pytorch.org/docs/stable/torch.html#parallelism
-        # At the time of writing the difference between threads and interop threads
-        # wasn't clear from the documentation. However, changing the
-        # interop_threads on runtime
-        # caused errors, so it is commented out here.
-        # torch_interop_threads = torch.get_num_interop_threads()
-        try:
-            torch.set_num_threads(n)
-            # torch.set_num_interop_threads(n)
-            yield
-        finally:
-            torch.set_num_threads(torch_threads)
-            # torch.set_num_interop_threads(torch_interop_threads)
-else:
-    @contextmanager
-    def set_torch_threads(n):
+@contextmanager
+def set_torch_threads(n):
+    try:
+        import torch
+    except ImportError:
+        return
+    torch_threads = torch.get_num_threads()
+    # See also https://pytorch.org/docs/stable/torch.html#parallelism
+    # At the time of writing the difference between threads and interop threads
+    # wasn't clear from the documentation. However, changing the
+    # interop_threads on runtime
+    # caused errors, so it is commented out here.
+    # torch_interop_threads = torch.get_num_interop_threads()
+    try:
+        torch.set_num_threads(n)
+        # torch.set_num_interop_threads(n)
         yield
+    finally:
+        torch.set_num_threads(torch_threads)
+        # torch.set_num_interop_threads(torch_interop_threads)
 
 
 @contextmanager


### PR DESCRIPTION
Mostly this prevents importing pytorch, matplotlib, skimage, sklearn at
import time. Local/lazy imports should still perform well (some ns), as they
reduce to something like a dict lookup.

This improves initial import time, measured as

    python -c 'import libertem.api'

by a factor of two. Running some of our slowest tests (tests/executor
and tests/server) is reduced from 264s to about 220s on my workstation. Let's see how the
CI time is improved, hopefully there the impact is even larger.

Something like the following was used to profile import times:

```
PYTHONPROFILEIMPORTTIME=1 python -c 'import libertem.api' 2>&1 | sort -k 3 -n
```

@uellue thoughts?

## TODO

- [ ] measure impact of `import torch` in `ApplyMasksUDF` - does it take time in the profile? Maybe move to `get_task_data`?

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)