### PR TITLE
Bugfix for COM analysis template

### DIFF
--- a/docs/source/changelog/bugfix/com.rst
+++ b/docs/source/changelog/bugfix/com.rst
@@ -1,0 +1,4 @@
+[Bugfix] Axes order in COM template
+===================================
+
+* The components in the field are (x, y). The template had them as (y, x).

--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -52,7 +52,7 @@ class ComTemplate(GeneratorHelper):
         plot = [
             "fig, axes = plt.subplots()",
             'axes.set_title("field")',
-            "y_centers, x_centers = com_result.field.raw_data",
+            "x_centers, y_centers = com_result.field.raw_data",
             "ch = ColormapCubehelix(start=1, rot=1, minLight=0.5, maxLight=0.5, sat=2)",
             "axes.imshow(ch.rgb_from_vector((x_centers, y_centers, 0)))"
         ]


### PR DESCRIPTION
The compnents were in the wrong order

## Contributor Checklist:

* [X ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
