### PR TITLE
Fixes for matplotlib 3.4

### DIFF
--- a/docs/source/changelog/bugfix/mpl-3-4-issues.rst
+++ b/docs/source/changelog/bugfix/mpl-3-4-issues.rst
@@ -1,0 +1,4 @@
+[Bugfix] fix compatibility with the latest matplotlib
+=====================================================
+* Applying a :code:`Norm` to >2D data is no longer allowed, so we reshape
+  the data appropriately. Also needed an additional fix for all-nan results (:issue:`1007`).

--- a/docs/source/changelog/bugfix/mpl-3-4-issues.rst
+++ b/docs/source/changelog/bugfix/mpl-3-4-issues.rst
@@ -1,4 +1,4 @@
 [Bugfix] fix compatibility with the latest matplotlib
 =====================================================
 * Applying a :code:`Norm` to >2D data is no longer allowed, so we reshape
-  the data appropriately. Also needed an additional fix for all-nan results (:issue:`1007`).
+  the data appropriately. Also needed an additional fix for all-nan results (:issue:`1007`, :pr:`1008`).

--- a/src/libertem/viz.py
+++ b/src/libertem/viz.py
@@ -22,7 +22,7 @@ def _get_norm(result, norm_cls=colors.Normalize, vmin=None, vmax=None):
 
     valid_mask = (result != 0) & ~np.isnan(result)
     if valid_mask.sum() == 0:
-        return norm_cls(vmin=0, vmax=0)  # all-NaN or all-zero
+        return norm_cls(vmin=1, vmax=1)  # all-NaN or all-zero
 
     if vmin is None:
         vmin = np.min(result[valid_mask])


### PR DESCRIPTION
Applying a `Norm` to >2D data is no longer allowed, so we reshape
the data appropriately. Also needed an additional fix for all-nan results.

Fixes #1007.

## Contributor Checklist:

* [N/A] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
