### PR TITLE
Handle user-provided positional and keyword arguments for autoloading

### DIFF
--- a/docs/source/changelog/bugfix/autoload.rst
+++ b/docs/source/changelog/bugfix/autoload.rst
@@ -1,0 +1,5 @@
+[Bugfix] Open datasets with autodetection, positional and keyword arguments
+===========================================================================
+
+* Handle keyword and positional arguments to :code:`Context.load('auto', ...)`
+  correctly. (:issue:`936`, :pr:`938`)

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -64,7 +64,7 @@ class Context:
             )
         self.executor = executor
 
-    def load(self, filetype: str, io_backend=None, *args, **kwargs) -> DataSet:
+    def load(self, filetype: str, *args, io_backend=None, **kwargs) -> DataSet:
         """
         Load a :class:`~libertem.io.dataset.base.DataSet`. As it doesn't load
         the whole data into RAM at once, you can load and process datasets

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -118,7 +118,7 @@ class Context:
         >>> ds = ctx.load("auto", path="...", io_backend=io_backend)  # doctest: +SKIP
         """
         # delegate to libertem.io.dataset.load:
-        return load(filetype, io_backend=io_backend, executor=self.executor, *args, **kwargs)
+        return load(filetype, *args, io_backend=io_backend, executor=self.executor, **kwargs)
 
     load.__doc__ = load.__doc__ % {"types": ", ".join(filetypes.keys())}
 

--- a/src/libertem/io/dataset/__init__.py
+++ b/src/libertem/io/dataset/__init__.py
@@ -21,23 +21,21 @@ filetypes = {
 }
 
 
-def _auto_load(path, executor):
+def _auto_load(path, *args, executor, **kwargs):
     if path is None:
         raise DataSetException(
-            "please specify the `path` kwarg to allow auto detection"
+            "please specify the `path` argument to allow auto detection"
         )
-
     detected_params = detect(path, executor=executor)
     filetype_detected = detected_params.get('type', None)
     if filetype_detected is None:
         raise DataSetException(
             "could not determine DataSet type for file '%s'" % path,
         )
-    params = detected_params["parameters"]
-    return load(filetype_detected, executor=executor, **params)
+    return load(filetype_detected, path, *args, executor=executor, **kwargs)
 
 
-def load(filetype, executor, enable_async=False, *args, **kwargs):
+def load(filetype, *args, enable_async=False, executor, **kwargs):
     """
     Low-level method to load a dataset. Usually you will want
     to use Context.load instead!
@@ -56,7 +54,7 @@ def load(filetype, executor, enable_async=False, *args, **kwargs):
     additional parameters are passed to the concrete DataSet implementation
     """
     if filetype == "auto":
-        return _auto_load(kwargs.get('path'), executor)
+        return _auto_load(*args, executor=executor, enable_async=enable_async, **kwargs)
 
     cls = get_dataset_cls(filetype)
 

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -165,7 +165,7 @@ class H5DataSet(DataSet):
     def detect_params(cls, path, executor):
         try:
             executor.run_function(cls._do_detect, path)
-        except (IOError, OSError, KeyError, ValueError, DataSetException):
+        except (IOError, OSError, KeyError, ValueError, TypeError, DataSetException):
             # not a h5py file or can't open for some reason:
             return False
 

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -96,7 +96,7 @@ class H5DataSet(DataSet):
         Minimum number of partitions, set to number of cores if not specified. Usually
         doesn't need to be specified.
     """
-    def __init__(self, path, ds_path, tileshape=None,
+    def __init__(self, path, ds_path=None, tileshape=None,
                  target_size=512*1024*1024, min_num_partitions=None, sig_dims=2, io_backend=None):
         super().__init__(io_backend=io_backend)
         if io_backend is not None:
@@ -123,6 +123,11 @@ class H5DataSet(DataSet):
         )
 
     def _do_initialize(self):
+        if self.ds_path is None:
+            datasets = _get_datasets(self.path)
+            datasets_list = sorted(datasets, key=lambda i: i[1], reverse=True)
+            name, size, shape, dtype = datasets_list[0]
+            self.ds_path = name
         with self.get_reader().get_h5ds() as h5ds:
             self._dtype = h5ds.dtype
             self._shape = Shape(h5ds.shape, sig_dims=self.sig_dims)

--- a/tests/io/datasets/test_frms6.py
+++ b/tests/io/datasets/test_frms6.py
@@ -49,6 +49,39 @@ def test_simple_open(default_frms6):
     assert tuple(default_frms6.shape) == (256, 256, 264, 264)
 
 
+def test_auto_open_corrections_kwargs(lt_ctx):
+    ds_corr = lt_ctx.load(
+        'auto', path=FRMS6_TESTDATA_PATH, enable_offset_correction=True, nav_shape=(2, 3)
+    )
+    assert not np.allclose(ds_corr.get_correction_data().get_dark_frame(), 0)
+    assert tuple(ds_corr.shape.nav) == (2, 3)
+
+    ds = lt_ctx.load(
+        'auto', path=FRMS6_TESTDATA_PATH, enable_offset_correction=False, nav_shape=(2, 3)
+    )
+    assert not ds.get_correction_data().have_corrections()
+    assert tuple(ds.shape.nav) == (2, 3)
+
+
+def test_auto_open_corrections_posargs(lt_ctx):
+    ds_corr = lt_ctx.load('auto', FRMS6_TESTDATA_PATH, True, None, None, (2, 3))
+    assert not np.allclose(ds_corr.get_correction_data().get_dark_frame(), 0)
+    assert tuple(ds_corr.shape.nav) == (2, 3)
+
+    ds = lt_ctx.load('auto', FRMS6_TESTDATA_PATH, False, None, None, (2, 3))
+    assert not ds.get_correction_data().have_corrections()
+    assert tuple(ds.shape.nav) == (2, 3)
+
+    ds_corr = lt_ctx.load('frms6', FRMS6_TESTDATA_PATH, True, None, None, (2, 3))
+    assert not np.allclose(ds_corr.get_correction_data().get_dark_frame(), 0)
+    assert tuple(ds_corr.shape.nav) == (2, 3)
+
+    ds = lt_ctx.load('frms6', FRMS6_TESTDATA_PATH, False, None, None, (2, 3))
+    assert not ds.get_correction_data().have_corrections()
+    assert tuple(ds.shape.nav) == (2, 3)
+
+
+
 def test_detetct(lt_ctx):
     assert FRMS6DataSet.detect_params(
         FRMS6_TESTDATA_PATH, lt_ctx.executor

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -83,9 +83,8 @@ def test_filetype_auto(hdf5, lt_ctx):
 
 
 def test_filetype_auto_fail_no_path(lt_ctx):
-    with pytest.raises(DataSetException) as e:
+    with pytest.raises(TypeError) as e:
         lt_ctx.load("auto")
-    assert e.match("please specify the `path` kwarg to allow auto detection")
 
 
 def test_filetype_auto_fail_file_does_not_exist(lt_ctx):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,7 @@ from libertem.udf.raw import PickUDF
 from libertem.udf.masks import ApplyMasksUDF
 from libertem.corrections import CorrectionSet
 from libertem.corrections.detector import correct
+from libertem.io.dataset.base.backend import IOBackend, IOBackendImpl
 
 
 def _naive_mask_apply(masks, data):
@@ -242,3 +243,19 @@ def get_testdata_path():
             os.path.join(os.path.dirname(__file__), '..', 'data')
         )
     )
+
+
+class FakeBackend(IOBackend, id_="fake"):
+    def get_impl(self):
+        return FakeBackendImpl()
+
+
+class FakeBackendImpl(IOBackendImpl):
+    def get_tiles(
+        self, tiling_scheme, fileset, read_ranges, roi, native_dtype, read_dtype, decoder,
+        sync_offset, corrections,
+    ):
+        raise RuntimeError("nothing to see here")
+        # to make this a generator, there needs to be a yield statement in
+        # the body of the function, even if it is never executed:
+        yield


### PR DESCRIPTION
Closes #936

This change allows to pass arbitrary positional and keyword arguments to
datasets loaded with 'auto' and with a specified type. This is tested with
FRMS6 since it triggered the original bug and has a number of
optional arguments which are convenient for testing.

* Turn `executor` and `enable_async` into keyword-only arguments to avoid
  collisions with user-provided positional arguments
* Make sure that *args and **kwargs are passed forward in all cases
* Avoid auto-detected parameters overriding or colliding with user-
  provided arguments. That is achieved by ignoring all
  detected values except the type
* Consequence: Make sure that dataset initialization can autodetect
  all optional or detectable parameters since they will not be passed
  to load() anymore. Only `ds_path` for HDF5 seemed to be affected.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--
