### PR TITLE
Prototype for a shared memory mask container

### DIFF
--- a/prototypes/sharedmem/client.ipynb
+++ b/prototypes/sharedmem/client.ipynb
@@ -1,0 +1,309 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "comic-destination",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "marked-brake",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'3.8.5 (default, Sep  3 2020, 21:29:08) [MSC v.1916 64 bit (AMD64)]'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "respected-private",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import functools\n",
+    "import time\n",
+    "import logging\n",
+    "from multiprocessing import shared_memory as shm\n",
+    "import multiprocessing\n",
+    "import json\n",
+    "from io import BytesIO\n",
+    "\n",
+    "log = logging.getLogger(__name__)\n",
+    "\n",
+    "import sparse\n",
+    "import scipy.sparse\n",
+    "import numpy as np\n",
+    "import cloudpickle\n",
+    "\n",
+    "from libertem.masks import to_dense, to_sparse, is_sparse\n",
+    "from libertem.common import Slice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "registered-durham",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shmem"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "favorite-summary",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_queue = multiprocessing.JoinableQueue()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "guided-cooking",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "starting <Process name='Process-1' parent=17092 initial>\n",
+      "<Process name='Process-1' pid=22408 parent=17092 started>\n"
+     ]
+    }
+   ],
+   "source": [
+    "%autoreload\n",
+    "ref_p = multiprocessing.Process(target=shmem.keep_a_reference, args=(ref_queue, ))\n",
+    "print(f\"starting {ref_p}\")\n",
+    "ref_p.start()\n",
+    "print(ref_p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "certified-trial",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_queue.put('hurz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "brazilian-creator",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Process name='Process-1' pid=22408 parent=17092 started>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ref_p"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "deluxe-thomas",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = functools.partial(sparse.eye, 13)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "promotional-acrylic",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "stored 0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c\n"
+     ]
+    }
+   ],
+   "source": [
+    "%autoreload\n",
+    "m = shmem.load_or_create(f, ref_queue)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "intense-tobago",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[WinError 183] File exists: '0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c'\n",
+      "loading 0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(<COO: shape=(12, 12), dtype=float64, nnz=12, fill_value=0.0>,\n",
+       " [SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c_meta', size=4096),\n",
+       "  SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c_coords', size=4096),\n",
+       "  SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c_data', size=4096),\n",
+       "  SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c', size=4096)])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%autoreload\n",
+    "shmem.load_or_create(f, ref_queue)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "vital-constitution",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[WinError 183] File exists: '0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c'\n",
+      "loading 0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(<COO: shape=(12, 12), dtype=float64, nnz=12, fill_value=0.0>,\n",
+       " [SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c_meta', size=4096),\n",
+       "  SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c_coords', size=4096),\n",
+       "  SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c_data', size=4096),\n",
+       "  SharedMemory('0_ffb6a9f3e5c80e8ed2bad9976551b6c54caed58515e27ac2feb2002bf30a59331e93c90e0aa706820490a6d0e3ba28461e81a009776a5fc809043ef310c2859c', size=4096)])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "shmem.load_or_create(f, ref_queue)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "loved-enclosure",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "starting <Process name='Process-7' parent=17092 initial>\n",
+      "<Process name='Process-7' pid=20272 parent=17092 started>\n",
+      "starting <Process name='Process-8' parent=17092 initial>\n",
+      "<Process name='Process-8' pid=17652 parent=17092 started>\n",
+      "starting <Process name='Process-9' parent=17092 initial>\n",
+      "<Process name='Process-9' pid=6692 parent=17092 started>\n",
+      "starting <Process name='Process-10' parent=17092 initial>\n",
+      "<Process name='Process-10' pid=14920 parent=17092 started>\n",
+      "starting <Process name='Process-11' parent=17092 initial>\n",
+      "<Process name='Process-11' pid=9808 parent=17092 started>\n",
+      "joining <Process name='Process-7' pid=20272 parent=17092 started>...\n",
+      "Done <Process name='Process-7' pid=20272 parent=17092 stopped exitcode=0>.\n",
+      "joining <Process name='Process-8' pid=17652 parent=17092 started>...\n",
+      "Done <Process name='Process-8' pid=17652 parent=17092 stopped exitcode=0>.\n",
+      "joining <Process name='Process-9' pid=6692 parent=17092 stopped exitcode=0>...\n",
+      "Done <Process name='Process-9' pid=6692 parent=17092 stopped exitcode=0>.\n",
+      "joining <Process name='Process-10' pid=14920 parent=17092 stopped exitcode=0>...\n",
+      "Done <Process name='Process-10' pid=14920 parent=17092 stopped exitcode=0>.\n",
+      "joining <Process name='Process-11' pid=9808 parent=17092 stopped exitcode=0>...\n",
+      "Done <Process name='Process-11' pid=9808 parent=17092 stopped exitcode=0>.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if __name__ == '__main__':\n",
+    "    processes = []\n",
+    "    for i in range(5):\n",
+    "        p = multiprocessing.Process(target=shmem.load_or_create, args=(f, ref_queue))\n",
+    "        print(f\"starting {p}\")\n",
+    "        p.start()\n",
+    "        print(p)\n",
+    "        processes.append(p)\n",
+    "    for p in processes:\n",
+    "        print(f\"joining {p}...\")\n",
+    "        p.join()\n",
+    "        print(f\"Done {p}.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "divided-stick",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/prototypes/sharedmem/shmem.py
+++ b/prototypes/sharedmem/shmem.py
@@ -1,0 +1,155 @@
+from multiprocessing import shared_memory as shm
+import json
+from io import BytesIO
+import time
+import pickle
+import hashlib
+import warnings
+
+import sparse
+import numpy as np
+
+from libertem.common.container import MaskContainer
+
+
+# Since shared memory may be returned in page-sized blocks
+# instead of the original size and the remainder might be uninitialized,
+# we encode the size in the first 8 bytes to make sure we decode and load only
+# "good" data
+def meta_to_bytes(obj):
+    enc = json.dumps(obj).encode('utf-8')
+    # prepend length encoded as as int64
+    sizebytes = bytes(np.int64([len(enc)])) + enc
+    return sizebytes
+
+
+def meta_from_bytes(b):
+    offset = np.dtype(np.int64).itemsize
+    size = np.ndarray(shape=1, dtype=np.int64, buffer=b)[0]
+    return json.loads(str(b[offset:offset+size], encoding='utf-8'))
+
+
+# We (ab)use the npz format to encode the array including metadata in memory
+def numpy_to_bytes(a):
+    b = BytesIO()
+    np.lib.format.write_array(b, a)
+    return b.getbuffer()
+
+
+def numpy_from_bytes(b):
+    b_io = BytesIO(b)
+    magic = np.lib.format.read_magic(b_io)
+    if magic == (1, 0):
+        header = np.lib.format.read_array_header_1_0(b_io)
+    elif magic == (2, 0):
+        header = np.lib.format.read_array_header_2_0(b_io)
+    else:
+        raise ValueError(f"Encountered unknown magic {magic}")
+    offset = b_io.tell()
+    return np.ndarray(shape=header[0], order=('F' if header[1] else 'C'), dtype=header[2], buffer=b, offset=offset)
+
+
+def store(computed_masks, base_key, ref_queue):
+    if isinstance(computed_masks, sparse.COO):
+        kind = 'coo'
+    elif isinstance(computed_masks, np.ndarray):
+        kind = 'ndarray'
+    else:
+        raise TypeError(f"Don't know how to handle {type(computed_masks)}")
+    meta = {
+        'kind': kind
+    }
+    meta_bytes = meta_to_bytes(meta)
+    meta_shm = shm.SharedMemory(create=True, name=f"{base_key}_meta", size=len(meta_bytes))
+    ref_queue.put(meta_shm.name)
+    meta_shm.buf[:] = meta_bytes
+
+    if kind == 'coo':
+        coords_bytes = numpy_to_bytes(computed_masks.coords)
+        coords_shm = shm.SharedMemory(create=True, name=f"{base_key}_coords", size=len(coords_bytes))
+        ref_queue.put(coords_shm.name)
+        coords_shm.buf[:] = coords_bytes
+
+        data_bytes = numpy_to_bytes(computed_masks.data)
+        data_shm = shm.SharedMemory(create=True, name=f"{base_key}_data", size=len(data_bytes))
+        ref_queue.put(data_shm.name)
+        data_shm.buf[:] = data_bytes
+        result = (meta_shm, coords_shm, data_shm)
+    else:
+        data_bytes = numpy_to_bytes(computed_masks)
+        data_shm = shm.SharedMemory(create=True, name=f"{base_key}_data", size=len(data_bytes))
+        ref_queue.put(data_shm.name)
+        data_shm.buf[:] = data_bytes
+        result = (meta_shm, data_shm)
+    return result
+
+
+def load(base_key):
+    meta_shm = shm.SharedMemory(create=False, name=f"{base_key}_meta")
+    meta = meta_from_bytes(meta_shm.buf)
+    kind = meta['kind']
+
+    if kind == 'coo':
+        coords_shm = shm.SharedMemory(create=False, name=f"{base_key}_coords")
+        coords = numpy_from_bytes(coords_shm.buf)
+
+        data_shm = shm.SharedMemory(create=False, name=f"{base_key}_data")
+        data = numpy_from_bytes(data_shm.buf)
+        result = (sparse.COO(data=data, coords=coords), [meta_shm, coords_shm, data_shm])
+    elif kind == 'ndarray':
+        data_shm = shm.SharedMemory(create=False, name=f"{base_key}_data")
+        data = numpy_from_bytes(data_shm.buf)
+        result = (data, [meta_shm, data_shm])
+    else:
+        raise ValueError(f"Unknown kind {kind}")
+    return result
+
+
+def load_or_create(mask_factories, ref_queue, salt=0):
+    id = hashlib.sha512(pickle.dumps(mask_factories)).hexdigest()
+    key = f"{salt}_{id}"
+    try:
+        m = shm.SharedMemory(create=True, name=f"{key}", size=1)
+        ref_queue.put(m.name)
+        c = MaskContainer(mask_factories=mask_factories)
+        # "handle" has to stay in scope until the data is loaded
+        # so that the reference count doesn't go down to 0
+        _ = store(c.computed_masks, key, ref_queue)
+        ref_queue.join()
+        print(f"stored {key}")
+        obj, handles = load(key)
+        handles.append(m)
+        # Make sure all references are kept save, i.e. the "keepalive"
+        # process has finished creating a reference
+        # Keep track of all existing handles
+        return (obj, handles)
+    except FileExistsError as e:
+        print(e)
+        for i in range(10):
+            try:
+                print(f"loading {key}...")
+                m = shm.SharedMemory(create=False, name=f"{key}")
+                obj, handles = load(key)
+                handles.append(m)
+                return (obj, handles)
+            except FileNotFoundError as e:
+                print(e)
+                time.sleep(0.1)
+        # Fallback: Calculate locally
+        c = MaskContainer(mask_factories=mask_factories)
+        print(f"fallback {key}")
+        return (c.computed_masks, [])
+
+
+def keep_a_reference(q):
+    refs = []
+    while True:
+        name = q.get()
+        try:
+            print(f"Trying to keep a reference of {name}...")
+            ref = shm.SharedMemory(create=False, name=name)
+            print(f"Reference of {name}: {ref}")
+            refs.append(ref)
+        except FileNotFoundError as e:
+            warnings.warn(str(e))
+        q.task_done()


### PR DESCRIPTION
This prototype demonstrates the core functionality of a shared memory MaskContainer.
At this stage, it just implements a method to share computed_masks.

This is not included in MaskContainer yet, but as stand-alone testing code with many tracing
`print()`s. Sharing tile slices should work analogously to computed_masks.

* The name to address objects is a function of mask_factories
* Determine likely availability of pre-computed masks through a canary object
* Fallback to local masks after timeout -- to be adjusted
* Supports both dense and sparse computed_masks
* Supports additional metadata as JSON

Lessons learned:

Life time management is a bit tricky. If the reference count for the buffer goes to zero,
the shared memory can be purged immediately, apparently. Balancing several interdependent objects
requires making sure that objects will most likely stay alive, and having a fallback
in case a race condition occurs. In this case, a separate process is started whose only
job is to keep references around so that objects will not be purged between processing
"partitions" (run_for_partition() emulated with multiprocessing).

A race condition between the "keep-alive" process and the object creation can occur.
`join()`ing the queue after data has been stored makes sure that keys are safe and secure
before proceeding and having variables fall out of scope or worker processes terminating.

The only IPC/orchestration in this example is a queue to keep track of the buffer names so
that a reference can be kept. Other than that, this is self-organizing and seems to handle a
"thundering herd" quite well: One process is first and creates the canary, the others wait
for it to finish the remaining items and then pick them up. Fr a real MaskContainer this
could be improved by making different workers request different tiles from the MaskContainer
first, so that the tile slice calculation is parallelized.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
