### PR TITLE
Catch more broken cupy installations

### DIFF
--- a/src/libertem/utils/devices.py
+++ b/src/libertem/utils/devices.py
@@ -11,10 +11,9 @@ logger = logging.getLogger(__name__)
 
 try:
     import cupy
-    cupy.cuda
 except ModuleNotFoundError:
     cupy = None
-except (ImportError, AttributeError) as e:
+except ImportError as e:
     # Cupy can be a bit fragile; allow running LiberTEM with
     # messed-up installation
     warnings.warn(repr(e), RuntimeWarning)
@@ -63,4 +62,12 @@ def has_cupy():
     CuPy is an optional dependency with special integration for UDFs. See
     :ref:`udf cuda` for details.
     '''
-    return cupy is not None
+    if cupy is None:
+        return False
+    try:
+        cupy.cuda
+        cupy.array(cupy.zeros((1,)))
+        return True
+    except Exception as e:  # possibly: AttributeError or CompileException
+        warnings.warn(repr(e), RuntimeWarning)
+        return False

--- a/tests/test_win_tweaks.py
+++ b/tests/test_win_tweaks.py
@@ -12,38 +12,26 @@ if platform.system() != 'Windows':
 real_import = builtins.__import__
 
 
-def monkey_import_notfound(name, globals=None, locals=None, fromlist=(), level=0):
+def monkey_notfound(name, *args, **kwargs):
     if name in ('win32security', 'pywintypes'):
         raise ModuleNotFoundError(f"Mocked module not found {name}")
-    return real_import(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
+    return real_import(name, *args, **kwargs)
 
 
-def monkey_import_importerror(name, globals=None, locals=None, fromlist=(), level=0):
+def monkey_importerror(name, *args, **kwargs):
     if name in ('win32security', ):
         raise ImportError(f"Mocked import error {name}")
-    return real_import(name, globals=globals, locals=locals, fromlist=fromlist, level=level)
-
-
-def test_import_selftest(monkeypatch):
-    monkeypatch.delitem(sys.modules, 'win32security', raising=False)
-    monkeypatch.setattr(builtins, '__import__', monkey_import_importerror)
-
-    with pytest.raises(ImportError):
-        import win32security
-
-
-def test_import_selftest2(monkeypatch):
-    monkeypatch.delitem(sys.modules, 'win32security', raising=False)
-    monkeypatch.setattr(builtins, '__import__', monkey_import_notfound)
-
-    with pytest.raises(ModuleNotFoundError):
-        import win32security
+    return real_import(name, *args, **kwargs)
 
 
 def test_import_broken(monkeypatch):
     monkeypatch.delitem(sys.modules, 'win32security', raising=False)
     monkeypatch.delitem(sys.modules, 'libertem.win_tweaks', raising=False)
-    monkeypatch.setattr(builtins, '__import__', monkey_import_importerror)
+    monkeypatch.setattr(builtins, '__import__', monkey_importerror)
+
+    # Self test
+    with pytest.raises(ImportError):
+        import win32security
 
     from libertem.win_tweaks import get_owner_name
 
@@ -55,7 +43,11 @@ def test_import_broken(monkeypatch):
 def test_import_missing(monkeypatch):
     monkeypatch.delitem(sys.modules, 'win32security', raising=False)
     monkeypatch.delitem(sys.modules, 'libertem.win_tweaks', raising=False)
-    monkeypatch.setattr(builtins, '__import__', monkey_import_notfound)
+    monkeypatch.setattr(builtins, '__import__', monkey_notfound)
+
+    # Self test
+    with pytest.raises(ModuleNotFoundError):
+        import win32security
 
     from libertem.win_tweaks import get_owner_name
 

--- a/tests/utils/test_devices.py
+++ b/tests/utils/test_devices.py
@@ -1,0 +1,121 @@
+import sys
+import builtins
+
+import pytest
+
+
+real_import = builtins.__import__
+
+
+def monkey_notfound(name, *args, **kwargs):
+    if name in ('cupy', ):
+        raise ModuleNotFoundError(f"Mocked module not found {name}")
+    return real_import(name, *args, **kwargs)
+
+
+def monkey_importerror(name, *args, **kwargs):
+    if name in ('cupy', ):
+        raise ImportError(f"Mocked import error {name}")
+    return real_import(name, *args, **kwargs)
+
+
+def monkey_brokencupycuda(name, *args, **kwargs):
+    if name in ('cupy.cuda', ):
+        raise AttributeError(f"Mocked import error {name}")
+    return real_import(name, *args, **kwargs)
+
+
+def test_detect_error(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'cupy', raising=False)
+    monkeypatch.delitem(sys.modules, 'cupy.cuda', raising=False)
+    monkeypatch.setattr(builtins, '__import__', monkey_importerror)
+
+    # Self test
+    with pytest.raises(ImportError):
+        import cupy
+
+    monkeypatch.delitem(sys.modules, 'libertem.utils.devices', raising=False)
+
+    with pytest.warns(RuntimeWarning, match="Mocked import error cupy"):
+        from libertem.utils.devices import detect
+        result = detect()
+
+    assert not result['has_cupy']
+
+
+def test_detect_notfound(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'cupy', raising=False)
+    monkeypatch.delitem(sys.modules, 'cupy.cuda', raising=False)
+    monkeypatch.setattr(builtins, '__import__', monkey_notfound)
+
+    # Self test
+    with pytest.raises(ModuleNotFoundError):
+        import cupy
+
+    monkeypatch.delitem(sys.modules, 'libertem.utils.devices', raising=False)
+
+    from libertem.utils.devices import detect
+    result = detect()
+
+    assert not result['has_cupy']
+
+
+def test_detect_nocuda(monkeypatch):
+    try:
+        import cupy
+    except Exception:
+        pytest.skip("Importable CuPy required for this test.")
+    monkeypatch.delattr(sys.modules['cupy'], 'cuda', raising=False)
+    # Self test
+    with pytest.raises(Exception):
+        cupy.cuda
+
+    monkeypatch.delitem(sys.modules, 'libertem.utils.devices', raising=False)
+
+    with pytest.warns(RuntimeWarning, match="module 'cupy' has no attribute 'cuda'"):
+        from libertem.utils.devices import detect
+        result = detect()
+
+    assert not result['has_cupy']
+
+
+def test_detect_broken(monkeypatch):
+    try:
+        import cupy
+    except Exception:
+        pytest.skip("Importable CuPy required for this test.")
+
+    # CuPy can throw all kinds of exceptions, depending on what exactly goes wrong
+    class FunkyException(Exception):
+        pass
+
+    def badfunc(*args, **kwargs):
+        raise FunkyException()
+
+    monkeypatch.setattr(cupy, 'array', badfunc)
+    monkeypatch.setattr(cupy, 'zeros', badfunc)
+
+    # Self test
+    with pytest.raises(FunkyException):
+        cupy.array(cupy.zeros(1,))
+
+    monkeypatch.delitem(sys.modules, 'libertem.utils.devices', raising=False)
+
+    from libertem.utils.devices import detect
+    with pytest.warns(RuntimeWarning, match='FunkyException'):
+        result = detect()
+
+    assert not result['has_cupy']
+
+
+def test_consistency():
+    try:
+        import cupy
+    except Exception:
+        pytest.skip("Importable CuPy required for this test.")
+
+    from libertem.utils.devices import detect
+
+    result = detect()
+    if result['cudas']:
+        assert result['has_cupy']

--- a/tests/utils/test_devices.py
+++ b/tests/utils/test_devices.py
@@ -106,16 +106,3 @@ def test_detect_broken(monkeypatch):
         result = detect()
 
     assert not result['has_cupy']
-
-
-def test_consistency():
-    try:
-        import cupy
-    except Exception:
-        pytest.skip("Importable CuPy required for this test.")
-
-    from libertem.utils.devices import detect
-
-    result = detect()
-    if result['cudas']:
-        assert result['has_cupy']


### PR DESCRIPTION
This includes the case of missing compute capability support in the installed CUDA runtime. Check moved to `has_cupy`.

Fixes #959

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
