### PR TITLE
Move threading control to JobExecutor

### DIFF
--- a/docs/source/changelog/features/threading_control.rst
+++ b/docs/source/changelog/features/threading_control.rst
@@ -1,0 +1,9 @@
+[Feature] Allow some UDF-internal threading
+===========================================
+* The executor can now allow UDFs to perform some internal threading,
+  making the number of allowed threads available as :code:`UDFMeta.threads_per_worker`.
+  This is mostly interesting for ad-hoc parallelization on top of the
+  :code:`InlineJobExecutor`, but could also be used for hybrid
+  multiprocess/multithreaded workloads (:pr:`993`).
+  Threads for numba, pyfftw, OMP/MKL are still automatically controlled,
+  the :code:`UDFMeta.threads_per_worker` addition is meant for other threading mechanisms.

--- a/src/libertem/executor/inline.py
+++ b/src/libertem/executor/inline.py
@@ -1,5 +1,7 @@
 import cloudpickle
-from .base import JobExecutor
+import psutil
+
+from .base import JobExecutor, Environment
 from .scheduler import Worker, WorkerSet
 from libertem.common.backend import get_use_cuda
 
@@ -12,10 +14,12 @@ class InlineJobExecutor(JobExecutor):
         self._debug = debug
 
     def run_tasks(self, tasks, cancel_id):
+        threads = psutil.cpu_count(logical=False)
+        env = Environment(threads_per_worker=threads)
         for task in tasks:
             if self._debug:
                 cloudpickle.loads(cloudpickle.dumps(task))
-            result = task()
+            result = task(env=env)
             if self._debug:
                 cloudpickle.loads(cloudpickle.dumps(result))
             yield result, task

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -5,6 +5,7 @@ import pytest
 
 from libertem.udf.base import UDF, UDFRunner
 from libertem.udf.base import UDFMeta
+from libertem.executor.base import Environment
 from libertem.io.dataset.memory import MemoryDataSet
 from libertem.utils.devices import detect
 from libertem.common.backend import set_use_cpu, set_use_cuda
@@ -533,6 +534,7 @@ def test_noncontiguous_tiles(lt_ctx, backend):
             partition=partition,
             roi=None,
             corrections=None,
+            env=Environment(threads_per_worker=1),
         )
 
     finally:


### PR DESCRIPTION
The `JobExecutor` is in complete control over the threading, so it can also decide to allow fine-grained Python/C threads in each process, for example if we only start `NUM_OF_CORES/2` processes, or in single-process mode (`InlineJobExecutor`).

This is the minimal change, a complete implementation could add information about the number of threads to `UDFMeta`, as discussed before.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
