### PR TITLE
Allow choosing between lin and log visualization

### DIFF
--- a/docs/source/changelog/features/linlogscale.rst
+++ b/docs/source/changelog/features/linlogscale.rst
@@ -1,0 +1,10 @@
+[Feature] Lin and log scaling for analyses for sum, stddev, pick and single mask
+================================================================================
+
+* Allow selecting lin and log scaled visualization for sum, stddev, pick and single mask analyses 
+  to handle data with large dynamic range. This adds key :code:`intensity_lin` to
+  :class:`~libertem.analysis.sum.SumResultSet`, :class:`~libertem.analysis.sum.PickResultSet`
+  and the result of :class:`~libertem.analysis.sd.SDAnalysis`.
+  It adds key :code:`intensity_log` to :class:`~libertem.analysis.sum.SingleMaskResultSet`.
+  The new keys are chosen to not affect existing keys.
+  (:issue:`925`, :pr:`929`)

--- a/prototypes/reproducers/create-outlier-data.ipynb
+++ b/prototypes/reproducers/create-outlier-data.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outfile = r'C:\\Users\\weber\\Largedata\\LargeData\\ER-C-1\\groups\\data_science\\data\\reference\\RAW\\outliers-32-32-32-32-float32.raw'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out = np.memmap(outfile, shape=(32, 32, 32, 32), dtype=np.float32, mode='w+')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out[:] = np.random.random((32, 32, 32, 32))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(16):\n",
+    "    out[15-i, 15-i, 15-i, 15-i] = -(10**i)\n",
+    "    out[i+16, i+16, i+16, i+16] = 10**i"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.6 (libertem)",
+   "language": "python",
+   "name": "libertem36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/libertem/analysis/base.py
+++ b/src/libertem/analysis/base.py
@@ -276,7 +276,7 @@ class BaseAnalysis(Analysis):
     def get_roi(self):
         return None
 
-    def get_complex_results(self, job_result, key_prefix, title, desc):
+    def get_complex_results(self, job_result, key_prefix, title, desc, default_lin=True):
         from libertem.viz import visualize_simple, CMAP_CIRCULAR_DEFAULT
         magn = np.abs(job_result)
         angle = np.angle(job_result)
@@ -286,9 +286,16 @@ class BaseAnalysis(Analysis):
             AnalysisResult(
                 raw_data=magn,
                 visualized=visualize_simple(magn),
-                key=key_prefix,
+                key=key_prefix if default_lin else f'{key_prefix}_lin',
                 title="%s [magn]" % title,
                 desc="%s [magn]" % desc,
+            ),
+            AnalysisResult(
+                raw_data=magn,
+                visualized=visualize_simple(magn, logarithmic=True),
+                key=f'{key_prefix}_log' if default_lin else key_prefix,
+                title="%s [log(magn)]" % title,
+                desc="%s [log(magn)]" % desc,
             ),
             AnalysisResult(
                 raw_data=job_result.real,

--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -146,7 +146,10 @@ class COMResultSet(AnalysisResultSet):
     divergence : libertem.analysis.base.AnalysisResult
         Divergence of the center of mass vector field at a given point
     curl : libertem.analysis.base.AnalysisResult
-        Curl of the center of mass 2D vector field at a given point. Added in 0.6.0.dev0
+        Curl of the center of mass 2D vector field at a given point.
+
+        .. versionadded:: 0.6.0.dev0
+
     x : libertem.analysis.base.AnalysisResult
         X component of the center of mass shift
     y : libertem.analysis.base.AnalysisResult

--- a/src/libertem/analysis/masks.py
+++ b/src/libertem/analysis/masks.py
@@ -138,7 +138,10 @@ class SingleMaskResultSet(AnalysisResultSet):
     intensity_log : libertem.analysis.base.AnalysisResult
         Log-scaled sum of the selected region for each detector frame, with shape of
         the navigation dimension. Absolute of the result if the dataset or mask contains
-        complex numbers. Added in 0.6.0.dev0
+        complex numbers.
+
+        .. versionadded:: 0.6.0.dev0
+
     intensity_real : libertem.analysis.base.AnalysisResult
         Real part of the sum of the selected region. This is only available if the dataset
         or mask contains complex numbers.

--- a/src/libertem/analysis/masks.py
+++ b/src/libertem/analysis/masks.py
@@ -81,8 +81,11 @@ class SingleMaskAnalysis(BaseMasksAnalysis):
             )
         return SingleMaskResultSet([
             AnalysisResult(raw_data=data, visualized=visualize_simple(data),
-                           key="intensity", title="intensity",
-                           desc=self.get_description()),
+                           key="intensity", title="intensity [lin]",
+                           desc=f'{self.get_description()} lin-scaled'),
+            AnalysisResult(raw_data=data, visualized=visualize_simple(data, logarithmic=True),
+                           key="intensity_log", title="intensity [log]",
+                           desc=f'{self.get_description()} log-scaled'),
         ])
 
 
@@ -132,6 +135,10 @@ class SingleMaskResultSet(AnalysisResultSet):
         Sum of the selected region for each detector frame, with shape of
         the navigation dimension. Absolute of the result if the dataset or mask contains
         complex numbers.
+    intensity_log : libertem.analysis.base.AnalysisResult
+        Log-scaled sum of the selected region for each detector frame, with shape of
+        the navigation dimension. Absolute of the result if the dataset or mask contains
+        complex numbers. Added in 0.6.0.dev0
     intensity_real : libertem.analysis.base.AnalysisResult
         Real part of the sum of the selected region. This is only available if the dataset
         or mask contains complex numbers.

--- a/src/libertem/analysis/raw.py
+++ b/src/libertem/analysis/raw.py
@@ -59,7 +59,10 @@ class PickResultSet(AnalysisResultSet):
         contains complex numbers. Log-scaled visualization.
     intensity_lin : libertem.analysis.base.AnalysisResult
         The specified detector frame. Absolute value if the dataset
-        contains complex numbers. Linear visualization. Added in 0.6.0.dev0
+        contains complex numbers. Linear visualization.
+
+        .. versionadded:: 0.6.0.dev0
+
     intensity_real : libertem.analysis.base.AnalysisResult
         Real part of the specified detector frame. This is only available if the dataset
         contains complex numbers.

--- a/src/libertem/analysis/raw.py
+++ b/src/libertem/analysis/raw.py
@@ -56,7 +56,10 @@ class PickResultSet(AnalysisResultSet):
     ----------
     intensity : libertem.analysis.base.AnalysisResult
         The specified detector frame. Absolute value if the dataset
-        contains complex numbers.
+        contains complex numbers. Log-scaled visualization.
+    intensity_lin : libertem.analysis.base.AnalysisResult
+        The specified detector frame. Absolute value if the dataset
+        contains complex numbers. Linear visualization. Added in 0.6.0.dev0
     intensity_real : libertem.analysis.base.AnalysisResult
         Real part of the specified detector frame. This is only available if the dataset
         contains complex numbers.
@@ -158,13 +161,16 @@ class PickFrameAnalysis(BaseAnalysis, id_="PICK_FRAME"):
                     key_prefix="intensity",
                     title="intensity",
                     desc="the frame at %s" % (coords,),
+                    default_lin=False,
                 )
             )
-        visualized = visualize_simple(data, logarithmic=True)
         return AnalysisResultSet([
-            AnalysisResult(raw_data=data, visualized=visualized,
-                           key="intensity", title="intensity",
-                           desc="the frame at %s" % (coords,)),
+            AnalysisResult(raw_data=data, visualized=visualize_simple(data, logarithmic=True),
+                           key="intensity", title="intensity [log]",
+                           desc="the frame at %s log-scaled" % (coords,)),
+            AnalysisResult(raw_data=data, visualized=visualize_simple(data, logarithmic=False),
+                           key="intensity_lin", title="intensity [lin]",
+                           desc="the frame at %s lin-scaled" % (coords,)),
         ])
 
     @classmethod

--- a/src/libertem/analysis/sd.py
+++ b/src/libertem/analysis/sd.py
@@ -61,11 +61,23 @@ class SDAnalysis(BaseAnalysis, id_="SD_FRAMES"):
         from libertem.viz import visualize_simple
         udf_results = std.consolidate_result(udf_results)
         return AnalysisResultSet([
-            AnalysisResult(raw_data=udf_results['var'].data,
-                           visualized=visualize_simple(
-                               udf_results['var'].data, logarithmic=True),
-                           key="intensity", title="intensity",
-                           desc="SD of frames"),
+            AnalysisResult(
+                raw_data=udf_results['std'],
+                visualized=visualize_simple(
+                    udf_results['std'], logarithmic=True
+                ),
+                key="intensity", title="intensity [log]",
+                desc="Standard deviation of frames log-scaled"
+            ),
+            AnalysisResult(
+                raw_data=udf_results['std'],
+                visualized=visualize_simple(
+                    udf_results['std'], logarithmic=False,
+                ),
+                key="intensity_lin",
+                title="intensity [lin]",
+                desc="Standard deviation of frames lin-scaled"
+            ),
         ])
 
     @classmethod

--- a/src/libertem/analysis/sum.py
+++ b/src/libertem/analysis/sum.py
@@ -64,7 +64,10 @@ class SumResultSet(AnalysisResultSet):
     intensity_lin : libertem.analysis.base.AnalysisResult
         Sum of all detector frames along the navigation dimension,
         preserving the signal dimension. Absolute value of the sum if the dataset
-        contains complex numbers. Lin-scaled visualization. Added in 0.6.0.dev0
+        contains complex numbers. Lin-scaled visualization.
+
+        .. versionadded:: 0.6.0.dev0
+
     intensity_real : libertem.analysis.base.AnalysisResult
         Real part of the sum of all detector frames along the navigation dimension,
         preserving the signal dimension. This is only available if the dataset

--- a/src/libertem/analysis/sum.py
+++ b/src/libertem/analysis/sum.py
@@ -60,7 +60,11 @@ class SumResultSet(AnalysisResultSet):
     intensity : libertem.analysis.base.AnalysisResult
         Sum of all detector frames along the navigation dimension,
         preserving the signal dimension. Absolute value of the sum if the dataset
-        contains complex numbers.
+        contains complex numbers. Log-scaled visualization.
+    intensity_lin : libertem.analysis.base.AnalysisResult
+        Sum of all detector frames along the navigation dimension,
+        preserving the signal dimension. Absolute value of the sum if the dataset
+        contains complex numbers. Lin-scaled visualization. Added in 0.6.0.dev0
     intensity_real : libertem.analysis.base.AnalysisResult
         Real part of the sum of all detector frames along the navigation dimension,
         preserving the signal dimension. This is only available if the dataset
@@ -102,15 +106,24 @@ class SumAnalysis(BaseAnalysis, id_="SUM_FRAMES"):
                     key_prefix="intensity",
                     title="intensity",
                     desc="sum of all frames",
+                    default_lin=False,
                 )
             )
 
         return SumResultSet([
+            AnalysisResult(
+                raw_data=udf_results['intensity'].data,
+                visualized=visualize_simple(
+                    udf_results['intensity'].data, logarithmic=True
+                ),
+                key="intensity", title="intensity [log]", desc="sum of frames log-scaled"
+            ),
             AnalysisResult(raw_data=udf_results['intensity'].data,
-                           visualized=visualize_simple(
-                               udf_results['intensity'].data, logarithmic=True
-                           ),
-                           key="intensity", title="intensity", desc="sum of frames"),
+                visualized=visualize_simple(
+                    udf_results['intensity'].data, logarithmic=False
+                ),
+                key="intensity_lin", title="intensity [lin]", desc="sum of frames lin-scaled"
+            ),
         ])
 
     @classmethod

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -276,7 +276,10 @@ class Context:
         flip_y : bool
             Flip the Y coordinate. Some detectors, namely Quantum Detectors Merlin,
             may have pixel (0, 0) at the lower left corner. This has to be corrected
-            to get the sign of the y shift as well as curl and divergence right. Added in 0.6.0.dev0
+            to get the sign of the y shift as well as curl and divergence right.
+
+            .. versionadded:: 0.6.0.dev0
+
         scan_rotation : float
             Scan rotation in degrees.
             The optics of an electron microscope can rotate the image. Furthermore, scan
@@ -288,7 +291,8 @@ class Context:
             to match the scan coordinate system. A positive value rotates the displacement
             vector clock-wise. That means if the detector seems rotated to the right relative
             to the scan, this value should be negative to counteract this rotation.
-            Added in 0.6.0.dev0
+
+            .. versionadded:: 0.6.0.dev0
 
         Returns
         -------

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -169,7 +169,9 @@ class BufferWrapper(object):
 
         where : string or None
             :code:`None` means NumPy array, :code:`device` to use a back-end specified
-            in :meth:`allocate`. New in 0.6.0.dev0
+            in :meth:`allocate`.
+
+            .. versionadded:: 0.6.0.dev0
         """
 
         self._extra_shape = tuple(extra_shape)

--- a/tests/test_analysis_raw.py
+++ b/tests/test_analysis_raw.py
@@ -98,6 +98,7 @@ def test_pick_analysis(lt_ctx, TYPE):
 
     assert result.intensity.raw_data.shape == (16, 16)
     assert np.allclose(result.intensity.raw_data, data[5, 5])
+    assert np.allclose(result.intensity_lin.raw_data, data[5, 5])
 
 
 @pytest.mark.parametrize(
@@ -118,6 +119,7 @@ def test_pick_from_3d_ds(lt_ctx, TYPE):
 
     assert result.intensity.raw_data.shape == (16, 16)
     assert np.allclose(result.intensity.raw_data, data[5])
+    assert np.allclose(result.intensity_lin.raw_data, data[5])
 
 
 def test_pick_from_3d_ds_job(lt_ctx):
@@ -186,6 +188,7 @@ def test_pick_analysis_via_api_1(lt_ctx, TYPE):
 
     assert result.intensity.raw_data.shape == (16, 16)
     assert np.allclose(result.intensity.raw_data, data[7, 8])
+    assert np.allclose(result.intensity_lin.raw_data, data[7, 8])
 
 
 @pytest.mark.parametrize(
@@ -206,6 +209,7 @@ def test_pick_analysis_via_api_2_3d_ds(lt_ctx, TYPE):
 
     assert result.intensity.raw_data.shape == (16, 16)
     assert np.allclose(result.intensity.raw_data, data[8])
+    assert np.allclose(result.intensity_lin.raw_data, data[8])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_analysis_shapes.py
+++ b/tests/test_analysis_shapes.py
@@ -33,6 +33,10 @@ def test_disk_1(lt_ctx, ds_random, TYPE):
         results.intensity.raw_data,
         expected,
     )
+    assert np.allclose(
+        results.intensity_log.raw_data,
+        expected,
+    )
 
 
 @pytest.mark.parametrize(
@@ -50,6 +54,10 @@ def test_disk_defaults(lt_ctx, ds_random, TYPE):
         results.intensity.raw_data,
         expected,
     )
+    assert np.allclose(
+        results.intensity_log.raw_data,
+        expected,
+    )
 
 
 @pytest.mark.parametrize(
@@ -64,6 +72,10 @@ def test_ring_1(lt_ctx, ds_random, TYPE):
     assert results.intensity.raw_data.shape == (16, 16)
     assert np.allclose(
         results.intensity.raw_data,
+        expected,
+    )
+    assert np.allclose(
+        results.intensity_log.raw_data,
         expected,
     )
 
@@ -89,6 +101,10 @@ def test_ring_3d_ds(lt_ctx, TYPE):
         results.intensity.raw_data.reshape((16, 16)),
         expected,
     )
+    assert np.allclose(
+        results.intensity_log.raw_data.reshape((16, 16)),
+        expected,
+    )
 
 
 @pytest.mark.parametrize(
@@ -102,6 +118,10 @@ def test_ring_defaults(lt_ctx, ds_random, TYPE):
     expected = _naive_mask_apply([mask], ds_random.data)
     assert np.allclose(
         results.intensity.raw_data,
+        expected,
+    )
+    assert np.allclose(
+        results.intensity_log.raw_data,
         expected,
     )
 
@@ -118,6 +138,10 @@ def test_point_1(lt_ctx, ds_random, TYPE):
     expected = _naive_mask_apply([mask], ds_random.data)
     assert np.allclose(
         results.intensity.raw_data,
+        expected,
+    )
+    assert np.allclose(
+        results.intensity_log.raw_data,
         expected,
     )
 
@@ -144,6 +168,10 @@ def test_point_3d_ds(lt_ctx, TYPE):
         results.intensity.raw_data.reshape((16, 16)),
         expected,
     )
+    assert np.allclose(
+        results.intensity_log.raw_data.reshape((16, 16)),
+        expected,
+    )
 
 
 @pytest.mark.parametrize(
@@ -161,6 +189,10 @@ def test_point_defaults(lt_ctx, ds_random, TYPE):
         results.intensity.raw_data,
         expected,
     )
+    assert np.allclose(
+        results.intensity_log.raw_data,
+        expected,
+    )
 
 
 @pytest.mark.parametrize(
@@ -175,6 +207,14 @@ def test_disk_complex(lt_ctx, ds_complex, TYPE):
     assert np.allclose(
         results.intensity_complex.raw_data,
         expected,
+    )
+    assert np.allclose(
+        results.intensity_log.raw_data,
+        np.abs(results.intensity_complex),
+    )
+    assert np.allclose(
+        results.intensity.raw_data,
+        np.abs(results.intensity_complex),
     )
 
 
@@ -191,6 +231,14 @@ def test_ring_complex(lt_ctx, ds_complex, TYPE):
         results.intensity_complex.raw_data,
         expected,
     )
+    assert np.allclose(
+        results.intensity_log.raw_data,
+        np.abs(results.intensity_complex),
+    )
+    assert np.allclose(
+        results.intensity.raw_data,
+        np.abs(results.intensity_complex),
+    )
 
 
 @pytest.mark.parametrize(
@@ -205,4 +253,12 @@ def test_point_complex(lt_ctx, ds_complex, TYPE):
     assert np.allclose(
         results.intensity_complex.raw_data,
         expected,
+    )
+    assert np.allclose(
+        results.intensity_log.raw_data,
+        np.abs(results.intensity_complex),
+    )
+    assert np.allclose(
+        results.intensity.raw_data,
+        np.abs(results.intensity_complex),
     )

--- a/tests/test_analysis_sum.py
+++ b/tests/test_analysis_sum.py
@@ -19,6 +19,7 @@ def test_sum_dataset_tilesize_1(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16, 16)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_dataset_tilesize_2(lt_ctx):
@@ -32,6 +33,7 @@ def test_sum_dataset_tilesize_2(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16, 16)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_endian(lt_ctx):
@@ -45,6 +47,7 @@ def test_sum_endian(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16, 16)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_signed(lt_ctx):
@@ -59,6 +62,7 @@ def test_sum_signed(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16, 16)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_timeseries(lt_ctx):
@@ -81,6 +85,7 @@ def test_sum_timeseries(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16, 16)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_spectrum_2d_frames(lt_ctx):
@@ -104,6 +109,7 @@ def test_sum_spectrum_2d_frames(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16 * 16,)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_spectrum_linescan(lt_ctx):
@@ -127,6 +133,7 @@ def test_sum_spectrum_linescan(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16 * 16,)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_hyperspectral(lt_ctx):
@@ -144,6 +151,7 @@ def test_sum_hyperspectral(lt_ctx):
 
     assert results['intensity'].raw_data.shape == (16, 16, 16)
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_complex(lt_ctx, ds_complex):
@@ -156,6 +164,8 @@ def test_sum_complex(lt_ctx, ds_complex):
 
     assert results['intensity'].raw_data.shape == (16, 16)
     assert np.allclose(results['intensity_complex'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, np.abs(expected))
+    assert np.allclose(results['intensity'].raw_data, np.abs(expected))
 
 
 def test_sum_with_roi(lt_ctx):
@@ -191,6 +201,7 @@ def test_sum_with_roi(lt_ctx):
     assert not np.allclose(results['intensity'].raw_data, data.sum(axis=(0, 1)))
     # ... but rather like `expected`:
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_zero_roi(lt_ctx):
@@ -225,6 +236,7 @@ def test_sum_zero_roi(lt_ctx):
     assert not np.allclose(results['intensity'].raw_data, data.sum(axis=(0, 1)))
     # ... but rather like `expected`:
     assert np.allclose(results['intensity'].raw_data, expected)
+    assert np.allclose(results['intensity_lin'].raw_data, expected)
 
 
 def test_sum_with_crop_frames(lt_ctx):


### PR DESCRIPTION
Closes #925 with a small modification to make sure large outliers
don't generate a completely blank plot.

See https://github.com/LiberTEM/LiberTEM/issues/925#issuecomment-744483882
for more discussions and an idea for a more comprehensive solution

Full implementation would be #134

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
