### PR TITLE
Use the right loop in dd.as_completed

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -410,8 +410,10 @@ async def http_client():
     # FIXME: maybe re-scope to module, but would also need
     # adjusted event_loop scope. if we have many API tests
     # maybe reconsider.
+    # The timeout needs to be this high to acommodate overloaded
+    # CI environments, or otherwise oversubscribed systems
     async with aiohttp.ClientSession(
-        timeout=aiohttp.ClientTimeout(total=30)
+        timeout=aiohttp.ClientTimeout(total=120)
     ) as session:
         yield session
 

--- a/docs/source/changelog/bugfix/multiple_dask_clients.rst
+++ b/docs/source/changelog/bugfix/multiple_dask_clients.rst
@@ -1,0 +1,5 @@
+[Bugfix] Fix stability issue with multiple dask clients
+=======================================================
+
+* `dd.as_completed` needs to specify the `loop` to work with multiple
+  `dask.distributed` clients (:pr:`921`).

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,9 +4,8 @@ Installation
 ============
 
 .. note::
-    LiberTEM is currently working with Python 3.6 and Python 3.7. Support for
-    Python 3.8 depends on a more current release of Dask.distributed we are not
-    compatible with yet. See also :issue:`452`, :pr:`482`.
+    LiberTEM can currently be used on Python 3.6, 3.7 and 3.8. Support for Python 3.9
+    is not finished yet, as some of our dependencies are not ready yet.
 
 .. note::
     Distinguish between installing a released version and installing the latest
@@ -51,7 +50,7 @@ Using virtualenv
 
 You can use `virtualenv <https://virtualenv.pypa.io/>`_ or `venv
 <https://docs.python.org/3/tutorial/venv.html>`_ if you have a system-wide
-Python 3.6 or 3.7 installation. For Mac OS X, using conda is recommended.
+Python 3.6, 3.7 or 3.8 installation. For Mac OS X, using conda is recommended.
 
 To create a new virtualenv for LiberTEM, you can use the following command:
 

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -197,3 +197,25 @@ extra info as well to aid later data evaluation. Note that the compilation tests
 will have poor statistics since it only runs once. If you have an idea on how to
 collect better statistics, please `let us know
 <https://github.com/LiberTEM/LiberTEM/issues/new>`_!
+
+
+Simulating slow systems with control groups
+-------------------------------------------
+
+Under Linux, it is possible to simulate a slow system using control groups:
+
+.. code-block:: shell
+
+    sudo cgcreate -g cpu:/slow
+    sudo cgset -r cpu.cfs_period_us=1000000 slow
+    sudo cgset -r cpu.cfs_quota_us=200000 slow
+    sudo chown root:<yourgroup> /sys/fs/cgroup/cpu,cpuacct/slow
+    sudo chmod 664 /sys/fs/cgroup/cpu,cpuacct/slow
+
+Then, as a user, you can use :code:`cgexec` to run a command in that control group:
+
+.. code-block:: shell
+
+    cgexec -g cpu:slow pytest tests/
+
+This is useful, for example, to debug test failures that only seem to happen in CI.

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -254,7 +254,8 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         self._futures[cancel_id] = futures
 
         try:
-            for future, result_wrap in dd.as_completed(futures, with_results=True, loop=self.client.loop):
+            as_completed = dd.as_completed(futures, with_results=True, loop=self.client.loop)
+            for future, result_wrap in as_completed:
                 if future.cancelled():
                     del self._futures[cancel_id]
                     raise JobCancelledError()

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -940,6 +940,9 @@ class UDFTask(Task):
             result['ndarray'] = 1
         return result
 
+    def __repr__(self):
+        return "<UDFTask %r>" % (self._udfs,)
+
 
 class UDFRunner:
     def __init__(self, udfs, debug=False):

--- a/tests/corrections/test_corrset.py
+++ b/tests/corrections/test_corrset.py
@@ -383,7 +383,7 @@ def test_tileshape_adjustment_fuzz():
         ])
         print("excluded_coords", excluded_coords.shape, excluded_coords)
         excluded_pixels = sparse.COO(coords=excluded_coords, shape=sig_shape, data=True)
-        corr = CorrectionSet(excluded_pixels=excluded_pixels)
+        corr = CorrectionSet(excluded_pixels=excluded_pixels, allow_empty=True)
         adjusted = corr.adjust_tileshape(
             tile_shape=tile_shape, sig_shape=sig_shape, base_shape=base_shape
         )

--- a/tests/io/test_cached.py
+++ b/tests/io/test_cached.py
@@ -23,12 +23,16 @@ def default_cached_ds(tmpdir_factory, default_raw, lt_ctx):
     yield ds
 
 
-# A running Dask client can introduce a timing issue
-# between automatic closing of a numpy.memmap object and renaming
-# the underlying file
-def test_start_client():
+@pytest.fixture(scope='module', autouse=True)
+def client_in_background():
+    # A running Dask client can introduce a timing issue
+    # between automatic closing of a numpy.memmap object and renaming
+    # the underlying file
     with dd.LocalCluster() as cluster:
         client = dd.Client(cluster, set_as_default=False)
+        yield
+        # to fix "distributed.client - ERROR - Failed to reconnect to scheduler after 10.00 seconds, closing client"  # NOQA
+        client.close()
 
 
 def test_simple(default_cached_ds):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = flake8, py{36,37,38,39}, benchmark, benchmark-cuda{101,102}, mypy
+envlist = flake8, py{36,37,38,39}, benchmark, benchmark-cuda{101,102,111}, mypy
 
 [testenv]
 commands=
-    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/}
+    pytest -s -vvv --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/}
     # win_tweaks.py depends on modules that are only available on Windows
     pytest --doctest-modules --ignore=src/libertem/win_tweaks.py src/libertem/
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py{36,37,38,39}, benchmark, benchmark-cuda{101,102,111}, mypy
+envlist = flake8, py{36,37,38,39}, benchmark, benchmark-cuda{101,102,110}, mypy
 
 [testenv]
 commands=
@@ -12,6 +12,7 @@ deps=
     -roverride_requirements.txt
     cuda101: cupy-cuda101
     cuda102: cupy-cuda102
+    cuda110: cupy-cuda110
 extras=
     hdbscan
 setenv=
@@ -19,8 +20,13 @@ setenv=
     # leads to collisions between the local source tree and the installed package when running tests.
     # See https://github.com/pytest-dev/pytest/issues/2042
     PY_IGNORE_IMPORTMISMATCH=1
-    # Debug asyncio problems:
-    PYTHONASYNCIODEBUG=1
+    # Debug asyncio problems - has some perf overhead, so only enable if there is a problem
+    # PYTHONASYNCIODEBUG=1
+    # Dask configuration to reduce background load:
+    DASK_DISTRIBUTED__ADMIN__TICK__INTERVAL=1000
+    DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING_INTERVAL=1000
+    DASK_DISTRIBUTED__WORKER__PROFILE__CYCLE=60000
+    DASK_DISTRIBUTED__WORKER__PROFILE__INTERVAL=30000
 passenv=
     DASK_SCHEDULER_ADDRESS
     TESTDATA_BASE_PATH


### PR DESCRIPTION
This is needed if there are multiple distributed `Client`s running in the same process, as the `Client` that was created last is registered as the global `Client` and then used for functions like `dd.as_completed`. That means we create futures on a different loop than we try to retrieve their results, which results in hangs (can be debugged using `PYTHONASYNCIODEBUG=1`), as setting the result for a future is not threadsafe.

As a drive-by fix, workers are now started in parallel in `libertem-worker`.

Refs #919 #684 #482

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
