### PR TITLE
Add pipeline with data access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ data
 *.idea
 .mypy_cache/
 .benchmarks
+junit.xml

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -6,41 +6,21 @@ stages:
     jobs:
     - job: data_tests
       pool: DataAccess
-      strategy:
-        matrix:
-          Python36:
-            python.version: '3.6'
-            TOXENV: 'py36'
-          Python37:
-            python.version: '3.7'
-            TOXENV: 'py37'
-          Python38:
-            python.version: '3.8'
-            TOXENV: 'py38'
       variables:
-        TOXENV: '$(TOXENV)'
+        TOXENV: 'py36'
         LT_TEST_DATA_PATH: '/data/'
       steps:
-      - task: UsePythonVersion@0
-        displayName: 'Use Python $(python.version)'
-        inputs:
-          versionSpec: '$(python.version)'
+      - bash: python3 -m venv venv
+        displayName: 'create venv'
+    
+      - bash: ./venv/bin/pip install tox
+        displayName: 'install tox'
 
-      - bash: pip install -U tox
-        displayName: 'install requirements'
-
-      - bash: tox
+      - bash: find /data/
+        displayName: 'list available data'
+    
+      - bash: ./venv/bin/tox
         displayName: 'Run tox tests'
-
-#   - bash: python3 -m venv venv
-#     displayName: 'create venv'
-# 
-#   - bash: ./venv/bin/pip install tox
-#     displayName: 'install tox'
-# 
-#   - bash: ./venv/bin/tox
-#     displayName: 'Run tox tests'
-
 
       - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml
         displayName: 'Submit coverage to codecov.io'
@@ -56,23 +36,3 @@ stages:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
           reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
-
-# Initial Azure pipeline for evaluation regarding running a on-premise agent
-# which has access to non-published data sets
-# - job: dataset_tests
-#   pool: DataAccess
-#   variables:
-#     TOXENV: 'py36'
-#     LT_TEST_DATA_PATH: '/data/'
-#   steps:
-#   - bash: python3 -m venv venv
-#     displayName: 'create venv'
-# 
-#   - bash: ./venv/bin/pip install tox
-#     displayName: 'install tox'
-# 
-#   - bash: ./venv/bin/tox
-#     displayName: 'Run tox tests'
-# 
-#   - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml -f client/coverage/coverage-final.json
-#     displayName: 'Submit coverage to codecov.io'

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -1,0 +1,78 @@
+trigger:
+- master
+
+stages:
+  - stage: test
+    jobs:
+    - job: data_tests
+      pool: DataAccess
+      strategy:
+        matrix:
+          Python36:
+            python.version: '3.6'
+            TOXENV: 'py36'
+          Python37:
+            python.version: '3.7'
+            TOXENV: 'py37'
+          Python38:
+            python.version: '3.8'
+            TOXENV: 'py38'
+      variables:
+        TOXENV: '$(TOXENV)'
+        LT_TEST_DATA_PATH: '/data/'
+      steps:
+      - task: UsePythonVersion@0
+        displayName: 'Use Python $(python.version)'
+        inputs:
+          versionSpec: '$(python.version)'
+
+      - bash: pip install -U tox
+        displayName: 'install requirements'
+
+      - bash: tox
+        displayName: 'Run tox tests'
+
+#   - bash: python3 -m venv venv
+#     displayName: 'create venv'
+# 
+#   - bash: ./venv/bin/pip install tox
+#     displayName: 'install tox'
+# 
+#   - bash: ./venv/bin/tox
+#     displayName: 'Run tox tests'
+
+
+      - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml
+        displayName: 'Submit coverage to codecov.io'
+
+      - task: PublishTestResults@2
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: 'junit.xml'
+          testRunTitle: 'Publish test results for Python $(python.version)'
+
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          codeCoverageTool: Cobertura
+          summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+          reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+
+# Initial Azure pipeline for evaluation regarding running a on-premise agent
+# which has access to non-published data sets
+# - job: dataset_tests
+#   pool: DataAccess
+#   variables:
+#     TOXENV: 'py36'
+#     LT_TEST_DATA_PATH: '/data/'
+#   steps:
+#   - bash: python3 -m venv venv
+#     displayName: 'create venv'
+# 
+#   - bash: ./venv/bin/pip install tox
+#     displayName: 'install tox'
+# 
+#   - bash: ./venv/bin/tox
+#     displayName: 'Run tox tests'
+# 
+#   - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml -f client/coverage/coverage-final.json
+#     displayName: 'Submit coverage to codecov.io'

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -8,7 +8,7 @@ stages:
       pool: DataAccess
       variables:
         TOXENV: 'py38'
-        LT_TEST_DATA_PATH: '/data/'
+        TESTDATA_BASE_PATH: '/data/'
       steps:
       - bash: find /data/
         displayName: 'list available data'
@@ -19,7 +19,10 @@ stages:
       - bash: ./venv/bin/pip install tox
         displayName: 'install tox'
 
-      - bash: ./venv/bin/tox
+      - bash: .tox/py38/bin/python3 -m pip --version
+        displayName: 'show pip version'
+
+      - bash: ./venv/bin/tox -- tests/io/
         displayName: 'Run tox tests'
 
       - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -13,7 +13,7 @@ stages:
       - bash: find /data/
         displayName: 'list available data'
 
-      - bash: python3 -m venv venv
+      - bash: python3.8 -m venv venv
         displayName: 'create venv'
     
       - bash: ./venv/bin/pip install tox

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -7,18 +7,18 @@ stages:
     - job: data_tests
       pool: DataAccess
       variables:
-        TOXENV: 'py36'
+        TOXENV: 'py38'
         LT_TEST_DATA_PATH: '/data/'
       steps:
+      - bash: find /data/
+        displayName: 'list available data'
+
       - bash: python3 -m venv venv
         displayName: 'create venv'
     
       - bash: ./venv/bin/pip install tox
         displayName: 'install tox'
 
-      - bash: find /data/
-        displayName: 'list available data'
-    
       - bash: ./venv/bin/tox
         displayName: 'Run tox tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -307,24 +307,3 @@ stages:
         displayName: 'install requirements'
       - bash: python scripts/release upload --pypi-test-user=libertem_bot --pypi-user=libertem_bot --no-dry-run
         displayName: 'Upload packages / release'
-
-
-# Initial Azure pipeline for evaluation regarding running a on-premise agent
-# which has access to non-published data sets
-# - job: dataset_tests
-#   pool: DataAccess
-#   variables:
-#     TOXENV: 'py36'
-#     LT_TEST_DATA_PATH: '/cachedata/users/clausen/libertem-test-data'
-#   steps:
-#   - bash: python3 -m venv venv
-#     displayName: 'create venv'
-# 
-#   - bash: ./venv/bin/pip install tox
-#     displayName: 'install tox'
-# 
-#   - bash: ./venv/bin/tox
-#     displayName: 'Run tox tests'
-# 
-#   - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml -f client/coverage/coverage-final.json
-#     displayName: 'Submit coverage to codecov.io'

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -91,7 +91,17 @@ update upon introducing or changing a feature:
 
 When you have submitted your pull request, someone from the LiberTEM
 organization will review your pull request, and may add comments or ask
-questions. If everything is good to go, your changes will be merged and you can
+questions. 
+
+In case your PR touches I/O code, an organization member may run
+the I/O tests with access to test data sets on a separate Azure Agent,
+using the following comment on the PR:
+
+.. code-block:: text
+
+    /azp run libertem.libertem-data
+
+If everything is good to go, your changes will be merged and you can
 delete the branch you created for the pull request.
 
 .. seealso:: `Guide on understanding the GitHub flow <https://guides.github.com/introduction/flow/>`_

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -12,9 +12,9 @@ from libertem.io.dataset.blo import BloDataSet
 from libertem.io.dataset.base import TilingScheme
 from libertem.common import Shape
 
-from utils import dataset_correction_verification
+from utils import dataset_correction_verification, get_testdata_path
 
-BLO_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'default.blo')
+BLO_TESTDATA_PATH = os.path.join(get_testdata_path(), 'default.blo')
 HAVE_BLO_TESTDATA = os.path.exists(BLO_TESTDATA_PATH)
 
 pytestmark = pytest.mark.skipif(not HAVE_BLO_TESTDATA, reason="need .blo testdata")  # NOQA

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -7,9 +7,9 @@ from libertem.udf.sum import SumUDF
 from libertem.io.dataset.base import TilingScheme
 from libertem.common import Shape
 
-from utils import dataset_correction_verification
+from utils import dataset_correction_verification, get_testdata_path
 
-SER_TESTDATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data', 'default.ser')
+SER_TESTDATA_PATH = os.path.join(get_testdata_path(), 'default.ser')
 HAVE_SER_TESTDATA = os.path.exists(SER_TESTDATA_PATH)
 
 pytestmark = pytest.mark.skipif(not HAVE_SER_TESTDATA, reason="need SER testdata")


### PR DESCRIPTION
Fixes #86. The test data is provided as a bind mount at `/data/` (currently pointing to a directory owned by my user, where I put the private test data to mirror my local setup, but that can be changed). 