### PR TITLE
Update configuration for new sphinxcontrib-bibtex release

### DIFF
--- a/docs/source/bibtex.json
+++ b/docs/source/bibtex.json
@@ -1,0 +1,37 @@
+{
+    "cited": {
+        "app/amorphous": [
+            "Gibson1997",
+            "6980942",
+            "Panova2019"
+        ],
+        "app/holography": [
+            "Lichte2008"
+        ],
+        "index": [
+            "doi:10.1002/9783527808465.EMC2016.6284",
+            "Ophus_2019",
+            "Krajnak2016",
+            "Tate2016",
+            "Simson2015"
+        ],
+        "reference/app/amorphous": [
+            "Gibson1997"
+        ],
+        "reference/app/holography": [
+            "Lichte2008"
+        ],
+        "reference/udf": [
+            "Schubert2018"
+        ],
+        "sample_datasets": [
+            "ophus_colin_2019_3592520",
+            "Zeltmann2019",
+            "giulio_guzzinati_2019_2566137",
+            "Guzzinati2019"
+        ],
+        "usage": [
+            "Zeltmann2019"
+        ]
+    }
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,6 +69,8 @@ extensions = [
     'sphinx_issues',
 ]
 
+bibtex_bibfiles = ['references-libertem.bib']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,0 +1,7 @@
+sphinx>1.4
+sphinx-autobuild
+sphinxcontrib-bibtex>=2
+sphinx-issues
+nbsphinx
+nbsphinx_link
+ipython

--- a/tox.ini
+++ b/tox.ini
@@ -93,15 +93,9 @@ setenv=
     PYTHONPATH={toxinidir}
 commands=
     python "{toxinidir}/scripts/build-authors-contributors"
-    sphinx-autobuild -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html" --port 8008 {posargs}
+    sphinx-autobuild -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html" --port 8008 {posargs} -j auto
 deps=
-    sphinx>1.4
-    sphinx-autobuild
-    sphinxcontrib-bibtex
-    sphinx-issues
-    nbsphinx
-    nbsphinx_link
-    ipython
+    -rdocs_requirements.txt
     # Inject release candidates for doctest testing
     -roverride_requirements.txt
 skipsdist=True
@@ -116,15 +110,10 @@ commands=
     python "{toxinidir}/scripts/build-authors-contributors"
     # Two runs to get complete bibliography. The first one will throw warnings about missing
     # citations.
-    sphinx-build -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
-    sphinx-build -W -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
+    sphinx-build -j auto -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
+    sphinx-build -j auto -W -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
 deps=
-    sphinx
-    sphinxcontrib-bibtex
-    sphinx-issues
-    nbsphinx
-    nbsphinx_link
-    ipython
+    -rdocs_requirements.txt
     # Inject release candidates for doctest testing
     -roverride_requirements.txt
 skipsdist=True
@@ -140,18 +129,13 @@ commands=
     python "{toxinidir}/scripts/build-authors-contributors"
     # Two runs to get complete bibliography. The first one will throw warnings about missing
     # citations.
-    sphinx-build -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
-    sphinx-build -W -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
-    sphinx-build -b doctest "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
+    sphinx-build -j auto -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
+    sphinx-build -j auto -W -b html "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
+    sphinx-build -j auto -b doctest "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
     # sphinx-build -b linkcheck "{toxinidir}/docs/source" "{toxinidir}/docs/build/html"
     # cat docs/build/html/output.txt
 deps=
-    sphinx
-    sphinxcontrib-bibtex
-    sphinx-issues
-    nbsphinx
-    nbsphinx_link
-    ipython
+    -rdocs_requirements.txt
 skipsdist=True
 whitelist_externals=
     cat


### PR DESCRIPTION
This is required because of some backward-imcompatibilities, namely the requirement for setting `bibtex_bibfiles`. Include the `bibtex.json` file in source control as suggested by upstream, if this is kept up to date this means we could remove the second build pass for updating the references.

Also:

 - use parallel building to speed up the build.
 - extract requirements for building docs into its own requirements file, which can be shared between tox environments

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
