### PR TITLE
Fix AUX data failure with single frame partitions

### DIFF
--- a/docs/source/changelog/bugfix/aux_failure_single_frame_part.rst
+++ b/docs/source/changelog/bugfix/aux_failure_single_frame_part.rst
@@ -1,0 +1,4 @@
+[Bugfix] Handle single-frame partitions in combination with aux data
+====================================================================
+
+* Instead of squeezing the aux buffer, reshape to the correct shape (:issue:`791`, :pr:`902`)

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -501,10 +501,10 @@ class AuxBufferWrapper(BufferWrapper):
         assert self._data is None
         assert buf.dtype == self._dtype
         extra = self._extra_shape
-        if not extra:
-            extra = (1,)
-        shape = (-1,) + extra
-        self._data = buf.reshape(shape).squeeze()
+        shape = (-1,)
+        if extra and extra != (1,):
+            shape = shape + extra
+        self._data = buf.reshape(shape)
         self._data_coords_global = is_global
 
     def __repr__(self):


### PR DESCRIPTION
If a partition consists of a single "sig" item, aux data shapes don't match. The singular dimension is "swallowed" somehow, apparently. I tried to find out where, but didn't get far.

This is mostly an issue for testing since normally partitions contain more than one sig element. For memory partitions, the "num_partitions" parameter can be set in such a way that no partitions with singular nav shape are created as a work-around.

Fixes #791 

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
