### PR TITLE
Fix problems with zero-copy reading and DM

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,6 +7,8 @@
 * [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
 changes were made to the GUI)
 
+<!--
+
 ## Please remove this section
 
 Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
@@ -20,3 +22,5 @@ clarification and help, for example in your PR description, with comments or in
 our [Gitter channel](https://gitter.im/LiberTEM/Lobby).
 
 Thank you for your contribution!
+
+-->

--- a/docs/source/changelog/bugfix/add_shape_to_tuple.rst
+++ b/docs/source/changelog/bugfix/add_shape_to_tuple.rst
@@ -1,5 +1,5 @@
 [Bugfix] Addition between Shape and tuple
-===========================================================
+=========================================
 
 * Tuples can be added directly to Shape objects. Right
   addition adds to the signal dimensions of the Shape

--- a/docs/source/changelog/bugfix/corrections.rst
+++ b/docs/source/changelog/bugfix/corrections.rst
@@ -1,5 +1,5 @@
 [Bug] Correction for many pixels
-==========================================
+================================
 
 * Improve internals of :mod:`libertem.corrections.detector` and
   :mod:`libertem.corrections.corrset` to better support correction

--- a/docs/source/changelog/bugfix/diasble_quickedit()
+++ b/docs/source/changelog/bugfix/diasble_quickedit()
@@ -1,4 +1,0 @@
-[Bugfix] Handling disable_quickedit() failure 
-===============================================
-
-* Libertem-server can now be started from Bash (:pr:`731`)

--- a/docs/source/changelog/bugfix/disable_quickedit_win.rst
+++ b/docs/source/changelog/bugfix/disable_quickedit_win.rst
@@ -1,0 +1,4 @@
+[Bugfix] Handling disable_quickedit() failure 
+=============================================
+
+* Libertem-server can now be started from Bash on Windows (:pr:`731`)

--- a/docs/source/changelog/bugfix/no-copy-multi-file.rst
+++ b/docs/source/changelog/bugfix/no-copy-multi-file.rst
@@ -1,0 +1,5 @@
+[Bugfix] Fix reading without a copy from multi-file datasets
+============================================================
+
+* The start offset of the file was not taken account when indexing
+  into the memory maps (:issue:`903`)

--- a/src/libertem/io/dataset/base/backend.py
+++ b/src/libertem/io/dataset/base/backend.py
@@ -131,7 +131,12 @@ class LocalFSMMapBackend(IOBackend):
                 origin=origin,
                 shape=Shape(shape, sig_dims=sig_dims)
             )
-            data_slice = tile_slice.get()
+            data_slice = (
+                slice(origin[0] - fh.start_idx, origin[0] - fh.start_idx + shape[0]),
+            ) + tuple([
+                slice(o, (o + s))
+                for (o, s) in zip(origin[1:], shape[1:])
+            ])
             data = memmap[data_slice]
             yield DataTile(
                 data,

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -138,7 +138,7 @@ class DMDataSet(DataSet):
                 file_header=self._offsets[fn],
             )
             files.append(f)
-            start_idx += 1  # FIXME: .nav.size?
+            start_idx += z_size
         return DMFileSet(files)
 
     def _get_files(self):


### PR DESCRIPTION
Zero-copy reading was not well tested with multiple files, resulting in #904. Also, the DM reader didn't properly calculate the `start_idx` and `end_idx` with multiple files with more than one frame per file (#903).

Fixes #903, fixes #904

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

<!-- 

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!
-->