### PR TITLE
Check parameter `executor` in api.Context; fix tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -296,17 +296,18 @@ def ipy_ctx():
 # Starting fresh distributed executors takes a lot of time and therefore
 # they should be used repeatedly if possible.
 # However, some benchmarks require a fresh distributed executor
-# and running several Dask executors in parallel leads to lockups when closing.
-# That means any shared executor has to be shut down before a fresh one is started.
+# and running several Dask executors in parallel has led to lockups when closing
+# in some instances.
+# That means any shared executor should be shut down before a fresh one is started.
 # For that reason we use a fixture with scope "class" and group
 # tests in a class that should all use the same executor.
 # That way we make sure the shared executor is torn down before any other test
 # starts a new one.
 
-# This is incompatible with using the local_cluster_url() fixture and any dependents
-# since that starts a session-scoped executor. Using that executor is not an option
-# either since it runs with a limited number of workers and thus doesn't test under
-# realistic load conditions.
+# Different from the local_cluster_ctx fixture that only uses two CPUs and at most
+# one GPU, this fixture starts a cluster for benchmarking under production condition that
+# uses all available CPUs and GPUs. Furthermore, the LiberTEM Context and not only the
+# Dask cluster is shared between functions.
 
 
 @pytest.fixture(scope="class")
@@ -400,9 +401,7 @@ async def async_executor(local_cluster_url):
 @pytest.fixture
 def dask_executor(local_cluster_url):
     executor = DaskJobExecutor.connect(local_cluster_url)
-
     yield executor
-
     executor.close()
 
 

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -57,6 +57,11 @@ class Context:
         """
         if executor is None:
             executor = self._create_local_executor()
+        if not isinstance(executor, JobExecutor):
+            raise ValueError(
+                f'Argument `executor` is not an instance of {JobExecutor}, '
+                f'got type "{type(executor)}" instead.'
+            )
         self.executor = executor
 
     def load(self, filetype: str, *args, **kwargs) -> DataSet:

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -371,7 +371,7 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         DaskJobExecutor
             the connected JobExecutor
         """
-        client = dd.Client(address=scheduler_uri)
+        client = dd.Client(address=scheduler_uri, set_as_default=False)
         return cls(client=client, is_local=False, *args, **kwargs)
 
     @classmethod

--- a/tests/test_analysis_masks.py
+++ b/tests/test_analysis_masks.py
@@ -683,17 +683,16 @@ def test_avoid_calculating_masks_on_client(hdf5_ds_1):
 
 
 @pytest.mark.functional
-def test_avoid_calculating_masks_on_client_udf(hdf5_ds_1):
+def test_avoid_calculating_masks_on_client_udf(hdf5_ds_1, local_cluster_ctx):
     mask = _mk_random(size=(16, 16))
-    # We have to start a local cluster so that the masks are
+    # We have to use a real cluster instead of InlineJobExecutor so that the masks are
     # computed in a different process
-    with api.Context() as ctx:
-        analysis = ctx.create_mask_analysis(
-            dataset=hdf5_ds_1, factories=[lambda: mask], mask_count=1, mask_dtype=np.float32
-        )
-        udf = analysis.get_udf()
-        ctx.run_udf(udf=udf, dataset=hdf5_ds_1)
-        assert udf._mask_container is None
+    analysis = local_cluster_ctx.create_mask_analysis(
+        dataset=hdf5_ds_1, factories=[lambda: mask], mask_count=1, mask_dtype=np.float32
+    )
+    udf = analysis.get_udf()
+    local_cluster_ctx.run_udf(udf=udf, dataset=hdf5_ds_1)
+    assert udf._mask_container is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,3 +1,9 @@
+import pytest
+
+from libertem.executor.inline import InlineJobExecutor
+from libertem.api import Context
+
+
 def test_ctx_load(lt_ctx, default_raw):
     lt_ctx.load(
         "raw",
@@ -6,3 +12,9 @@ def test_ctx_load(lt_ctx, default_raw):
         dtype="float32",
         detector_size=(128, 128),
     )
+
+
+def test_context_arguments():
+    with pytest.raises(ValueError):
+        # refs https://github.com/LiberTEM/LiberTEM/issues/918
+        Context(executor=InlineJobExecutor)

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -51,10 +51,10 @@ def test_start_local_default(hdf5_ds_1, local_cluster_ctx):
                 )
             cupy_only = None
 
-        numpy_only = ctx.run_udf(
-            udf=DebugDeviceUDF(backends=('numpy',)),
-            dataset=hdf5_ds_1
-        )
+    numpy_only = ctx.run_udf(
+        udf=DebugDeviceUDF(backends=('numpy',)),
+        dataset=hdf5_ds_1
+    )
 
     assert np.allclose(
         hybrid.mask_0.raw_data,


### PR DESCRIPTION
Give a meaningful error message if a bad value is passed as an executor.

Refs #918 

Drive-by change: Fix tests to not lock up when I run them on moellenstedt with remote VSCode. Not sure if the lock-ups occur under other circumstances as well.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
