### PR TITLE
UDF: Consistency fixes and `get_results` improvements

### DIFF
--- a/docs/source/changelog/bugfix/udf-consistency.rst
+++ b/docs/source/changelog/bugfix/udf-consistency.rst
@@ -1,0 +1,4 @@
+[Bugfix] UDF: consistency fixes
+===============================
+* Consistently use attribute access in :code:`UDF.process_*`, :code:`UDF.merge`,
+  :code:`UDF.get_results` etc. (:issue:`1000`, :pr:`1003`)

--- a/docs/source/changelog/bugfix/udf-consistency.rst
+++ b/docs/source/changelog/bugfix/udf-consistency.rst
@@ -1,4 +1,5 @@
 [Bugfix] UDF: consistency fixes
 ===============================
 * Consistently use attribute access in :code:`UDF.process_*`, :code:`UDF.merge`,
-  :code:`UDF.get_results` etc. (:issue:`1000`, :pr:`1003`)
+  :code:`UDF.get_results` etc. instead of mixing it with :code:`__getitem__` dict-like
+  access (:issue:`1000`, :pr:`1003`)

--- a/docs/source/changelog/bugfix/udf-consistency.rst
+++ b/docs/source/changelog/bugfix/udf-consistency.rst
@@ -3,3 +3,4 @@
 * Consistently use attribute access in :code:`UDF.process_*`, :code:`UDF.merge`,
   :code:`UDF.get_results` etc. instead of mixing it with :code:`__getitem__` dict-like
   access (:issue:`1000`, :pr:`1003`)
+* Also allow non-sliced assignment, for example :code:`self.results.res += frame`

--- a/docs/source/changelog/features/udf-get-results.rst
+++ b/docs/source/changelog/features/udf-get-results.rst
@@ -1,4 +1,4 @@
 [Feature] UDF: Support for a final postprocessing on main node
 ==============================================================
-* This adds :meth:`UDF.get_results`, :meth:`UDF.result` and the :code:`allocate`
-  parameter to :meth:`UDF.buffer` (:pr:`994`).
+* This adds :meth:`UDF.get_results` and the :code:`use`
+  parameter to :meth:`UDF.buffer` (:pr:`994`, :pr:`1003`, :issue:`1001`).

--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -389,7 +389,7 @@ Here is an example demonstrating :code:`kind="sig"` buffers and the :code:`merge
          """
          merge two partial results, from src into dest
          """
-         dest['maxbuf'][:] = np.maximum(dest['maxbuf'], src['maxbuf'])
+         dest.maxbuf[:] = np.maximum(dest.maxbuf, src.maxbuf)
 
    res = ctx.run_udf(
       udf=MaxUDF(),

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -172,16 +172,22 @@ step that is run on the main node, you can override
 
     ctx.run_udf(dataset=dataset, udf=AverageUDF())
 
-Note that :code:`get_result_buffers` returns a placeholder entry for the :code:`average`
-result using :code:`use='result_only'`, which is then filled in :code:`get_results`.
-We don't need to repeat those buffers that should be returned unchanged; if you want
-to omit a buffer from the results completely, you can declare it as private with
-:code:`self.buffer(..., use='private')` in :code:`get_result_buffers`.
+Note that :meth:`UDF.get_result_buffers` returns a placeholder entry for the
+:code:`average` result using :code:`use='result_only'`, which is then filled in
+:code:`get_results`.  We don't need to repeat those buffers that should be
+returned unchanged; if you want to omit a buffer from the results completely,
+you can declare it as private with :code:`self.buffer(..., use='private')` in
+:code:`get_result_buffers`.
 
-When returned from :meth:`Context.run_udf`, all results are wrapped into :code:`BufferWrapper`
-instances. This is done primarily to get convenient access to a version of the result that is
-suitable for visualization, even if a :code:`roi` was used, but still allow access to the
-raw result using :attr:`BufferWrapper.raw_data` attribute.
+:meth:`UDF.get_results` should return the results as a dictionary of numpy
+arrays, with the keys matching those returned by
+:meth:`UDF.get_result_buffers`.
+
+When returned from :meth:`Context.run_udf`, all results are wrapped into
+:code:`BufferWrapper` instances. This is done primarily to get convenient
+access to a version of the result that is suitable for visualization, even if
+a :code:`roi` was used, but still allow access to the raw result using
+:attr:`BufferWrapper.raw_data` attribute.
 
 .. versionadded:: 0.7.0
    :meth:`UDF.get_results` and the :code:`use` argument for :meth:`UDF.buffer` were added.
@@ -384,7 +390,7 @@ dimension as it appears in processing:
             }
 
         def merge(self, dest, src):
-            dest['pixelsum_nav_raw'][:] += src['pixelsum_nav_raw']
+            dest.pixelsum_nav_raw[:] += src.pixelsum_nav_raw
 
         def process_frame(self, frame):
             np_slice = self.meta.slice.get(nav_only=True)

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -153,7 +153,7 @@ step that is run on the main node, you can override
             return {
                 'sum': self.buffer(kind='sig', dtype=np.float32),
                 'num_frames': self.buffer(kind='single', dtype=np.uint64),
-                'average': self.buffer(kind='sig', dtype=np.float32, allocate=False),
+                'average': self.buffer(kind='sig', dtype=np.float32, use='result_only'),
             }
 
         def process_frame(self, frame):
@@ -161,26 +161,30 @@ step that is run on the main node, you can override
             self.results.num_frames[:] += 1
 
         def merge(self, dest, src):
-            dest['sum'][:] += src['sum']
-            dest['num_frames'][:] += src['num_frames']
+            dest.sum[:] += src.sum
+            dest.num_frames[:] += src.num_frames
 
         def get_results(self):
-            avg = self.results.sum / self.results.num_frames
             return {
-                'sum': self.results['sum'],  # a BufferWrapper
-                'average': self.result(name='average', data=avg),
+                # NOTE: 'sum' omitted here, will be returned unchanged
+                'average': self.results.sum / self.results.num_frames,
             }
 
     ctx.run_udf(dataset=dataset, udf=AverageUDF())
 
 Note that :code:`get_result_buffers` returns a placeholder entry for the :code:`average`
-result using :code:`allocate=False`, which is then filled in :code:`get_results`.
-We use :code:`UDF.result(..., data=avg)` here to get consistent result types: all buffers are
-returned as :class:`BufferWrapper` instances.
+result using :code:`use='result_only'`, which is then filled in :code:`get_results`.
+We don't need to repeat those buffers that should be returned unchanged; if you want
+to omit a buffer from the results completely, you can declare it as private with
+:code:`self.buffer(..., use='private')` in :code:`get_result_buffers`.
+
+When returned from :meth:`Context.run_udf`, all results are wrapped into :code:`BufferWrapper`
+instances. This is done primarily to get convenient access to a version of the result that is
+suitable for visualization, even if a :code:`roi` was used, but still allow access to the
+raw result using :attr:`BufferWrapper.raw_data` attribute.
 
 .. versionadded:: 0.7.0
-   :meth:`UDF.get_results`, :meth:`UDF.result`, and the :code:`allocate` argument for
-   :meth:`UDF.buffer` were added.
+   :meth:`UDF.get_results` and the :code:`use` argument for :meth:`UDF.buffer` were added.
 
 
 Pre-processing

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -189,6 +189,20 @@ access to a version of the result that is suitable for visualization, even if
 a :code:`roi` was used, but still allow access to the raw result using
 :attr:`BufferWrapper.raw_data` attribute.
 
+The detailed rules for buffer declarations, :code:`get_result_buffers` and :code:`get_results` are:
+
+1) All buffers are declared in :code:`get_result_buffers`
+2) If a buffer is only computed in :code:`get_results`, it should be marked via
+   :code:`use='result_only'` so it isn't allocated on workers
+3) If a buffer is only used as intermediary result, it should be marked via :code:`use='private'`
+4) Not including a buffer in :code:`get_results` means it will either be passed on
+   unchanged, or dropped if :code:`use='private'`
+5) It's an error to omit an :code:`use='result_only'` buffer in :code:`get_results`
+6) It's an error to include a :code:`use='private'` buffer in :code:`get_results`
+7) All results are returned from :code:`Context.run_udf` as :code:`BufferWrapper` instances
+8) By default, if :code:`get_results` is not implemented, :code:`use='private'` buffers are dropped,
+   and others are passed through unchanged
+
 .. versionadded:: 0.7.0
    :meth:`UDF.get_results` and the :code:`use` argument for :meth:`UDF.buffer` were added.
 

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -91,6 +91,8 @@ be calculated.
         sl = c.get(key=tile_slice, transpose=False)
         self.results.corr[:] += sl.dot(tile_t).T
 
+.. _`udf post processing`:
+
 Post-processing
 ---------------
 

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -173,7 +173,7 @@ class BufferWrapper(object):
 
             .. versionadded:: 0.6.0
 
-        use : "private", "reault_only" or None
+        use : "private", "result_only" or None
             If you specify :code:`"private"` here, the result will only be made available
             to internal functions, like :meth:`process_frame`, :meth:`merge` or
             :meth:`get_results`. It will not be available to the user of the UDF, which means

--- a/src/libertem/exceptions.py
+++ b/src/libertem/exceptions.py
@@ -1,0 +1,5 @@
+class UDFException(Exception):
+    """
+    Raised when the UDF interface is somehow misused
+    """
+    pass

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -769,12 +769,14 @@ class UDF(UDFBase):
         ----------
 
         dest
-            global results; you can access the ndarrays for each buffer name (from `get_result_buffers`)
-            by attribute access (:code:`dest.your_buffer_name`)
+            global results; you can access the ndarrays for each
+            buffer name (from `get_result_buffers`) by attribute access
+            (:code:`dest.your_buffer_name`)
 
         src
-            results for a partition; you can access the ndarrays for each buffer name (from `get_result_buffers`)
-            by attribute access (:code:`src.your_buffer_name`)
+            results for a partition; you can access the ndarrays for each
+            buffer name (from `get_result_buffers`) by attribute access
+            (:code:`src.your_buffer_name`)
 
         Note
         ----

--- a/src/libertem/udf/logsum.py
+++ b/src/libertem/udf/logsum.py
@@ -31,7 +31,7 @@ class LogsumUDF(UDF):
 
     def merge(self, dest, src):
         ""
-        dest['logsum'][:] += src['logsum'][:]
+        dest.logsum[:] += src.logsum[:]
 
     def process_frame(self, frame):
         ""

--- a/src/libertem/udf/raw.py
+++ b/src/libertem/udf/raw.py
@@ -59,4 +59,4 @@ class PickUDF(UDF):
         # We receive full-size buffers from each node that
         # contributes at least one frame and rely on the rest being filled
         # with zeros correctly.
-        dest['intensity'][:] += src['intensity']
+        dest.intensity[:] += src.intensity

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -235,13 +235,13 @@ class StdDevUDF(UDF):
                 kind='sig', dtype=dtype
             ),
             'var': self.buffer(
-                kind='sig', dtype=dtype, allocate=False,
+                kind='sig', dtype=dtype, use='result_only',
             ),
             'std': self.buffer(
-                kind='sig', dtype=dtype, allocate=False,
+                kind='sig', dtype=dtype, use='result_only',
             ),
             'mean': self.buffer(
-                kind='sig', dtype=dtype, allocate=False,
+                kind='sig', dtype=dtype, use='result_only',
             ),
         }
 
@@ -329,12 +329,9 @@ class StdDevUDF(UDF):
         var = self.results['varsum'].raw_data / num_frames
 
         return {
-            'num_frames': self.results['num_frames'],
-            'varsum': self.results['varsum'],
-            'sum': self.results['sum'],
-            'var': self.result(name='var', data=var),
-            'std': self.result(name='std', data=np.sqrt(var)),
-            'mean': self.result(name='mean', data=self.results['sum'].raw_data / num_frames),
+            'var': var,
+            'std': np.sqrt(var),
+            'mean': self.results.sum / num_frames,
         }
 
 

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -269,18 +269,18 @@ class StdDevUDF(UDF):
             Partial results that contains sum of variances, sum of frames, and the
             number of frames of a partition to be merged into the aggregation buffers
         """
-        dest_n = dest['num_frames'][0]
-        src_n = src['num_frames'][0]
+        dest_n = dest.num_frames[0]
+        src_n = src.num_frames[0]
 
         n = merge(
             dest_n=dest_n,
-            dest_sum=reshaped_view(dest['sum'], (-1,)),
-            dest_varsum=reshaped_view(dest['varsum'], (-1,)),
+            dest_sum=reshaped_view(dest.sum, (-1,)),
+            dest_varsum=reshaped_view(dest.varsum, (-1,)),
             src_n=src_n,
-            src_sum=reshaped_view(src['sum'], (-1,)),
-            src_varsum=reshaped_view(src['varsum'], (-1,)),
+            src_sum=reshaped_view(src.sum, (-1,)),
+            src_varsum=reshaped_view(src.varsum, (-1,)),
         )
-        dest['num_frames'][:] = n
+        dest.num_frames[:] = n
 
     def process_tile(self, tile):
         """
@@ -324,9 +324,9 @@ class StdDevUDF(UDF):
             :code:`'sum', 'varsum', 'num_frames', 'var', 'std', and 'mean'`
             as :code:`BufferWrapper`
         '''
-        num_frames = int(self.results['num_frames'].raw_data[0])
+        num_frames = int(self.results.num_frames[0])
 
-        var = self.results['varsum'].raw_data / num_frames
+        var = self.results.varsum / num_frames
 
         return {
             'var': var,

--- a/src/libertem/udf/sum.py
+++ b/src/libertem/udf/sum.py
@@ -40,4 +40,4 @@ class SumUDF(UDF):
 
     def merge(self, dest, src):
         ''
-        dest['intensity'][:] += src['intensity']
+        dest.intensity[:] += src.intensity

--- a/src/libertem/warnings.py
+++ b/src/libertem/warnings.py
@@ -1,0 +1,6 @@
+class UseDiscouragedWarning(FutureWarning):
+    """
+    This warning is thrown when a problematic feature of an API is used,
+    which we currently don't have plans to remove (for backwards-compatability)
+    """
+    pass

--- a/src/libertem/warnings.py
+++ b/src/libertem/warnings.py
@@ -1,3 +1,12 @@
+"""
+Custom warning subclasses. Useful for selectively filtering. For example, to
+cause an exception for all `UseDiscouragedWarning` that are thrown in the test
+suite, one can run:
+
+$ pytest -Werror:libertem.warnings.UseDiscouragedWarning tests/
+"""
+
+
 class UseDiscouragedWarning(FutureWarning):
     """
     This warning is thrown when a problematic feature of an API is used,

--- a/tests/udf/test_buffer_declarations.py
+++ b/tests/udf/test_buffer_declarations.py
@@ -347,10 +347,29 @@ class OldDictMergeAccess(UDF):
         self.results.default[:] = np.sum(frame)
 
     def merge(self, dest, src):
-        dest['default'][:] += src['default'][:]
+        dest['default'][:] = src['default'][:]
 
 
-def test_warning_for_dict_access(lt_ctx, default_raw):
+def test_warning_for_dict_access_merge(lt_ctx, default_raw):
     udf = OldDictMergeAccess()
     with pytest.warns(UseDiscouragedWarning):
-        results = lt_ctx.run_udf(dataset=default_raw, udf=udf)
+        lt_ctx.run_udf(dataset=default_raw, udf=udf)
+
+
+class OldUDFDataDictAccess(UDF):
+    def get_result_buffers(self):
+        return {
+            'default': self.buffer(kind='nav', dtype=np.float32),
+        }
+
+    def process_frame(self, frame):
+        self.results.default[:] = np.sum(frame)
+
+    def postprocess(self):
+        self.results['default'].raw_data
+
+
+def test_warning_for_dict_access_postprocess(lt_ctx, default_raw):
+    udf = OldUDFDataDictAccess()
+    with pytest.warns(UseDiscouragedWarning):
+        lt_ctx.run_udf(dataset=default_raw, udf=udf)

--- a/tests/udf/test_buffer_declarations.py
+++ b/tests/udf/test_buffer_declarations.py
@@ -67,7 +67,7 @@ class NoAllocateResultsUDF(UDF):
     def get_results(self):
         return {
             'buf1': self.results.buf1,
-            'buf2': np.array(self.results.buf1) + 1,
+            'buf2': self.results.buf1 + 1,
         }
 
 
@@ -98,7 +98,7 @@ class UnifyResultTypesUDF(UDF):
     def get_results(self):
         return {
             'buf1': self.results.buf1,
-            'buf2': np.array(self.results.buf1) + 1,
+            'buf2': self.results.buf1 + 1,
         }
 
 

--- a/tests/udf/test_buffer_declarations.py
+++ b/tests/udf/test_buffer_declarations.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from libertem.udf.base import UDF, UDFException
+from libertem.exceptions import UDFException
+from libertem.udf.base import UDF
 from libertem.common.buffers import BufferWrapper
 
 
@@ -89,7 +90,7 @@ class UnifyResultTypesUDF(UDF):
     def merge(self, dest, src):
         assert 'buf2' not in dest
         assert 'buf2' not in src
-        dest['buf1'][:] += src['buf1']
+        dest.buf1[:] += src.buf1
 
     def process_frame(self, frame):
         pass
@@ -127,8 +128,8 @@ class AverageUDF(UDF):
         self.results.num_frames[:] += 1
 
     def merge(self, dest, src):
-        dest['sum'][:] += src['sum']
-        dest['num_frames'][:] += src['num_frames']
+        dest.sum[:] += src.sum
+        dest.num_frames[:] += src.num_frames
 
     def get_results(self):
         avg = self.results.sum / self.results.num_frames

--- a/tests/udf/test_buffer_declarations.py
+++ b/tests/udf/test_buffer_declarations.py
@@ -1,0 +1,335 @@
+import numpy as np
+import pytest
+
+from libertem.udf.base import UDF, UDFException
+from libertem.common.buffers import BufferWrapper
+
+
+"""
+Rules for buffer declarations, `get_result_buffers` and `get_results`:
+
+1) All buffers are declared in `get_result_buffers`
+2) If a buffer is only computed in `get_results`, it should be marked via
+   `use='result_only'` so it isn't allocated on workers
+3) If a buffer is only used as intermediary result, it should be marked via `use='private'`
+4) Not including a buffer in `get_results` means it will either be passed on
+   unchanged, or dropped if `use='private'`
+5) It's an error to omit an `use='result_only'` buffer in `get_results`
+6) It's an error to include a `use='private'` buffer in `get_results`
+7) All results are returned from `Context.run_udf` as `BufferWrapper` instances
+8) By default, if `get_results` is not implemented, `use='private'` buffers are dropped,
+   and others are passed through unchanged
+"""
+
+
+class UndeclaredBufferUDF(UDF):
+    def get_result_buffers(self):
+        return {
+            'buf': self.buffer(kind='nav', dtype=np.float32),
+        }
+
+    def process_frame(self, frame):
+        pass
+
+    def get_results(self):
+        return {
+            'buf': self.results.buf,
+            'blah': np.zeros((128, 128), dtype=np.float64),
+        }
+
+
+def test_undeclared_buffer_error(lt_ctx, default_raw):
+    """
+    1) All buffers are declared in `get_result_buffers`
+    """
+    udf = UndeclaredBufferUDF()
+    with pytest.raises(UDFException):
+        lt_ctx.run_udf(dataset=default_raw, udf=udf)
+
+
+class NoAllocateResultsUDF(UDF):
+    def get_result_buffers(self):
+        return {
+            'buf1': self.buffer(kind='sig', dtype=np.float32),
+            'buf2': self.buffer(kind='sig', dtype=np.float32, use='result_only'),
+        }
+
+    def merge(self, dest, src):
+        assert 'buf2' not in dest
+        assert 'buf2' not in src
+        dest.buf1[:] += src.buf1
+
+    def process_frame(self, frame):
+        self.results.buf1[:] += frame
+        assert self.results.buf2 is None
+
+    def get_results(self):
+        return {
+            'buf1': self.results.buf1,
+            'buf2': np.array(self.results.buf1) + 1,
+        }
+
+
+def test_no_allocate_result(lt_ctx, default_raw):
+    """
+    2) If a buffer is only computed in `get_results`, it should be marked via
+       `use='result_only'` so it isn't allocated on workers
+    """
+    udf = NoAllocateResultsUDF()
+    lt_ctx.run_udf(dataset=default_raw, udf=udf)
+
+
+class UnifyResultTypesUDF(UDF):
+    def get_result_buffers(self):
+        return {
+            'buf1': self.buffer(kind='sig', dtype=np.float32),
+            'buf2': self.buffer(kind='sig', dtype=np.float32, use='result_only'),
+        }
+
+    def merge(self, dest, src):
+        assert 'buf2' not in dest
+        assert 'buf2' not in src
+        dest['buf1'][:] += src['buf1']
+
+    def process_frame(self, frame):
+        pass
+
+    def get_results(self):
+        return {
+            'buf1': self.results.buf1,
+            'buf2': np.array(self.results.buf1) + 1,
+        }
+
+
+def test_unified_result_types(lt_ctx, default_raw):
+    """
+    7) All results are returned from `Context.run_udf` as `BufferWrapper` instances
+    """
+    udf = UnifyResultTypesUDF()
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf)
+    assert isinstance(results['buf1'], BufferWrapper)
+    assert isinstance(results['buf2'], BufferWrapper)
+
+
+class AverageUDF(UDF):
+    """
+    Like SumUDF, but also computes the average
+    """
+    def get_result_buffers(self):
+        return {
+            'sum': self.buffer(kind='sig', dtype=np.float32),
+            'num_frames': self.buffer(kind='single', dtype=np.uint64),
+            'average': self.buffer(kind='sig', dtype=np.float32, use='result_only'),
+        }
+
+    def process_frame(self, frame):
+        self.results.sum[:] += frame
+        self.results.num_frames[:] += 1
+
+    def merge(self, dest, src):
+        dest['sum'][:] += src['sum']
+        dest['num_frames'][:] += src['num_frames']
+
+    def get_results(self):
+        avg = self.results.sum / self.results.num_frames
+        return {
+            'sum': self.results.sum,
+            'average': avg,
+        }
+
+
+def test_delayed_buffer_alloc(lt_ctx, default_raw):
+    udf = AverageUDF()
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf)
+    assert np.allclose(
+        results['sum'].data / default_raw.shape.nav.size,
+        results['average']
+    )
+    assert results['average'].dtype.kind == 'f'
+
+
+def test_delayed_buffer_alloc_roi(lt_ctx, default_raw):
+    udf = AverageUDF()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+    assert np.allclose(
+        results['sum'].data / np.sum(roi),
+        results['average']
+    )
+
+
+class SumSigUDFAndAHalf(UDF):
+    def get_result_buffers(self):
+        return {
+            'sum': self.buffer(kind='nav', dtype=np.float32),
+            'sum_half': self.buffer(kind='nav', dtype=np.float32, use='result_only'),
+        }
+
+    def process_frame(self, frame):
+        self.results.sum[:] = np.sum(frame)
+
+    def get_results(self):
+        return {
+            'sum': self.results.sum,
+            'sum_half': self.results.sum / 2,
+        }
+
+
+def test_get_results_nav_with_roi(lt_ctx, default_raw):
+    udf = SumSigUDFAndAHalf()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+    assert np.allclose(
+        results['sum'].raw_data / 2,
+        results['sum_half'].raw_data
+    )
+    assert np.allclose(
+        results['sum'].data / 2,
+        results['sum_half'].data,
+        equal_nan=True,
+    )
+
+
+class UsePrivate1Defaults(UDF):
+    def get_result_buffers(self):
+        return {
+            'default': self.buffer(kind='nav', dtype=np.float32),
+            'private': self.buffer(kind='nav', dtype=np.float32, use='private'),
+        }
+
+    def process_frame(self, frame):
+        self.results.default[:] = np.sum(frame)
+        self.results.private[:] = np.sum(frame)
+
+
+def test_use_private_defaults(lt_ctx, default_raw):
+    """
+    3) If a buffer is only used as intermediary result, it should be marked via `use='private'`
+    8) By default, if `get_results` is not implemented, `use='private'` buffers are dropped,
+       and others are passed through unchanged
+    """
+    udf = UsePrivate1Defaults()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+    assert 'default' in results
+    assert 'private' not in results
+
+
+class UsePrivate2ImplicitOmit(UsePrivate1Defaults):
+    def get_results(self):
+        return {
+            'default': self.results.default,
+        }
+
+
+def test_use_private_implicit_omit(lt_ctx, default_raw):
+    """
+    3) If a buffer is only used as intermediary result, it should be marked via `use='private'`
+    4) Not including a buffer in `get_results` means it will either be passed on
+       unchanged, or dropped if `use='private'`
+    """
+    udf = UsePrivate2ImplicitOmit()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+    assert 'default' in results
+    assert 'private' not in results
+
+
+class UsePrivate3DontReturn(UsePrivate1Defaults):
+    def get_results(self):
+        return {
+            'private': np.ones(self.meta.dataset_shape.nav),
+        }
+
+
+def test_use_private_dont_include_in_get_results(lt_ctx, default_raw):
+    """
+    6) It's an error to include a `use='private'` buffer in `get_results`
+    """
+    udf = UsePrivate3DontReturn()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    with pytest.raises(UDFException):
+        lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+
+
+class BufferVisibilityDefault(UDF):
+    def get_result_buffers(self):
+        return {
+            'default': self.buffer(kind='nav', dtype=np.float32),
+            'private': self.buffer(kind='nav', dtype=np.float32, use='private'),
+            'result_only': self.buffer(kind='nav', dtype=np.float32, use='result_only'),
+        }
+
+    def process_frame(self, frame):
+        self.results.default[:] = np.sum(frame)
+        self.results.private[:] = np.sum(frame)
+        assert self.results.result_only is None
+
+    # NOTE: no get_results implemented -> error because of the result_only buffer!
+
+
+def test_buffer_visibility_default(lt_ctx, default_raw):
+    """
+    5) It's an error to omit an `use='result_only'` buffer in `get_results`
+    """
+    udf = BufferVisibilityDefault()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    with pytest.raises(UDFException) as m:
+        lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+    assert m.match(
+        "don't know how to set use='result_only'"
+        " buffer 'result_only'; please implement `get_results`"
+    )
+
+
+class BufferVisibilityResOnly(BufferVisibilityDefault):
+    def get_results(self):
+        return {
+            'result_only': self.results.default,  # just copy over the 'default' buffer
+            # NOTE: other keys omitted, this should pass on the non-private keys
+        }
+
+
+def test_buffer_visibility_with_result_only(lt_ctx, default_raw):
+    udf = BufferVisibilityResOnly()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+    assert 'result_only' in results
+    assert 'default' in results, 'the use=None buffer should be implicitly included in the result'
+    assert 'private' not in results
+
+    for k in results:
+        np.array(results[k])
+        results[k].raw_data
+        results[k].data
+
+
+class ResultOnlyWithFullShape(UDF):
+    def get_result_buffers(self):
+        return {
+            'default': self.buffer(kind='nav', dtype=np.float32),
+            'result_only': self.buffer(kind='nav', dtype=np.float32, use='result_only'),
+        }
+
+    def process_frame(self, frame):
+        self.results.default[:] = np.sum(frame)
+
+    def get_results(self):
+        # we want to embed the results ourselves... does this work?
+        resonly = np.zeros(self.meta.dataset_shape.nav, dtype=self.results.default.dtype)
+        resonly[self.meta.roi] = self.results.default
+        return {
+            'result_only': resonly,
+        }
+
+
+def test_get_results_nav_with_roi_full_shape(lt_ctx, default_raw):
+    udf = ResultOnlyWithFullShape()
+    roi = np.random.choice([True, False], size=default_raw.shape.nav)
+    results = lt_ctx.run_udf(dataset=default_raw, udf=udf, roi=roi)
+    assert 'result_only' in results
+    assert np.allclose(
+        results['default'].data[roi],
+        results['result_only'].data[roi]
+    )
+    assert np.allclose(results['result_only'].data[~roi], 0)

--- a/tests/udf/test_by_tile.py
+++ b/tests/udf/test_by_tile.py
@@ -128,9 +128,9 @@ def test_roi_extra_dimension_shape(lt_ctx):
             # self.results.test3[:] += (framecount, 2*framecount)
 
         def merge(self, dest, src):
-            dest['test'][:] = src['test'][:]
-            dest['test2'][:] += src['test2'][:]
-            # dest['test3'][:] += src['test3'][:]
+            dest.test[:] = src.test[:]
+            dest.test2[:] += src.test2[:]
+            # dest.test3[:] += src.test3[:]
 
     extra = ExtraShapeUDF()
     roi = _mk_random(size=dataset.shape.nav, dtype=bool)

--- a/tests/udf/test_meta.py
+++ b/tests/udf/test_meta.py
@@ -27,10 +27,10 @@ class PixelsumBaseUDF(UDF):
         }
 
     def merge(self, dest, src):
-        dest['pixelsum_nav_raw'][:] += src['pixelsum_nav_raw']
-        dest['pixelsum_sig_raw'][:] += src['pixelsum_sig_raw']
-        dest['pixelsum_nav'][:] += src['pixelsum_nav']
-        dest['pixelsum_sig'][:] += src['pixelsum_sig']
+        dest.pixelsum_nav_raw[:] += src.pixelsum_nav_raw
+        dest.pixelsum_sig_raw[:] += src.pixelsum_sig_raw
+        dest.pixelsum_nav[:] += src.pixelsum_nav
+        dest.pixelsum_sig[:] += src.pixelsum_sig
 
 
 class PixelsumPartitionUDF(PixelsumBaseUDF):

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -127,8 +127,8 @@ def test_kind_single(lt_ctx):
             self.results.sum_frame[:] += np.sum(frame, axis=1)
 
         def merge(self, dest, src):
-            dest['counter'][:] += src['counter']
-            dest['sum_frame'][:] += src['sum_frame']
+            dest.counter[:] += src.counter
+            dest.sum_frame[:] += src.sum_frame
 
     counter = CounterUDF()
     res = lt_ctx.run_udf(dataset=dataset, udf=counter)
@@ -160,8 +160,8 @@ def test_bad_merge(lt_ctx):
             self.results.pixelsum[:] = np.sum(frame)
 
         def merge(self, dest, src):
-            # bad, because it just sets a key in dest, it doesn't copy over the data to dest
-            dest['pixelsum'] = src['pixelsum']
+            # bad, because it just sets an attribute in dest, it doesn't copy over the data to dest
+            dest.pixelsum = src.pixelsum
 
     with pytest.raises(TypeError):
         bm = BadmergeUDF()
@@ -229,9 +229,9 @@ def test_extra_dimension_shape(lt_ctx):
             self.results.test3[:] += (1, 2)
 
         def merge(self, dest, src):
-            dest['test'][:] = src['test'][:]
-            dest['test2'][:] += src['test2'][:]
-            dest['test3'][:] += src['test3'][:]
+            dest.test[:] = src.test[:]
+            dest.test2[:] += src.test2[:]
+            dest.test3[:] += src.test3[:]
 
     extra = ExtraShapeUDF()
     res = lt_ctx.run_udf(dataset=dataset, udf=extra)
@@ -339,9 +339,9 @@ def test_roi_extra_dimension_shape(lt_ctx):
             self.results.test3[:] += (1, 2)
 
         def merge(self, dest, src):
-            dest['test'][:] = src['test'][:]
-            dest['test2'][:] += src['test2'][:]
-            dest['test3'][:] += src['test3'][:]
+            dest.test[:] = src.test[:]
+            dest.test2[:] += src.test2[:]
+            dest.test3[:] += src.test3[:]
 
     extra = ExtraShapeUDF()
     roi = _mk_random(size=dataset.shape.nav, dtype=bool)
@@ -460,7 +460,7 @@ def test_dtypes(lt_ctx, preferred_dtype, data_dtype, expected_dtype):
             assert self.results.dataset_dtype.dtype == self.meta.dataset_dtype
 
         def merge(self, dest, src):
-            dest['dtype'][:] = src['dtype'][:]
+            dest.dtype[:] = src.dtype[:]
 
     if expected_dtype is None:
         expected_dtype = np.result_type(preferred_dtype, data_dtype)
@@ -501,7 +501,7 @@ class ReshapedViewUDF(UDF):
         flat_buf[:] = 1
 
     def merge(self, dest, src):
-        dest["sigbuf"][:] = src["sigbuf"][:]
+        dest.sigbuf[:] = src.sigbuf[:]
 
     def get_backends(self):
         return ('numpy', 'cupy')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,18 +125,18 @@ class DebugDeviceUDF(UDF):
         print(f"meta device_class {self.meta.device_class}")
 
     def merge(self, dest, src):
-        de, sr = dest['device_id'][0], src['device_id'][0]
+        de, sr = dest.device_id[0], src.device_id[0]
         for key, value in sr.items():
             assert key not in de
             de[key] = value
 
-        de, sr = dest['backend'][0], src['backend'][0]
+        de, sr = dest.backend[0], src.backend[0]
         for key, value in sr.items():
             assert key not in de
             de[key] = value
 
-        dest['on_device'][:] += src['on_device']
-        dest['device_class'][:] = src['device_class']
+        dest.on_device[:] += src.on_device
+        dest.device_class[:] = src.device_class
 
     def get_backends(self):
         return self.params.backends


### PR DESCRIPTION
Now, all accesses to buffers in `UDF.results` and the `src`/`dest` parameters of `UDF.merge` should be done via `__getattr__`; if the `BufferWrapper` is really needed, then `UDF.results.get_buffer` should be used.

As a follow-up to #994, `get_results` now should consistently return numpy arrays, which are then converted to `BufferWrapper`s before returning them to the user. This means we can make `get_results` a bit more DRY by not having to repeat buffer names. Also, buffers that don't have to be post-processed, can be left out in `get_results`, and will be returned unchanged. If you want to use a buffer only internally, without exposing it to the user, pass `use='private'` to `UDF.buffer`.

The `allocate` parameter was merged with the `use` parameter, and now `use='result_only'` should be used instead of `allocate=False`.

* Replace `__getitem__` with `__getattr__` in `merge` methods of built-in UDFs, in `libertem.udf` and in tests
* Move `UDFException` to new module `libertem.exceptions`
* Create a custom warning class for discouraged API usage: `UseDiscouragedWarning`
  This can be especially useful combined with `-W`, for example: `pytest -Werror:libertem.warnings.UseDiscouragedWarning tests/`

Fixes #1000, fixes #1001, fixes #631, refs #627

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
