### PR TITLE
Handle misconfigured pywin32 gracefully

### DIFF
--- a/src/libertem/win_tweaks.py
+++ b/src/libertem/win_tweaks.py
@@ -3,21 +3,42 @@ import msvcrt
 import ctypes
 from ctypes import windll, wintypes, byref
 import logging
+import warnings
 
-import win32security
-import pywintypes
 
 logger = logging.getLogger(__name__)
 
 
-def get_owner_name(full_path, stat):
-    try:
-        s = win32security.GetFileSecurity(full_path, win32security.OWNER_SECURITY_INFORMATION)
-        sid = s.GetSecurityDescriptorOwner()
-        (name, domain, t) = win32security.LookupAccountSid(None, sid)
-        return "%s\\%s" % (domain, name)
-    except pywintypes.error as e:
-        raise IOError(e)
+def get_owner_name_dummy(full_path, stat):
+    return "Unknown"
+
+
+try:
+    import win32security
+    import pywintypes
+
+    def get_owner_name(full_path, stat):
+        try:
+            s = win32security.GetFileSecurity(full_path, win32security.OWNER_SECURITY_INFORMATION)
+            sid = s.GetSecurityDescriptorOwner()
+            (name, domain, t) = win32security.LookupAccountSid(None, sid)
+            return "%s\\%s" % (domain, name)
+        except pywintypes.error as e:
+            raise IOError(e)
+
+except ModuleNotFoundError:
+    warnings.warn("Install package pywin32 to enable detecting file owners on Windows.")
+
+    get_owner_name = get_owner_name_dummy
+
+except ImportError as e:
+    warnings.warn(
+        f"Importing modules from pywin32 failed. {e} "
+        "Possibly the post installation script of pywin32 has to be run. More information: "
+        "https://github.com/mhammond/pywin32#installing-via-pip"
+    )
+
+    get_owner_name = get_owner_name_dummy
 
 
 ENABLE_QUICK_EDIT = 0x0040

--- a/src/libertem/win_tweaks.py
+++ b/src/libertem/win_tweaks.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_owner_name_dummy(full_path, stat):
-    return "Unknown"
+    return "<Unknown>"
 
 
 try:

--- a/tests/test_win_tweaks.py
+++ b/tests/test_win_tweaks.py
@@ -6,7 +6,7 @@ import pytest
 
 
 if platform.system() != 'Windows':
-    pytest.skip("Skipping Windows-specific tests")
+    pytest.skip("Skipping Windows-specific tests", allow_module_level=True)
 
 
 real_import = builtins.__import__

--- a/tests/test_win_tweaks.py
+++ b/tests/test_win_tweaks.py
@@ -1,0 +1,64 @@
+import sys
+import builtins
+import platform
+
+import pytest
+
+
+if platform.system() != 'Windows':
+    pytest.skip("Skipping Windows-specific tests")
+
+
+real_import = builtins.__import__
+
+
+def monkey_import_notfound(name, globals=None, locals=None, fromlist=(), level=0):
+    if name in ('win32security', 'pywintypes'):
+        raise ModuleNotFoundError(f"Mocked module not found {name}")
+    return real_import(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+
+
+def monkey_import_importerror(name, globals=None, locals=None, fromlist=(), level=0):
+    if name in ('win32security', ):
+        raise ImportError(f"Mocked import error {name}")
+    return real_import(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+
+
+def test_import_selftest(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'win32security', raising=False)
+    monkeypatch.setattr(builtins, '__import__', monkey_import_importerror)
+
+    with pytest.raises(ImportError):
+        import win32security
+
+
+def test_import_selftest2(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'win32security', raising=False)
+    monkeypatch.setattr(builtins, '__import__', monkey_import_notfound)
+
+    with pytest.raises(ModuleNotFoundError):
+        import win32security
+
+
+def test_import_broken(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'win32security', raising=False)
+    monkeypatch.delitem(sys.modules, 'libertem.win_tweaks', raising=False)
+    monkeypatch.setattr(builtins, '__import__', monkey_import_importerror)
+
+    from libertem.win_tweaks import get_owner_name
+
+    # Make sure the dummy fallback version works
+    # This would fail with the actual get_owner_name() function
+    assert get_owner_name('/asdf/bla', None) == '<Unknown>'
+
+
+def test_import_missing(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'win32security', raising=False)
+    monkeypatch.delitem(sys.modules, 'libertem.win_tweaks', raising=False)
+    monkeypatch.setattr(builtins, '__import__', monkey_import_notfound)
+
+    from libertem.win_tweaks import get_owner_name
+
+    # Make sure the dummy fallback version works
+    # This would fail with the actual get_owner_name() function
+    assert get_owner_name('/asdf/bla', None) == '<Unknown>'


### PR DESCRIPTION
Show a warning pointing to the probable fix,
disable the affected feature and continue running
instead of failing hard.

Closes #949 

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
