### PR TITLE
Consider ROI size in tiling; drive-by cleanup

### DIFF
--- a/benchmarks/io/test_mib.py
+++ b/benchmarks/io/test_mib.py
@@ -123,7 +123,7 @@ class TestUseSharedExecutor:
         ctx = shared_dist_ctx
         ds = ctx.load(filetype="mib", path=mib_hdr, io_backend=io_backend)
 
-        sparse_roi = np.zeros(ds.shape.nav.size, dtype=np.bool)
+        sparse_roi = np.zeros(ds.shape.nav.size, dtype=bool)
         sparse_roi[::sparsity] = True
 
         def mask():

--- a/prototypes/gridreduction/Gridmaker.ipynb
+++ b/prototypes/gridreduction/Gridmaker.ipynb
@@ -30,7 +30,7 @@
     "    exclude = np.array(exclude)\n",
     "    i, j = np.meshgrid(xes, yes)\n",
     "    indices = np.concatenate(np.array((i, j)).T)\n",
-    "    select = np.ones_like(indices[:,0], dtype=np.bool)\n",
+    "    select = np.ones_like(indices[:,0], dtype=bool)\n",
     "    for e in exclude:\n",
     "        # Only include values where at least one is different from the exclude list\n",
     "        select *= (np.not_equal(indices[:,0], e[0]) + np.not_equal(indices[:,1], e[1]))\n",

--- a/src/libertem/analysis/fullmatch.py
+++ b/src/libertem/analysis/fullmatch.py
@@ -25,7 +25,7 @@ class FullMatcher(grm.Matcher):
     '''
     def __init__(
             self, tolerance=3, min_weight=0.1, min_match=3, min_angle=np.pi/10,
-            min_points=10, min_delta=0, max_delta=np.float('inf'), min_candidates=3,
+            min_points=10, min_delta=0, max_delta=np.inf, min_candidates=3,
             max_candidates=7, clusterer=None, min_cluster_size_fraction=4,
             min_samples_fraction=20):
         '''
@@ -166,7 +166,7 @@ class FullMatcher(grm.Matcher):
             np.allclose(corr.centers[i], zero)
             + np.allclose(corr.refineds[i], zero)
             for i in range(len(corr))
-        ], dtype=np.bool)
+        ], dtype=bool)
 
         def listed(working_set, polar_cand):
             return polar_cand

--- a/src/libertem/analysis/gridmatching.py
+++ b/src/libertem/analysis/gridmatching.py
@@ -37,7 +37,7 @@ class PointSelection:
     def __init__(self, correlation_result: CorrelationResult, selector=None):
         self.correlation_result = correlation_result
         if selector is None:
-            self.selector = np.ones(len(correlation_result.centers), dtype=np.bool)
+            self.selector = np.ones(len(correlation_result.centers), dtype=bool)
         else:
             assert len(correlation_result.centers) == len(selector)
             self.selector = selector
@@ -223,7 +223,7 @@ class Matcher:
         scaled_diffs = diffs / (np.maximum(1, np.abs(indices))**0.5)
         errors = np.linalg.norm(scaled_diffs, axis=1)
         matched_selector = errors < self.tolerance
-        matched_indices = rounded[matched_selector].astype(np.int)
+        matched_indices = rounded[matched_selector].astype(int)
         # remove the ones that weren't matched
         new_selector = point_selection.new_selector(matched_selector)
         result = Match.from_point_selection(
@@ -286,10 +286,10 @@ class Match(PointSelection):
         Match
             A :class:`Match` instance with empty selector and all-'nan' attributes
         '''
-        nanvec = np.array([np.float('nan'), np.float('nan')])
+        nanvec = np.array([np.nan, np.nan])
         return cls(
             correlation_result=correlation_result,
-            selector=np.zeros(len(correlation_result), dtype=np.bool),
+            selector=np.zeros(len(correlation_result), dtype=bool),
             zero=nanvec,
             a=nanvec,
             b=nanvec,
@@ -348,7 +348,7 @@ class Match(PointSelection):
             raise ValueError(
                 "Shape of indices is %s, expected (n, 2) or (2, n, m)" % str(indices.shape))
 
-        selector = np.ones(len(indices), dtype=np.bool)
+        selector = np.ones(len(indices), dtype=bool)
         if drop_zero:
             nz = np.any(indices != 0, axis=1)
             selector *= nz
@@ -368,7 +368,7 @@ class Match(PointSelection):
             diff = np.linalg.norm(self.refineds - self.calculated_refineds, axis=1)
             return (diff * self.peak_elevations).mean() / self.peak_elevations.mean()
         else:
-            return np.float('inf')
+            return np.inf
 
     def derive(self, selector=None, zero=None, a=None, b=None, indices=None):
         if zero is None:

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -556,7 +556,7 @@ class Context:
         Running a UDF on a subset of data:
 
         >>> from libertem.udf.sumsigudf import SumSigUDF
-        >>> roi = np.zeros(dataset.shape.nav, dtype=np.bool)
+        >>> roi = np.zeros(dataset.shape.nav, dtype=bool)
         >>> roi[0, 0] = True
         >>> result = ctx.run_udf(dataset=dataset, udf=SumSigUDF(), roi=roi)
         >>> # to get the full navigation-shaped results, with NaNs where the `roi` was False:

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -42,7 +42,7 @@ def empty_aligned(size, dtype):
 
 
 def zeros_aligned(size, dtype):
-    if dtype == np.object or np.prod(size, dtype=np.int64) == 0:
+    if dtype == object or np.prod(size, dtype=np.int64) == 0:
         res = np.zeros(size, dtype=dtype)
     else:
         res = empty_aligned(size, dtype)
@@ -105,7 +105,7 @@ class BufferPool:
 
     @contextmanager
     def zeros(self, size, dtype):
-        if dtype == np.object or np.prod(size, dtype=np.int64) == 0:
+        if dtype == object or np.prod(size, dtype=np.int64) == 0:
             yield np.zeros(size, dtype=dtype)
         else:
             with self.empty(size, dtype) as res:

--- a/src/libertem/common/numba.py
+++ b/src/libertem/common/numba.py
@@ -248,7 +248,7 @@ dispatcher_registry['custom_cpu'] = MyCPUDispatcher
 def prime_numba_cache(ds):
     dtypes = (np.float32, None)
     for dtype in dtypes:
-        roi = np.zeros(ds.shape.nav, dtype=np.bool).reshape((-1,))
+        roi = np.zeros(ds.shape.nav, dtype=bool).reshape((-1,))
         roi[0] = 1
 
         from libertem.udf.sum import SumUDF

--- a/src/libertem/executor/base.py
+++ b/src/libertem/executor/base.py
@@ -11,18 +11,12 @@ class ExecutorError(Exception):
 
 class JobCancelledError(Exception):
     """
-    raised by async executors in run_job if the job was cancelled
+    raised by async executors in run_tasks() or run_each_partition() if the task was cancelled
     """
     pass
 
 
 class JobExecutor(object):
-    def run_job(self, job, cancel_id=None):
-        """
-        run a Job
-        """
-        raise NotImplementedError()
-
     def run_function(self, fn, *args, **kwargs):
         """
         run a callable `fn` on any worker
@@ -146,12 +140,6 @@ class JobExecutor(object):
 
 
 class AsyncJobExecutor(object):
-    async def run_job(self, job, cancel_id):
-        """
-        Run a Job
-        """
-        raise NotImplementedError()
-
     async def run_tasks(self, tasks, cancel_id):
         """
         Run a number of Tasks, yielding (result, task) tuples
@@ -275,15 +263,6 @@ class AsyncAdapter(AsyncJobExecutor):
 
     def ensure_sync(self):
         return self._wrapped
-
-    async def run_job(self, job, cancel_id):
-        """
-        run a Job
-        """
-        gen = self._wrapped.run_job(job, cancel_id)
-        agen = async_generator(gen, self._pool)
-        async for i in agen:
-            yield i
 
     async def run_tasks(self, tasks, cancel_id):
         """

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -235,11 +235,6 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         self.lt_resources = lt_resources
         self._futures = {}
 
-    def run_job(self, job, cancel_id=None):
-        tasks = job.get_tasks()
-        for result, task in self.run_tasks(tasks, cancel_id=cancel_id):
-            yield result
-
     def run_tasks(self, tasks, cancel_id):
         tasks = list(tasks)
         tasks_wrapped = []

--- a/src/libertem/executor/inline.py
+++ b/src/libertem/executor/inline.py
@@ -11,11 +11,6 @@ class InlineJobExecutor(JobExecutor):
     def __init__(self, debug=False, *args, **kwargs):
         self._debug = debug
 
-    def run_job(self, job, cancel_id=None):
-        tasks = job.get_tasks()
-        for result, task in self.run_tasks(tasks, cancel_id=job):
-            yield result
-
     def run_tasks(self, tasks, cancel_id):
         for task in tasks:
             if self._debug:

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -540,9 +540,15 @@ class Negotiator:
         full_base_shape = (1,) + tuple(base_shape)
         min_factors = (depth,) + tuple(min_factors)
 
+        if roi is None:
+            containing_shape = partition.shape
+        else:
+            roi_slice = partition.slice.get(roi.reshape(-1), nav_only=True)
+            containing_shape = (np.count_nonzero(roi_slice), ) + tuple(partition.shape.sig)
+
         factors = self._get_scale_factors(
             full_base_shape,
-            containing_shape=partition.shape,
+            containing_shape=containing_shape,
             size=size_px,
             min_factors=min_factors,
         )
@@ -611,7 +617,7 @@ class Negotiator:
     def _get_udf_size_pref(self, udf):
         from libertem.udf import UDF
         udf_prefs = udf.get_tiling_preferences()
-        size = udf_prefs.get("total_size", np.float("inf"))
+        size = udf_prefs.get("total_size", np.inf)
         if size is UDF.TILE_SIZE_BEST_FIT:
             size = self._get_default_size()
         return size

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -543,8 +543,7 @@ class Negotiator:
         if roi is None:
             containing_shape = partition.shape
         else:
-            roi_slice = partition.slice.get(roi.reshape(-1), nav_only=True)
-            containing_shape = (np.count_nonzero(roi_slice), ) + tuple(partition.shape.sig)
+            containing_shape = partition.slice.adjust_for_roi(roi.reshape(-1)).shape
 
         factors = self._get_scale_factors(
             full_base_shape,

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -92,8 +92,8 @@ def sparse_circular_multi_stack(mask_index, centerX, centerY, imageSizeX, imageS
         radius=radius)
     return sparse_template_multi_stack(
         mask_index=mask_index,
-        offsetX=np.array(centerX, dtype=np.int) - bbox_center,
-        offsetY=np.array(centerY, dtype=np.int) - bbox_center,
+        offsetX=np.array(centerX, dtype=int) - bbox_center,
+        offsetY=np.array(centerY, dtype=int) - bbox_center,
         template=template,
         imageSizeX=imageSizeX,
         imageSizeY=imageSizeY,

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -523,11 +523,11 @@ class UDF(UDFBase):
     The main user-defined functions interface. You can implement your functionality
     by overriding methods on this class.
     """
-    USE_NATIVE_DTYPE = np.bool
+    USE_NATIVE_DTYPE = bool
     TILE_SIZE_BEST_FIT = object()
-    TILE_SIZE_MAX = np.float("inf")
+    TILE_SIZE_MAX = np.inf
     TILE_DEPTH_DEFAULT = object()
-    TILE_DEPTH_MAX = np.float("inf")
+    TILE_DEPTH_MAX = np.inf
 
     def __init__(self, **kwargs):
         """

--- a/src/libertem/utils/generate.py
+++ b/src/libertem/utils/generate.py
@@ -132,7 +132,7 @@ def exclude_pixels(sig_dims, num_excluded):
     if num_excluded == 0:
         return None
     # Map of pixels that can be reconstructed faithfully from neighbors in a linear gradient
-    free_map = np.ones(sig_dims, dtype=np.bool)
+    free_map = np.ones(sig_dims, dtype=bool)
 
     # Exclude all border pixels
     for dim in range(len(sig_dims)):

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -289,7 +289,7 @@ def test_compare_backends(lt_ctx, default_blo, buffered_blo):
 
 
 def test_compare_backends_sparse(lt_ctx, default_blo, buffered_blo):
-    roi = np.zeros(default_blo.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_blo.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[16] = True

--- a/tests/io/datasets/test_dm.py
+++ b/tests/io/datasets/test_dm.py
@@ -380,7 +380,7 @@ def test_compare_backends(lt_ctx, default_dm, buffered_dm):
 
 
 def test_compare_backends_sparse(lt_ctx, default_dm, buffered_dm):
-    roi = np.zeros(default_dm.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_dm.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[-1] = True

--- a/tests/io/datasets/test_empad.py
+++ b/tests/io/datasets/test_empad.py
@@ -399,7 +399,7 @@ def test_compare_backends(lt_ctx, default_empad, buffered_empad):
 
 
 def test_compare_backends_sparse(lt_ctx, default_empad, buffered_empad):
-    roi = np.zeros(default_empad.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_empad.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[8] = True

--- a/tests/io/datasets/test_frms6.py
+++ b/tests/io/datasets/test_frms6.py
@@ -494,7 +494,7 @@ def test_compare_backends(lt_ctx, default_frms6, buffered_frms6):
 
 
 def test_compare_backends_sparse(lt_ctx, default_frms6, buffered_frms6):
-    roi = np.zeros(default_frms6.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_frms6.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[16] = True

--- a/tests/io/datasets/test_hdf5.py
+++ b/tests/io/datasets/test_hdf5.py
@@ -354,7 +354,7 @@ def test_roi_2(random_hdf5, lt_ctx, mnp):
     print(mask)
 
     assert mask.shape == (5, 5)
-    assert mask.dtype == np.bool
+    assert mask.dtype == bool
 
     reader = ds.get_reader()
     with reader.get_h5ds() as h5ds:

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -372,7 +372,7 @@ def test_compare_backends(lt_ctx, default_k2is, buffered_k2is):
 
 
 def test_compare_backends_sparse(lt_ctx, default_k2is, buffered_k2is):
-    roi = np.zeros(default_k2is.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_k2is.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[16] = True

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -409,7 +409,7 @@ def test_compare_backends(lt_ctx, default_mib, buffered_mib):
 
 
 def test_compare_backends_sparse(lt_ctx, default_mib, buffered_mib):
-    roi = np.zeros(default_mib.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_mib.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[16] = True

--- a/tests/io/datasets/test_raw.py
+++ b/tests/io/datasets/test_raw.py
@@ -713,7 +713,7 @@ def test_compare_backends(lt_ctx, default_raw, buffered_raw):
 
 
 def test_compare_backends_sparse(lt_ctx, default_raw, buffered_raw):
-    roi = np.zeros(default_raw.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_raw.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[-1] = True

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -435,7 +435,7 @@ def test_compare_backends(lt_ctx, default_seq, buffered_seq):
 
 
 def test_compare_backends_sparse(lt_ctx, default_seq, buffered_seq):
-    roi = np.zeros(default_seq.shape.nav, dtype=np.bool).reshape((-1,))
+    roi = np.zeros(default_seq.shape.nav, dtype=bool).reshape((-1,))
     roi[0] = True
     roi[1] = True
     roi[16] = True

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -75,7 +75,7 @@ def test_comparison_roi(default_ser, default_ser_raw, lt_ctx_fast):
 
 def test_roi(lt_ctx):
     ds = lt_ctx.load("ser", path=SER_TESTDATA_PATH)
-    roi = np.zeros(ds.shape.nav, dtype=np.bool)
+    roi = np.zeros(ds.shape.nav, dtype=bool)
     roi[0, 1] = True
 
     parts = ds.get_partitions()

--- a/tests/io/test_tiling_negotiation.py
+++ b/tests/io/test_tiling_negotiation.py
@@ -126,6 +126,32 @@ def test_get_scheme_upper_size_1():
     assert tuple(scheme.shape) == (65, 28, 144)
 
 
+def test_get_scheme_upper_size_roi():
+    """
+    Confirm that a small ROI will not be split
+    up unnecessarily.
+    """
+    data = _mk_random(size=(1024, 144, 144))
+    dataset = MemoryDataSet(
+        data=data,
+        num_partitions=1,
+        sig_dims=2
+    )
+
+    roi = np.zeros(dataset.shape.nav, dtype=bool)
+    # All in a single partition here
+    roi[0] = True
+    roi[512] = True
+    roi[-1] = True
+
+    neg = Negotiator()
+    p = next(dataset.get_partitions())
+    udf = TilingUDFBestFit()
+    scheme = neg.get_scheme(udfs=[udf], partition=p, read_dtype=np.float32, roi=roi)
+    assert scheme.shape.sig.dims == 2
+    assert tuple(scheme.shape) == (3, 144, 144)
+
+
 def test_get_scheme_upper_size_2():
     """
     Test that will hit the 2**20 default size

--- a/tests/test_analysis_sum.py
+++ b/tests/test_analysis_sum.py
@@ -188,7 +188,7 @@ def test_sum_with_roi(lt_ctx):
     assert mask.shape == (16, 16)
     assert mask[0, 0] == 0
     assert mask[6, 5] == 1
-    assert mask.dtype == np.bool
+    assert mask.dtype == bool
 
     # applying the mask flattens the first two dimensions, so we
     # only sum over axis 0 here:
@@ -223,7 +223,7 @@ def test_sum_zero_roi(lt_ctx):
     mask = masks.circular(roi["cx"], roi["cy"], 16, 16, roi["r"])
     assert mask.shape == (16, 16)
     assert np.count_nonzero(mask) == 0
-    assert mask.dtype == np.bool
+    assert mask.dtype == bool
 
     # applying the mask flattens the first two dimensions, so we
     # only sum over axis 0 here:

--- a/tests/udf/test_by_tile.py
+++ b/tests/udf/test_by_tile.py
@@ -133,7 +133,7 @@ def test_roi_extra_dimension_shape(lt_ctx):
             # dest['test3'][:] += src['test3'][:]
 
     extra = ExtraShapeUDF()
-    roi = _mk_random(size=dataset.shape.nav, dtype=np.bool)
+    roi = _mk_random(size=dataset.shape.nav, dtype=bool)
     res = lt_ctx.run_udf(dataset=dataset, udf=extra, roi=roi)
 
     navcount = np.count_nonzero(roi)

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -343,7 +343,7 @@ def test_roi_extra_dimension_shape(lt_ctx):
             dest['test3'][:] += src['test3'][:]
 
     extra = ExtraShapeUDF()
-    roi = _mk_random(size=dataset.shape.nav, dtype=np.bool)
+    roi = _mk_random(size=dataset.shape.nav, dtype=bool)
     res = lt_ctx.run_udf(dataset=dataset, udf=extra, roi=roi)
 
     navcount = np.count_nonzero(roi)
@@ -491,7 +491,7 @@ def test_with_progress_bar(lt_ctx):
 class ReshapedViewUDF(UDF):
     def get_result_buffers(self):
         return {
-            "sigbuf": self.buffer(kind="sig", dtype=np.int, where="device")
+            "sigbuf": self.buffer(kind="sig", dtype=int, where="device")
         }
 
     def process_tile(self, tile):


### PR DESCRIPTION
Previously, the tile shape was always calculated for the full partition size regardless of ROI. That can lead to a relatively large number of very small tiles if the ROI is almost empty in the area of a partition. With this change, the tile shape is calculated based on the actual size that will be processed.

Additional changes:

* Vestigial remnant of the job interface excised
* Handle https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
