### PR TITLE
Better error message when trying to open 2D HDF5 files

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -62,6 +62,11 @@ def hdf5(tmpdir_factory):
 
 
 @pytest.fixture(scope='session')
+def hdf5_2d(tmpdir_factory):
+    yield from get_or_create_hdf5(tmpdir_factory, "hdf5-test-2d.h5", data=np.ones((16, 16)))
+
+
+@pytest.fixture(scope='session')
 def hdf5_3d(tmpdir_factory):
     yield from get_or_create_hdf5(tmpdir_factory, "hdf5-test-3d.h5", data=np.ones((17, 16, 16)))
 
@@ -166,6 +171,15 @@ def hdf5_ds_2(random_hdf5):
 def hdf5_ds_3d(hdf5_3d):
     ds = H5DataSet(
         path=hdf5_3d.filename, ds_path="data",
+    )
+    ds = ds.initialize(InlineJobExecutor())
+    return ds
+
+
+@pytest.fixture
+def hdf5_ds_2d(hdf5_2d):
+    ds = H5DataSet(
+        path=hdf5_2d.filename, ds_path="data",
     )
     ds = ds.initialize(InlineJobExecutor())
     return ds

--- a/src/libertem/common/shape.py
+++ b/src/libertem/common/shape.py
@@ -78,7 +78,10 @@ class Shape(object):
         >>> s.size
         256
         """
-        return functools.reduce(operator.mul, self)
+        shape_tuple = tuple(self)
+        if len(shape_tuple) == 0:
+            return 0
+        return functools.reduce(operator.mul, shape_tuple)
 
     def flatten_nav(self):
         """

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -130,7 +130,12 @@ class H5DataSet(DataSet):
             self.ds_path = name
         with self.get_reader().get_h5ds() as h5ds:
             self._dtype = h5ds.dtype
-            self._shape = Shape(h5ds.shape, sig_dims=self.sig_dims)
+            shape = h5ds.shape
+            if len(shape) == self.sig_dims:
+                # shape = (1,) + shape -> this leads to indexing errors down the line
+                # so we currently don't support opening 2D HDF5 files
+                raise DataSetException("2D HDF5 files are currently not supported")
+            self._shape = Shape(shape, sig_dims=self.sig_dims)
             self._image_count = self._shape.nav.size
             self._meta = DataSetMeta(
                 shape=self.shape,

--- a/tests/common/test_shape.py
+++ b/tests/common/test_shape.py
@@ -16,6 +16,16 @@ def test_shape_get_size():
     assert s.size == 16 * 16 * 128 * 128
 
 
+def test_size_zero():
+    s = Shape((), sig_dims=0)
+    assert s.size == 0
+
+
+def test_size_nav_zero():
+    s = Shape((128, 128), sig_dims=2)
+    assert s.nav.size == 0
+
+
 def test_shape_flatten_nav():
     s = Shape((16, 16, 128, 128), sig_dims=2)
     assert tuple(s.flatten_nav()) == (16 * 16, 128, 128)


### PR DESCRIPTION
Fixes #955. 2D HDF5 files are not yet supported; in LiberTEM it probably only makes sense to open stacks of 2D HDF5 files, if at all.

Also improve `Shape.size`:

 * Empty `Shape` objects (i.e. ()) now have a defined size instead of throwing an exception

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
