### PR TITLE
Restructure documentation a bit, switch to read-the-docs theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ cost-efficient system built from stock components. All CPU cores and CUDA device
 a system can be used in parallel.
 
 LiberTEM is supported on Linux, Mac OS X and Windows. Other platforms that allow
-installation of Python 3 and the required packages will likely work as well. The
+installation of Python 3.6+ and the required packages will likely work as well. The
 GUI is running in a web browser.
 
 Installation

--- a/docs/source/acknowledgments.rst
+++ b/docs/source/acknowledgments.rst
@@ -125,17 +125,30 @@ notebook project, which has the following license:
 Funding
 ~~~~~~~
 
-.. |clearfloat|  raw:: html
+.. raw:: html
 
-    <div class="clearer"></div>
+    <style>
+        .libertem-ack-item { display: flex; }
+        .libertem-ack-item img { display: block; }
+        .libertem-ack-item > a { flex-shrink: 0; display: block; padding-right: 20px; }
+    </style>
+
+.. |itemstart|  raw:: html
+
+    <div class="libertem-ack-item">
+
+.. |itemend|  raw:: html
+
+    </div>
 
 LiberTEM kindly acknowledges funding and support from the following sources:
 
 ERC Proof-of-Concept grant VIDEO
 ................................
 
+|itemstart|
+
 .. image:: ./images/EU.jpg
-    :align: left
     :width: 100px
     :alt: European Union flag
     :target: https://erc.europa.eu/projects-figures/erc-funded-projects/results?search_api_views_fulltext=%09Versatile+and+Innovative+Detector+for+Electron+Optics
@@ -144,56 +157,56 @@ This project has received funding from the European Research Council (ERC) under
 the European Union’s Horizon 2020 research and innovation programme (`grant
 agreement No 780487
 <https://erc.europa.eu/projects-figures/erc-funded-projects/results?search_api_views_fulltext=%09Versatile+and+Innovative+Detector+for+Electron+Optics>`_).
-
-|clearfloat|
+|itemend|
 
 CritCat
 .......
 
+|itemstart|
+
 .. image:: ./images/EU.jpg
-    :align: left
     :width: 100px
     :alt: European Union flag
 
 This project has received funding from the European Union's Horizon 2020
 research and innovation programme under `grant agreement No 686053
 <http://www.critcat.eu/>`_.
-
-|clearfloat|
+|itemend|
 
 ESTEEM3
 .......
 
+|itemstart|
+
 .. image:: ./images/EU.jpg
-    :align: left
     :width: 100px
     :alt: European Union flag
 
 This project has received funding from the European Union's Horizon 2020
 research and innovation programme under grant agreement No 823717 – `ESTEEM3
 <https://cordis.europa.eu/project/rcn/220936/factsheet/en>`_.
-
-|clearfloat|
+|itemend|
 
 ERC Synergy grant 3D MAGiC
 ..........................
 
+|itemstart|
+
 .. image:: ./images/EU.jpg
-    :align: left
     :width: 100px
     :alt: European Union flag
 
 This project has received funding from the European Research Council (ERC) under
 the European Union’s Horizon 2020 research and innovation programme (grant
 agreement No 856538).
-
-|clearfloat|
+|itemend|
 
 moreSTEM
 ........
 
+|itemstart|
+
 .. image:: ./images/Helmholtz.png
-    :align: left
     :width: 100px
     :alt: Helmholtz Gemeinschaft Deutscher Forschungszentren
 
@@ -203,14 +216,14 @@ the Helmholtz Association
 within the `Helmholtz Young Investigator Group moreSTEM
 <https://morestem.fz-juelich.de/>`_ under Contract No. VH-NG-1317 at
 Forschungszentrum Jülich in Germany.
-
-|clearfloat|
+|itemend|
 
 Ptychography 4.0
 ................
 
+|itemstart|
+
 .. image:: ./images/Helmholtz-lower.png
-    :align: left
     :width: 100px
     :alt: Helmholtz Gemeinschaft Deutscher Forschungszentren
 
@@ -218,45 +231,45 @@ We gratefully acknowledge funding from the `Information & Data Science Pilot
 Project
 <https://www.helmholtz.de/en/research/information-data-science/information-data-science-pilot-projects/pilot-projects-2/>`_
 "Ptychography 4.0" of the Helmholtz Association.
-
-|clearfloat|
-
+|itemend|
 
 Google Summer of Code
 .....................
 
+|itemstart|
+
 .. image:: images/GSoC-icon-192.png
-    :align: left
     :width: 100px
     :alt: Google Summer of Code logo
 
 We kindly acknowledge funding from `Google Summer of Code 2019
 <https://summerofcode.withgoogle.com/>`_ under the `umbrella of the Python
 software foundation <https://python-gsoc.org/>`_.
-
-|clearfloat|
+|itemend|
 
 Gatan Inc.
 ..........
 
+|itemstart|
+
 .. image:: images/Gatan-logo-vertical.png
-    :align: left
     :width: 100px
     :alt: Gatan Inc.
 
 STEMx equipment and software for 4D STEM data acquisition with K2 IS camera
 courtesy of `Gatan Inc <https://www.gatan.com/>`_.
-
-|clearfloat|
+|itemend|
 
 Forschungszentrum Jülich, Ernst-Ruska Centrum
 .............................................
 
+|itemstart|
+
 .. image:: ./images/FZJ.jpg
-    :align: left
     :width: 100px
     :alt: Forschungszentrum Jülich GmbH
     :target: https://www.fz-juelich.de/er-c/EN/Home/home_node.html
 
 Forschungszentrum Jülich is supporting LiberTEM with funding for personnel,
 access to its infrastructure and administrative support.
+|itemend|

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -76,8 +76,8 @@ all parts can run on a single node. We can also skip the caching step, if the da
 is already available locally.
 
 When taking care to avoid needless copying and buffering, we can achieve native
-throughput on each node. With NVMe SSDs, this means we can `process multiple
-gigabytes per second per node <performance>`_.
+throughput on each node. With NVMe SSDs, this means we can :ref:`process multiple
+gigabytes per second per node <performance>`.
 
 
 Mathematical expression for applying masks

--- a/docs/source/changelog/features/corrections.rst
+++ b/docs/source/changelog/features/corrections.rst
@@ -1,5 +1,5 @@
 [Feature] configurable corrections
 ==================================
 
-* Corrections can now be specified by the user when running a UDF (:pr:`778,831`) 
+* Corrections can now be specified by the user when running a UDF (:pr:`778,831,939`) 
 * Support for loading dark frame and gaim map that are sometimes shipped with SEQ data sets

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,6 +67,7 @@ extensions = [
     'nbsphinx_link',
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx_issues',
+    'sphinx_rtd_theme',
 ]
 
 bibtex_bibfiles = ['references-libertem.bib']
@@ -104,7 +105,9 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
+
+html_logo = '_static/logo.png'
 
 html_favicon = '../../corporatedesign/logo/favicon.ico'
 
@@ -113,7 +116,6 @@ html_favicon = '../../corporatedesign/logo/favicon.ico'
 # documentation.
 #
 html_theme_options = {
-    'logo': 'logo.png'
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ import libertem
 # -- Project information -----------------------------------------------------
 
 project = 'LiberTEM'
-copyright = '2018, LiberTEM Authors'
+copyright = '2021, LiberTEM Authors'
 author = 'LiberTEM Authors'
 
 _version_bits = libertem.__version__.split('.')

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -49,7 +49,7 @@ Before creating a pull request, please make sure all tests still pass. See
 and add test cases for your contribution. See the section `Code coverage`_ below
 on how to check if your new code is covered by tests.
 
-To make sure our code base stays readable, we follow a `Code Style`_.
+To make sure our code base stays readable and consistent, we follow a `Code Style`_.
 
 Please update ``packaging/creators.json`` with your author information when you
 contribute to LiberTEM for the first time. This helps us to keep track of all
@@ -147,6 +147,13 @@ Now you can run pytest on a subset of tests, for example:
 
    (libertem) $ pytest tests/test_analysis_masks.py
 
+Or you can run tests in parallel, which may make sense if you have a beefy
+machine with many cores and a lot of RAM:
+
+.. code-block:: shell
+
+   (libertem) $ pytest -n auto tests/
+
 See the `pytest documentation
 <https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests>`_
 for details on how to select which tests to run. Before submitting a pull
@@ -178,7 +185,7 @@ In these examples, ``--`` separates the the arguments of tox (left of ``--``)
 from the arguments for pytest on the right. List of marks used in our test
 suite:
 
-- `slow`: tests that take much more than 1 second to run
+- `slow`: tests that take much longer than 1 second to run
 - `functional`: tests that spin up a local dask cluster
 
 CUDA
@@ -265,45 +272,6 @@ default:
    $ cd client/
    $ npm test
 
-On Windows
-~~~~~~~~~~
-
-On Windows with Anaconda, you have to create named aliases for the Python
-interpreter before you can run :literal:`tox` so that tox finds the python
-interpreter where it is expected. Assuming that you run LiberTEM with Python
-3.6, place the following file as :literal:`python3.6.bat` in your LiberTEM conda
-environment base folder, typically
-:literal:`%LOCALAPPDATA%\\conda\\conda\\envs\\libertem\\`, where the
-:literal:`python.exe` of that environment is located.
-
-.. code-block:: bat
-
-    @echo off
-    REM @echo off is vital so that the file doesn't clutter the output
-    REM execute python.exe with the same command line
-    @python.exe %*
-
-To execute tests with Python 3.7, you create a new environment with Python 3.7:
-
-.. code-block:: shell
-
-    > conda create -n libertem-3.7 python=3.7
-
-Now you can create :literal:`python3.7.bat` in your normal LiberTEM environment
-alongside :literal:`python3.6.bat` and make it execute the Python interpreter of
-your new libertem-3.7 environment:
-
-.. code-block:: bat
-
-    @echo off
-    REM @echo off is vital so that the file doesn't clutter the output
-    REM execute python.exe in a different environment
-    REM with the same command line
-    @%LOCALAPPDATA%\conda\conda\envs\libertem-3.7\python.exe %*
-
-See also:
-https://tox.readthedocs.io/en/latest/developers.html#multiple-python-versions-on-windows
-
 Code style
 ----------
 
@@ -313,7 +281,7 @@ the flake8 section in :code:`setup.cfg` for the current PEP8 settings. As a
 general rule, try to keep your changes in a similar style as the surrounding
 code.
 
-You can check the code style by running:
+Before submitting a pull request, please check the code style by running:
 
 .. code-block:: bat
 
@@ -344,7 +312,11 @@ the live building process:
 
     $ tox -e docs
 
-You can then view a live-built version at http://localhost:8008
+You can then view the documentation at http://localhost:8008, which will
+be rebuilt every time a change to the documentation source code is detected.
+Note that changes to the Python source code don't trigger a rebuild, so if
+you are working on docstrings, you may have to manually trigger a rebuild,
+for example by saving one of the :code:`.rst` files.
 
 You can include code samples with the `doctest sphinx extension
 <https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html>`_ and test
@@ -356,10 +328,10 @@ them with
 
 .. _`building the client`:
 
-Building the client
--------------------
+Building the GUI (client)
+-------------------------
 
-The LiberTEM client is written in TypeScript, using a combination of
+The LiberTEM GUI (also called the client) is written in TypeScript, using a combination of
 React/Redux/Redux-Saga. The client communicates with the Python API server using
 both HTTP and websockets. Because browsers can't directly execute TypeScript,
 there is a build step involved, which translates the TypeScript code into
@@ -367,13 +339,13 @@ JavaScript that is then understood by the browser. This build step is needed
 both for development and then again for building the production version.
 
 If you would like to contribute to the client, you first need to set up the
-development environment. For this, first install NodeJS. On Linux, we recommend
+development environment. For this, first install Node.js. On Linux, we recommend
 to `install via package manager
 <https://nodejs.org/en/download/package-manager/>`_, on Windows `the installer
 <https://nodejs.org/en/download/>`_ should be fine. Choose the current LTS
 version.
 
-One you have NodeJS installed, you should have the :code:`npm` command available
+One you have Node.js installed, you should have the :code:`npm` command available
 in your path. You can then install the needed build tools and dependencies by
 changing to the client directory and running the install command:
 

--- a/docs/source/dev/setup.rst
+++ b/docs/source/dev/setup.rst
@@ -1,0 +1,105 @@
+Setting up a development environment
+====================================
+
+.. note::
+    Distinguish between installing a released version and installing the latest
+    development version. Both :ref:`installing from PyPi` and :ref:`installing from a git
+    clone` use pip, but they do fundamentally different things. :code:`pip
+    install libertem` downloads the latest release from PyPi.
+
+    Changing directory to a git clone and running :code:`pip install -e .`
+    installs from the local directory in editable mode. "Editable mode" means
+    that the source directory is linked into the current Python environment
+    rather than copied. That means changes in the source directory are
+    immediately active in the Python environment.
+
+    Installing from a git clone in editable mode is the correct setup for
+    development work and using :ref:`the latest features in the development
+    branch <continuous>`. Installing from PyPI is easier and preferred for
+    production use and for new users.
+
+
+When you want to develop LiberTEM itself, or run the latest git version, the installation works a
+bit differently as opposed to installing from PyPi.
+As a first step, please follow the instructions for creating a Python virtual environment from
+the :ref:`installation` section. Then, instead of installing from PyPi, follow the instructions below.
+
+.. _`installing from a git clone`:
+
+Installing from a git clone
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to follow the latest development, you should install LiberTEM from
+a git clone. As a prerequisite, you need to have git installed on your system. On Linux,
+we suggest using the git package that comes with your package manager. On Windows, you can use one
+of the many available clients, like  `git for windows <https://gitforwindows.org/>`_, 
+`GitHub Desktop <https://desktop.github.com/>`_, `TortoiseGit <https://tortoisegit.org/>`_,
+or the git integration of your development environment.
+
+.. code-block:: shell
+
+    $ git clone https://github.com/LiberTEM/LiberTEM
+
+Or, if you wish to contribute to LiberTEM, create a fork of the LiberTEM repository
+by following these steps:
+
+#. Log into your `GitHub <https://github.com/>`_ account.
+
+#. Go to the `LiberTEM GitHub <https://github.com/liberteM/LiberTEM/>`_ home page.
+
+#. Click on the *fork* button:
+
+    ..  figure:: ../images/forking_button.png
+
+#. Clone your fork of LiberTEM from GitHub to your computer
+
+.. code-block:: shell
+
+    $ git clone https://github.com/your-user-name/LiberTEM
+
+For more information about `forking a repository
+<https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_.
+For a beginner-friendly introduction to git and GitHub, consider going through
+the following resources:
+
+* This `free course <https://www.udacity.com/course/version-control-with-git--ud123>`_
+  covers the essentials of using Git.
+* Practice `pull request <https://github.com/firstcontributions/first-contributions>`_
+  in a safe sandbox environment.
+* Sample `workflow <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`_
+  for contributing code.
+
+Activate the Python environment (conda or virtualenv) and change to the newly
+created directory with the clone of the LiberTEM repository. Now you can start
+the LiberTEM installation. Please note the dot at the end, which indicates the
+current directory!
+
+.. code-block:: shell
+
+    (libertem) $ pip install -e .
+
+This should download the dependencies and install LiberTEM in the environment.
+Please continue by reading the :ref:`usage documentation`.
+
+Installing extra dependencies works just like with PyPi:
+
+.. code-block:: shell
+
+    (libertem) $ pip install -e .[torch,hdbscan,cupy]
+
+Updating
+~~~~~~~~
+
+If you have installed from a git clone, you can easily update it to the current
+status. Open a command line in the base directory of the LiberTEM clone and
+update the source code with this command:
+
+.. code-block:: shell
+
+    $ git pull
+
+The installation with ``pip install -e`` has installed LiberTEM in `"editable"
+mode <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_.
+That means the changes pulled from git are active immediately. Only if the
+requirements for installed third-party packages have changed, you should re-run
+``pip install -e .`` in order to install any missing packages.

--- a/docs/source/dev/setup.rst
+++ b/docs/source/dev/setup.rst
@@ -1,15 +1,37 @@
 Setting up a development environment
 ====================================
 
+When you want to develop LiberTEM itself, or run the latest git version, the installation works a
+bit differently as opposed to installing from PyPI.
+As a first step, please follow the instructions for creating a Python virtual environment from
+the :ref:`installation` section. Then, instead of installing from PyPI, follow the instructions below.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+In addition to a Python installation, there are a few system dependencies needed when contributing:
+
+* `pandoc <https://pandoc.org/installing.html>`_ is needed to build the documentation
+* Node.js is needed for rebuilding the LiberTEM GUI. On Linux, we recommend
+  to `install via package manager
+  <https://nodejs.org/en/download/package-manager/>`_, on Windows `the installer
+  <https://nodejs.org/en/download/>`_ should be fine. Choose the current LTS
+  version.
+
+.. _`installing from a git clone`:
+
+Installing from a git clone
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. note::
     Distinguish between installing a released version and installing the latest
-    development version. Both :ref:`installing from PyPi` and :ref:`installing from a git
+    development version. Both :ref:`installing from PyPI` and :ref:`installing from a git
     clone` use pip, but they do fundamentally different things. :code:`pip
-    install libertem` downloads the latest release from PyPi.
+    install libertem` downloads the latest release from PyPI.
 
     Changing directory to a git clone and running :code:`pip install -e .`
     installs from the local directory in editable mode. "Editable mode" means
-    that the source directory is linked into the current Python environment
+    that the source directory is "linked" into the current Python environment
     rather than copied. That means changes in the source directory are
     immediately active in the Python environment.
 
@@ -17,17 +39,6 @@ Setting up a development environment
     development work and using :ref:`the latest features in the development
     branch <continuous>`. Installing from PyPI is easier and preferred for
     production use and for new users.
-
-
-When you want to develop LiberTEM itself, or run the latest git version, the installation works a
-bit differently as opposed to installing from PyPi.
-As a first step, please follow the instructions for creating a Python virtual environment from
-the :ref:`installation` section. Then, instead of installing from PyPi, follow the instructions below.
-
-.. _`installing from a git clone`:
-
-Installing from a git clone
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to follow the latest development, you should install LiberTEM from
 a git clone. As a prerequisite, you need to have git installed on your system. On Linux,
@@ -81,7 +92,7 @@ current directory!
 This should download the dependencies and install LiberTEM in the environment.
 Please continue by reading the :ref:`usage documentation`.
 
-Installing extra dependencies works just like with PyPi:
+Installing extra dependencies works just like when installing LiberTEM from PyPI:
 
 .. code-block:: shell
 
@@ -103,3 +114,43 @@ mode <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_.
 That means the changes pulled from git are active immediately. Only if the
 requirements for installed third-party packages have changed, you should re-run
 ``pip install -e .`` in order to install any missing packages.
+
+Setting up tox on Windows
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We are using tox to run our tests.
+On Windows with Anaconda, you have to create named aliases for the Python
+interpreter before you can run :literal:`tox` so that tox finds the python
+interpreter where it is expected. Assuming that you run LiberTEM with Python
+3.6, place the following file as :literal:`python3.6.bat` in your LiberTEM conda
+environment base folder, typically
+:literal:`%LOCALAPPDATA%\\conda\\conda\\envs\\libertem\\`, where the
+:literal:`python.exe` of that environment is located.
+
+.. code-block:: bat
+
+    @echo off
+    REM @echo off is vital so that the file doesn't clutter the output
+    REM execute python.exe with the same command line
+    @python.exe %*
+
+To execute tests with Python 3.7, you create a new environment with Python 3.7:
+
+.. code-block:: shell
+
+    > conda create -n libertem-3.7 python=3.7
+
+Now you can create :literal:`python3.7.bat` in your normal LiberTEM environment
+alongside :literal:`python3.6.bat` and make it execute the Python interpreter of
+your new libertem-3.7 environment:
+
+.. code-block:: bat
+
+    @echo off
+    REM @echo off is vital so that the file doesn't clutter the output
+    REM execute python.exe in a different environment
+    REM with the same command line
+    @%LOCALAPPDATA%\conda\conda\envs\libertem-3.7\python.exe %*
+
+See also:
+https://tox.readthedocs.io/en/latest/developers.html#multiple-python-versions-on-windows

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -49,8 +49,8 @@ have to be entered as separated values into the fields. You can hit a comma to j
 the next field. We follow the NumPy convention here and specify the "fast-access" dimension
 last, so a value of :code:`42`, :code:`21` would mean the same as specifying
 :code:`(42, 21)` in the Python API, setting :code:`y=42` and :code:`x=21`. Note that the GUI
-is currently limited to 2D visualizations, while the scripting API should handle more
-general visualizations.
+is currently limited to 2D visualizations, while the scripting API can handle more
+general cases.
 
 See also :ref:`the concepts section <concepts>`.
 
@@ -71,8 +71,12 @@ There are some common parameters across data set types:
   when using the Python API, it can be of any dimensionality.
 `sync_offset`
   You can specify a `sync_offset` to handle synchronization or acquisition problems.
-  If it's positive, `sync_offset` number of frames would be skipped from start.
-  If it's negative, `abs(sync_offset)` number of blank frames would be inserted at start.
+  If it's positive, `sync_offset` number of frames will be skipped from start.
+  If it's negative, `abs(sync_offset)` number of blank frames will be inserted at start.
+`io_backend`
+  Different methods for I/O are available in LiberTEM, which can influence performance. 
+  See :ref:`io backends` for details.
+  
 
 .. _`supported formats`:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,31 +16,41 @@ Documentation
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Contents
    
-
    install
    usage
-   concepts
-   api
-   formats
-   udf
-   packages
-   sample_datasets
    applications
-   architecture
-   performance
-   debugging
-   reference/index
+   formats
+   sample_datasets
+   api
+   udf
    changelog
-   tips
-   why_python
-   gsoc
-   contributing
-   authorship
    citing
    acknowledgments
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   reference/index
+   tips
+   packages
+   concepts
+   performance
+   why_python
+
+.. toctree::
+   :maxdepth: 2
+   :caption: For developers
+
+   contributing
+   dev/setup.rst
    dev/how-io-works
+   architecture
+   debugging
+   gsoc
+   authorship
 
 Indices and tables
 ------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ Documentation
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents
+   :caption: User manual
    
    install
    usage

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,11 +44,11 @@ Documentation
    :maxdepth: 2
    :caption: For developers
 
-   contributing
    dev/setup.rst
-   dev/how-io-works
-   architecture
+   contributing
    debugging
+   architecture
+   dev/how-io-works
    gsoc
    authorship
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -124,9 +124,9 @@ For more information about conda, see their `documentation about creating and
 managing environments
 <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_.
 
-.. _`installing from PyPi`:
+.. _`installing from PyPI`:
 
-Installing from PyPi
+Installing from PyPI
 ~~~~~~~~~~~~~~~~~~~~
 
 To install the latest release version, you can use pip. Activate the Python
@@ -149,7 +149,7 @@ we recommend `installing PyTorch <https://pytorch.org/>`_. We currently use
 PyTorch only on the CPU. Contributions to use GPUs as well are very welcome!
 
 You can let pip install PyTorch automatically by using the torch variant, for
-example from PyPi:
+example from PyPI:
 
 .. code-block:: shell
 
@@ -180,7 +180,7 @@ dependency because of installation issues on some platforms.
 Updating
 ~~~~~~~~
 
-When installed from PyPi via pip, you can update like this:
+When installed from PyPI via pip, you can update like this:
 
 .. code-block:: shell
 
@@ -191,7 +191,9 @@ have changed.
 
 After updating the installation, you can run the updated version by restarting
 the libertem-server and afterwards reloading all browser windows that are
-running the LiberTEM GUI.
+running the LiberTEM GUI. In other environments, like jupyter notebooks, you
+need to restart the Python interpreter to make sure the new version is used,
+for example by restarting the ipython kernel.
 
 .. _`install on windows`:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,7 +12,8 @@ Installation
 
 .. include:: _single_node.rst
 
-The short version:
+The short version
+-----------------
 
 .. code-block:: shell
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -7,24 +7,23 @@ Installation
     LiberTEM can currently be used on Python 3.6, 3.7 and 3.8. Support for Python 3.9
     is not finished yet, as some of our dependencies are not ready yet.
 
-.. note::
-    Distinguish between installing a released version and installing the latest
-    development version. Both `installing from PyPi`_ and `installing from a git
-    clone`_ use pip, but they do fundamentally different things. :code:`pip
-    install libertem` downloads the latest release from PyPi.
-
-    Changing directory to a git clone and running :code:`pip install -e .`
-    installs from the local directory in editable mode. "Editable mode" means
-    that the source directory is linked into the current Python environment
-    rather than copied. That means changes in the source directory are
-    immediately active in the Python environment.
-
-    Installing from a git clone in editable mode is the correct setup for
-    development work and using :ref:`the latest features in the development
-    branch <continuous>`. Installing from PyPI is easier and preferred for
-    production use and for new users.
+    If you would like to install the latest development version, please also
+    see :ref:`installing from a git clone`.
 
 .. include:: _single_node.rst
+
+The short version:
+
+.. code-block:: shell
+
+    $ virtualenv -p python3 ~/libertem-venv/
+    $ source ~/libertem-venv/bin/activate
+    (libertem) $ pip install "libertem[torch]"
+
+    # optional for GPU support
+    (libertem) $ pip install cupy
+
+For details, please read on!
 
 Linux and Mac OS X
 ------------------
@@ -84,8 +83,8 @@ working with virtualenvs, using a convenience wrapper like `virtualenvwrapper
 Using conda
 ###########
 
-If you are already using conda, or if you don't have a system-wide Python 3.6 or
-3.7 installation, you can create a conda environment for LiberTEM.
+If you are already using conda, or if you don't have a system-wide Python 3.6, 3.7 or
+3.8 installation, you can create a conda environment for LiberTEM.
 
 This section assumes that you have `installed conda
 <https://conda.io/projects/conda/en/latest/user-guide/install/index.html#regular-installation>`_
@@ -96,7 +95,7 @@ command:
 
 .. code-block:: shell
 
-    $ conda create -n libertem python=3.7
+    $ conda create -n libertem python=3.8
 
 To install or later run LiberTEM, activate the environment with the following
 command (see also :ref:`install on windows` if applicable):
@@ -118,6 +117,8 @@ For more information about conda, see their `documentation about creating and
 managing environments
 <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_.
 
+.. _`installing from PyPi`:
+
 Installing from PyPi
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -130,59 +131,6 @@ environment (conda or virtualenv) and install using:
 
 This should install LiberTEM and its dependencies in the environment. Please
 continue by reading the :ref:`usage documentation`.
-
-.. _`installing from a git clone`:
-
-Installing from a git clone
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you want to follow the latest development, you should install LiberTEM from
-a git clone:
-
-.. code-block:: shell
-
-    $ git clone https://github.com/LiberTEM/LiberTEM
-
-Or, if you wish to contribute to LiberTEM, create a fork of the LiberTEM repository
-by following these steps:
-
-#. Log into your `GitHub <https://github.com/>`_ account.
-
-#. Go to the `LiberTEM GitHub <https://github.com/liberteM/LiberTEM/>`_ home page.
-
-#. Click on the *fork* button:
-
-    ..  figure:: ./images/forking_button.png
-
-#. Clone your fork of LiberTEM from GitHub to your computer
-
-.. code-block:: shell
-
-    $ git clone https://github.com/your-user-name/LiberTEM
-
-For more information about `forking a repository
-<https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_.
-For a beginner-friendly introduction to git and GitHub, consider going through
-the following resources:
-
-* This `free course <https://www.udacity.com/course/version-control-with-git--ud123>`_
-  covers the essentials of using Git.
-* Practice `pull request <https://github.com/firstcontributions/first-contributions>`_
-  in a safe sandbox environment.
-* Sample `workflow <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`_
-  for contributing code.
-
-Activate the Python environment (conda or virtualenv) and change to the newly
-created directory with the clone of the LiberTEM repository. Now you can start
-the LiberTEM installation. Please note the dot at the end, which indicates the
-current directory!
-
-.. code-block:: shell
-
-    (libertem) $ pip install -e .
-
-This should download the dependencies and install LiberTEM in the environment.
-Please continue by reading the :ref:`usage documentation`.
 
 PyTorch
 ~~~~~~~
@@ -200,12 +148,6 @@ example from PyPi:
 
     (libertem) $ pip install "libertem[torch]"
 
-Or from git checkout:
-
-.. code-block:: shell
-
-    (libertem) $ pip install -e .[torch]
-
 CuPy
 ~~~~
 
@@ -214,12 +156,6 @@ GPU support is based on `CuPy <https://cupy.chainer.org/>`_.
 .. code-block:: shell
 
     (libertem) $ pip install "libertem[cupy]"
-
-Or from git checkout:
-
-.. code-block:: shell
-
-    (libertem) $ pip install -e .[cupy]
 
 .. versionadded:: 0.6.0
 
@@ -237,19 +173,14 @@ dependency because of installation issues on some platforms.
 Updating
 ~~~~~~~~
 
-If you have installed from a git clone, you can easily update it to the current
-status. Open a command line in the base directory of the LiberTEM clone and
-update the source code with this command:
+When installed from PyPi via pip, you can update like this:
 
 .. code-block:: shell
 
-    $ git pull
+    (libertem) $ pip install -U libertem
 
-The installation with ``pip install -e`` has installed LiberTEM in `"editable"
-mode <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_.
-That means the changes pulled from git are active immediately. Only if the
-requirements for installed third-party packages have changed, you should re-run
-``pip install -e .`` in order to install any missing packages.
+This should install a new version of LiberTEM and update all requirements that
+have changed.
 
 After updating the installation, you can run the updated version by restarting
 the libertem-server and afterwards reloading all browser windows that are
@@ -264,13 +195,7 @@ The recommended method to install LiberTEM on Windows is based on `Miniconda 64
 bit with Python version 3.6 or 3.7 <https://www.anaconda.com/distribution/>`_.
 This installs a Python distribution.
 
-For `installing from a git clone`_ you require a suitable git client, for
-example `GitHub Desktop <https://desktop.github.com/>`_, `TortoiseGit
-<https://tortoisegit.org/>`_, or `git for windows
-<https://gitforwindows.org/>`_. Clone the repository
-https://github.com/LiberTEM/LiberTEM in a folder of your choice.
-
-From here on the installation and running of LiberTEM on Windows with the
+The installation and running of LiberTEM on Windows with the
 Anaconda Prompt is very similar to `Using conda`_ on Linux or Mac OS X.
 
 Differences:
@@ -290,57 +215,8 @@ Differences:
 
     (libertem) > conda install pip
 
-Jupyter
--------
-
-To use the Python API from within a Jupyter notebook, you can install Jupyter
-into your LiberTEM virtual environment.
-
-.. code-block:: shell
-
-    (libertem) $ pip install jupyter
-
-You can then run a local notebook from within the LiberTEM environment, which
-should open a browser window with Jupyter that uses your LiberTEM environment.
-
-.. code-block:: shell
-
-    (libertem) $ jupyter notebook
-
-JupyterHub
-----------
-
-If you'd like to use the Python API from a LiberTEM virtual environment on a
-system that manages logins with JupyterHub, you can easily `install a custom
-kernel definition
-<https://ipython.readthedocs.io/en/stable/install/kernel_install.html>`_ for
-your LiberTEM environment.
-
-First, you can launch a terminal on JupyterHub from the "New" drop-down menu in
-the file browser. Alternatively you can execute shell commands by prefixing them
-with "!" in a Python notebook.
-
-In the terminal you can create and activate virtual environments and perform the
-LiberTEM installation as described above. Within the activated LiberTEM
-environment you additionally install ipykernel:
-
-.. code-block:: shell
-
-    (libertem) $ pip install ipykernel
-
-Now you can create a custom ipython kernel definition for your environment:
-
-.. code-block:: shell
-
-    (libertem) $ python -m ipykernel install --user --name libertem --display-name "Python (libertem)"
-
-After reloading the file browser window, a new Notebook option "Python
-(libertem)" should be available in the "New" drop-down menu. You can test it by
-creating a new notebook and running
-
-.. code-block:: python
-
-    In [1]: import libertem
+This should install LiberTEM and its dependencies in the environment. Please
+continue by reading the :ref:`usage documentation`.
 
 Troubleshooting
 ---------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -43,14 +43,16 @@ Creating an isolated Python environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To provide an isolated environment for LiberTEM and its dependencies, you can
-use virtualenvs or conda environments.
+use virtualenvs or conda environments. This is important if you want to use
+different Python applications that may have conflicting dependencies, and it
+allows to quickly re-create an environment in case things go sideways.
 
 Using virtualenv
 ################
 
 You can use `virtualenv <https://virtualenv.pypa.io/>`_ or `venv
 <https://docs.python.org/3/tutorial/venv.html>`_ if you have a system-wide
-Python 3.6, 3.7 or 3.8 installation. For Mac OS X, using conda is recommended.
+Python 3.6, 3.7 or 3.8 installation. For Mac OS X, using `conda`_ is recommended.
 
 To create a new virtualenv for LiberTEM, you can use the following command:
 
@@ -81,13 +83,17 @@ without :code:`source`, please `refer to the virtualenv documentation
 working with virtualenvs, using a convenience wrapper like `virtualenvwrapper
 <https://virtualenvwrapper.readthedocs.io/en/latest/>`_ is recommended.
 
+Continue by `installing from PyPI`_.
+
+.. _`conda`:
+
 Using conda
 ###########
 
 If you are already using conda, or if you don't have a system-wide Python 3.6, 3.7 or
 3.8 installation, you can create a conda environment for LiberTEM.
 
-This section assumes that you have `installed conda
+This section assumes that you have `installed anaconda or miniconda
 <https://conda.io/projects/conda/en/latest/user-guide/install/index.html#regular-installation>`_
 and that your installation is working.
 

--- a/docs/source/packages.rst
+++ b/docs/source/packages.rst
@@ -12,3 +12,7 @@ This list provides an overview of the current sub-packages and is constantly upd
 :libertem-blobfinder:
     Since 0.4.0: Correlation-based peak finding and strain mapping.
     https://libertem.github.io/LiberTEM-blobfinder/
+
+:libertem-holo:
+    Since 0.6.0: Off-axis electron holography (work in progress)
+    https://github.com/LiberTEM/LiberTEM-holo/

--- a/docs/source/reference/application.rst
+++ b/docs/source/reference/application.rst
@@ -1,7 +1,12 @@
 .. _`application api`:
 
-Application-specific API
-========================
+Application-specific APIs
+=========================
+
+.. note::
+    Starting from 0.4.0, the application-specific code of LiberTEM will be
+    spun out step by step as sub-packages that can be installed independent of
+    LiberTEM core. See :ref:`packages` for the current overview of sub-packages.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,7 +1,7 @@
 .. _reference:
 
-Reference
-=========
+Python API reference
+====================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -9,6 +9,7 @@ Python API reference
    api
    udf
    dataset
+   io_backends
    application
    masks
    internals

--- a/docs/source/reference/io_backends.rst
+++ b/docs/source/reference/io_backends.rst
@@ -1,0 +1,25 @@
+
+.. _`io backends`:
+
+I/O Backends
+============
+
+By default, on Windows, a buffered strategy is chosen, whereas Linux and Mac
+OS use unbuffered memory-mapped I/O. You can pass an instance of
+:class:`~libertem.io.dataset.base.backend.IOBackend` as the :code:`io_backend`
+parameter of :meth:`~libertem.api.Context.load` to use a different backend.
+This allows you to override the default backend choice, or set parameters
+for the backend.
+
+Available I/O backends
+----------------------
+
+BufferedBackend
+~~~~~~~~~~~~~~~
+
+.. autoclass:: libertem.io.dataset.base.BufferedBackend
+
+MmapBackend
+~~~~~~~~~~~
+
+.. autoclass:: libertem.io.dataset.base.MMapBackend

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -13,7 +13,7 @@ See :ref:`user-defined functions` for an introduction and in-depth explanation.
 .. automodule:: libertem.udf.base
    :members:
    :special-members: __init__
-   :exclude-members: UDFTask,UDFRunner
+   :exclude-members: Task,UDFTask,UDFRunner,UDFData
 
 .. _`run udf ref`:
 

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -13,7 +13,7 @@ See :ref:`user-defined functions` for an introduction and in-depth explanation.
 .. automodule:: libertem.udf.base
    :members:
    :special-members: __init__
-   :exclude-members: Task,UDFTask,UDFRunner,UDFData
+   :exclude-members: Task,UDFTask,UDFRunner
 
 .. _`run udf ref`:
 

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -99,8 +99,6 @@ Before (using a release candidate package)
     * Still usable, decent response times?
 * Confirm that pull requests and issues are handled as intended, i.e. milestoned and merged
   in appropriate branch.
-* Add the current LiberTEM version to
-  `CVL <https://github.com/Characterisation-Virtual-Laboratory/CharacterisationVL-Software>`_ (add both the singularity and the .desktop file!)
 
 After releasing on GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,3 +113,5 @@ After releasing on GitHub
 * Send announcement message on mailing list
 * Edit :code:`setup.cfg` to include flaky tests again
 * Bump version in master branch to next .dev0
+* Add the current LiberTEM version to
+  `CVL <https://github.com/Characterisation-Virtual-Laboratory/CharacterisationVL-Software>`_ (add both the singularity and the .desktop file!)

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -106,7 +106,7 @@ After releasing on GitHub
 * Confirm that all release packages are built and release notes are up-to-date
 * Install release package
 * Confirm correct version info
-* confirm package upload to PyPi
+* confirm package upload to PyPI
 * Publish new version on zenodo.org
 * Update documentation with new links, if necessary
     * Add zenodo badge for the new release to Changelog page

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -1,6 +1,8 @@
 Tips and tricks
 ===============
 
+This is a collection of various helpful tips that don't fit in elsewhere.
+
 .. _`ssh forwarding`:
 
 Using SSH forwarding
@@ -219,3 +221,60 @@ Then, as a user, you can use :code:`cgexec` to run a command in that control gro
     cgexec -g cpu:slow pytest tests/
 
 This is useful, for example, to debug test failures that only seem to happen in CI.
+
+
+.. _`jupyter install`:
+
+Jupyter
+-------
+
+To use the Python API from within a Jupyter notebook, you can install Jupyter
+into your LiberTEM virtual environment.
+
+.. code-block:: shell
+
+    (libertem) $ pip install jupyter
+
+You can then run a local notebook from within the LiberTEM environment, which
+should open a browser window with Jupyter that uses your LiberTEM environment.
+
+.. code-block:: shell
+
+    (libertem) $ jupyter notebook
+
+.. _`jupyterhub install`:
+
+JupyterHub
+----------
+
+If you'd like to use the Python API from a LiberTEM virtual environment on a
+system that manages logins with JupyterHub, you can easily `install a custom
+kernel definition
+<https://ipython.readthedocs.io/en/stable/install/kernel_install.html>`_ for
+your LiberTEM environment.
+
+First, you can launch a terminal on JupyterHub from the "New" drop-down menu in
+the file browser. Alternatively you can execute shell commands by prefixing them
+with "!" in a Python notebook.
+
+In the terminal you can create and activate virtual environments and perform the
+LiberTEM installation as described above. Within the activated LiberTEM
+environment you additionally install ipykernel:
+
+.. code-block:: shell
+
+    (libertem) $ pip install ipykernel
+
+Now you can create a custom ipython kernel definition for your environment:
+
+.. code-block:: shell
+
+    (libertem) $ python -m ipykernel install --user --name libertem --display-name "Python (libertem)"
+
+After reloading the file browser window, a new Notebook option "Python
+(libertem)" should be available in the "New" drop-down menu. You can test it by
+creating a new notebook and running
+
+.. code-block:: python
+
+    In [1]: import libertem

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -220,8 +220,9 @@ Then, as a user, you can use :code:`cgexec` to run a command in that control gro
 
     cgexec -g cpu:slow pytest tests/
 
-This is useful, for example, to debug test failures that only seem to happen in CI.
-
+This is useful, for example, to debug test failures that only seem to happen in CI
+or under heavy load. Note that tools like :code:`cgcreate` only work with cgroups v1,
+with newer distributions using cgroups v2 you may have to adapt these instructions.
 
 .. _`jupyter install`:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -41,7 +41,9 @@ There are a few command line options available::
       --help          Show this message and exit.
 
 .. versionadded:: 0.4.0
-    :code:`--browser` / :code:`--no-browser` option is added, open browser by default.
+    :code:`--browser` / :code:`--no-browser` option was added, open browser by default.
+.. versionadded:: 0.6.0
+    :code:`-l, --log-level` was added.
 
 To access LiberTEM remotely, you can use :ref:`use SSH forwarding <ssh forwarding>`.
 
@@ -144,16 +146,23 @@ Running analyses
 ----------------
 
 Once a dataset is loaded, you can add analyses to it. As an example we choose a
-"Ring" analysis.
+"Ring" analysis, which implements a ring-shaped virtual detector.
 
 ..  figure:: ./images/use/add_analysis.png
 
-The GUI shows two windows: On the left it shows the current mask. Directly after
+..  figure:: ./images/use/adjust.png
+
+
+This analysis shows two views on your data: the two detector dimensions on
+the left, the scanning dimensions on the right, assuming a 4D-STEM dataset.
+For the general case, we also call the detector dimensions the *signal
+dimensions*, and the scanning dimensions the *navigation dimensions*.
+
+Directly after
 adding the analysis, LiberTEM starts calculating an average of all the detector
-frames. As soon as this is finished, the average is overlaid with the mask to
-help the user with positioning the virtual detector. The window on the right
+frames. The average is overlaid with the mask representing the virtual detector. The view on the right
 will later show the result of applying the mask to the data. In the beginning it
-is empty. The first processing might take a while depending on file size and IO
+is empty. The first processing might take a while depending on file size and I/O
 performance. Fast SSDs and enough RAM to keep the working files in the file
 system cache are highly recommended for a good user experience.
 
@@ -161,10 +170,8 @@ You can adjust the virtual detector by dragging the handles in the GUI. Below it
 shows the parameters in numerical form. This is useful to extract positions, for
 example for scripting.
 
-..  figure:: ./images/use/adjust.png
-
 After clicking "Apply", LiberTEM performs the calculation and shows the result
-in scan coordinates on the right.
+in scan coordinates on the right side.
 
 ..  figure:: ./images/use/apply.png
 
@@ -194,7 +201,7 @@ rectangle. You can adjust the rectangle by dragging the handles in the GUI.
 ..  figure:: ./images/use/rect.png
 
 Some analyses, such as the Center of Mass (COM) analysis, can render the result
-in different ways. You can select the channel in the "Image" drop-down menu
+in different ways. You can select different result channels in the "Channel" drop-down menu
 below the right window.
 
 ..  figure:: ./images/use/image.png
@@ -219,7 +226,7 @@ continue working with the same parameters using scripting.
 
 .. figure:: ./images/use/download-jupyter.png
 
-Or copy individual cells of Jupyter notebook directly from GUI, also option
+It's also possible to copy individual cells of Jupyter notebook directly from GUI, with an option
 to copy the complete source code.
 
 .. figure:: ./images/use/copy-jupyter.png

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -2,6 +2,7 @@ sphinx>1.4
 sphinx-autobuild
 sphinxcontrib-bibtex>=2
 sphinx-issues
+sphinx-rtd-theme
 nbsphinx
 nbsphinx_link
 ipython

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -715,7 +715,7 @@ class Context:
         corrections
             Corrections to apply while running the UDF. If none are given,
             the corrections that are part of the :code:`DataSet` are used,
-            if there are any.
+            if there are any. See also :ref:`corrections`.
 
         backends : None or iterable containing 'numpy', 'cupy' and/or 'cuda'
             Restrict the back-end to a subset of the capabilities of the UDF.
@@ -767,12 +767,17 @@ class Context:
         return results[0]
 
     def map(self, dataset: DataSet, f, roi: np.ndarray = None,
-            progress: bool = False) -> BufferWrapper:
+            progress: bool = False,
+            corrections: CorrectionSet = None,
+            backends=None) -> BufferWrapper:
         '''
         Create an :class:`AutoUDF` with function :meth:`f` and run it on :code:`dataset`
 
         .. versionchanged:: 0.5.0
             Added the :code:`progress` parameter
+
+        .. versionchanged:: 0.6.0
+            Added the :code:`corrections` and :code:`backends` parameter
 
         Parameters
         ----------
@@ -786,8 +791,13 @@ class Context:
             region of interest as bool mask over the navigation axes of the dataset
         progress : bool
             Show progress bar
-        io_backend : IOBackend or None
-            Use a different I/O backend for running this function
+        corrections
+            Corrections to apply while running the function. If none are given,
+            the corrections that are part of the :code:`DataSet` are used,
+            if there are any. See also :ref:`corrections`.
+        backends : None or iterable containing 'numpy', 'cupy' and/or 'cuda'
+            Restrict the back-end to a subset of the capabilities of the UDF.
+            This can be useful for testing hybrid UDFs.
 
         Returns
         -------
@@ -803,6 +813,8 @@ class Context:
             udf=udf,
             roi=roi,
             progress=progress,
+            corrections=corrections,
+            backends=backends,
         )
         return results['result']
 

--- a/src/libertem/io/dataset/base/backend.py
+++ b/src/libertem/io/dataset/base/backend.py
@@ -22,6 +22,9 @@ class IOBackend:
     def __init__(self):
         pass
 
+    def get_impl(self) -> 'IOBackendImpl':
+        raise NotImplementedError()
+
     @classmethod
     def from_json(cls, msg):
         """

--- a/src/libertem/io/dataset/base/backend_buffered.py
+++ b/src/libertem/io/dataset/base/backend_buffered.py
@@ -90,22 +90,22 @@ def block_get_min_fill_factor(rrs):
 
 
 class BufferedBackend(IOBackend, id_="buffered"):
+    """
+    I/O backend using a buffered reading strategy. Useful for slower media
+    like HDDs, where seeks cause performance drops. Used by default
+    on Windows.
+
+    This does not perform optimally on SSDs under all circumstances, for
+    better best-case performance, try using
+    :class:`~libertem.io.dataset.base.MMapBackend` instead.
+
+    Parameters
+    ----------
+    max_buffer_size : int
+        Maximum buffer size, in bytes. This is passed to the tileshape
+        negotiation to select the right depth.
+    """
     def __init__(self, max_buffer_size=16*1024*1024):
-        """
-        I/O backend using a buffered reading strategy. Useful for slower media
-        like HDDs, where seeks cause performance drops. Used by default
-        on Windows.
-
-        This does not perform optimally on SSDs under all circumstances, for
-        better best-case performance, try using
-        :class:`~libertem.io.dataset.base.MMapBackend` instead.
-
-        Parameters
-        ----------
-        max_buffer_size : int
-            Maximum buffer size, in bytes. This is passed to the tileshape
-            negotiation to select the right depth.
-        """
         self._max_buffer_size = max_buffer_size
 
     @classmethod

--- a/src/libertem/io/dataset/base/backend_mmap.py
+++ b/src/libertem/io/dataset/base/backend_mmap.py
@@ -61,15 +61,16 @@ def _get_prefetch_ranges(num_files, tile_ranges):
 
 
 class MMapBackend(IOBackend, id_="mmap"):
-    def __init__(self, enable_readahead_hints=False):
-        """
-        I/O backend using memory mapped files.
+    """
+    I/O backend using memory mapped files. Used by default on non-Windows
+    systems.
 
-        Parameters
-        ----------
-        enable_readahead_hints : bool
-            Linux only. Try to influence readahead behavior (experimental).
-        """
+    Parameters
+    ----------
+    enable_readahead_hints : bool
+        Linux only. Try to influence readahead behavior (experimental).
+    """
+    def __init__(self, enable_readahead_hints=False):
         self._enable_readahead = enable_readahead_hints
 
     def get_impl(self):

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -57,7 +57,7 @@ class DMDataSet(DataSet):
     Note
     ----
     Single-file 4D DM files are not yet supported. The use-case would be
-    to read DM4 files from the conversion of K2 data, but those data sets
+    to read DM4 files from the conversion of K2 STEMx data, but those data sets
     are actually transposed (nav/sig are swapped).
 
     That means the data would have to be transposed back into the usual shape,

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -555,6 +555,8 @@ class K2ISFile(LocalFile):
 class K2ISDataSet(DataSet):
     """
     Read raw K2IS data sets. They consist of 8 .bin files and one .gtg file.
+    Currently, data acquired using the STEMx unit is supported, metadata
+    about the scan size is read from the .gtg file.
 
     Parameters
     ----------

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -473,9 +473,9 @@ class MIBDataSet(DataSet):
     are assumed to follow a naming pattern of some non-numerical prefix,
     and a sequential numerical suffix.
 
-    Note that, as of the current version, no gain correction or hot/cold pixel
-    removal is done yet: processing is done on the RAW data, though you can do
-    pre-processing in your own UDF.
+    Note that if you are using a per-pixel trigger setup, LiberTEM won't
+    be able to deduce the x scanning dimension - in that case, you will
+    need to specify the `nav_shape` yourself.
 
     Examples
     --------

--- a/src/libertem/io/dataset/mrc.py
+++ b/src/libertem/io/dataset/mrc.py
@@ -74,6 +74,11 @@ class MRCDataSet(DataSet):
     """
     Read MRC files.
 
+    Examples
+    --------
+
+    >>> ds = ctx.load("mrc", path="/path/to/file.mrc")  # doctest: +SKIP
+
     Parameters
     ----------
     path: str

--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -176,6 +176,11 @@ class SEQDataSet(DataSet):
     """
     Read data from Norpix SEQ files.
 
+    Examples
+    --------
+
+    >>> ds = ctx.load("seq", path="/path/to/file.seq", nav_shape=(1024, 1024))  # doctest: +SKIP
+
     Parameters
     ----------
     path

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -90,6 +90,11 @@ class SERDataSet(DataSet):
     """
     Read TIA SER files.
 
+    Examples
+    --------
+
+    >>> ds = ctx.load("ser", path="/path/to/file.ser")  # doctest: +SKIP
+
     Parameters
     ----------
     path: str

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -484,7 +484,7 @@ class UDFBase:
         '''
         Compute back-end library to use.
 
-        Generally, use :code:`self.xp` instead of :code`np` to use NumPy or CuPy transparently
+        Generally, use :code:`self.xp` instead of :code:`np` to use NumPy or CuPy transparently
 
         .. versionadded:: 0.6.0
         '''
@@ -800,6 +800,7 @@ class NoOpUDF(UDF):
         Perform dtype conversion. By default, this is :attr:`UDF.USE_NATIVE_DTYPE`.
     '''
     def __init__(self, preferred_input_dtype=UDF.USE_NATIVE_DTYPE):
+        ""
         super().__init__(preferred_input_dtype=preferred_input_dtype)
 
     def process_tile(self, tile):


### PR DESCRIPTION
Closes #297 

Other than switching to the rtd-theme, I've worked a bit on the structure, including splitting the docs into three main sections: user documentation, reference, developer docs. I've also already split the installation to remove installation from git from the normal installation instructions, which already shortens that section by a bit.

## Contributor Checklist:

* [N/A] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)