### PR TITLE
WIP: `BufferWrapper`: support for partitions that slice the signal dimensions

### DIFF
--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -194,6 +194,7 @@ class BufferWrapper(object):
         # set to True if the data coords are global ds coords
         self._data_coords_global = False
         self._shape = None
+        self._part_sig_slice = None
         self._ds_shape = None
         self._roi = None
         self._roi_is_zero = None
@@ -206,6 +207,9 @@ class BufferWrapper(object):
         self._roi = roi
 
     def set_shape_partition(self, partition, roi=None):
+        """
+        Set shape and slice information from `partition`.
+        """
         self.set_roi(roi)
         roi_count = None
         if roi is not None:
@@ -214,6 +218,7 @@ class BufferWrapper(object):
             assert roi_count <= partition.shape[0]
             assert roi_part.shape[0] == partition.shape[0]
         self._shape = self._shape_for_kind(self._kind, partition.shape, roi_count)
+        self._part_sig_slice = partition.slice.discard_nav()
         self._update_roi_is_zero()
 
     def set_shape_ds(self, dataset_shape, roi=None):
@@ -470,7 +475,7 @@ class BufferWrapper(object):
 
         '''
         if self._kind == "sig":
-            key = tile.tile_slice.discard_nav()
+            key = tile.tile_slice.discard_nav().shift(self._part_sig_slice)
             if key in self._contiguous_cache:
                 view = self._contiguous_cache[key]
             else:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1317,9 +1317,6 @@ class UDFRunner:
             xp = cupy_udfs[0].xp
 
         for tile in tiles:
-            if self.pdb_port is not None and tile.tile_slice.origin[0] == 100:
-                import remote_pdb
-                remote_pdb.RemotePdb('127.0.0.1', self.pdb_port).set_trace()
             self._run_tile(numpy_udfs, partition, tile, tile)
             if cupy_udfs:
                 # Work-around, should come from dataset later

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -318,7 +318,7 @@ class UDFData:
         for k, buf in self._get_buffers():
             self._views[k] = buf.get_view_for_dataset(dataset)
 
-    def set_view_for_partition(self, partition: Shape):
+    def set_view_for_partition(self, partition: Partition):
         for k, buf in self._get_buffers():
             self._views[k] = buf.get_view_for_partition(partition)
 

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -197,3 +197,6 @@ class ApplyMasksUDF(UDF):
             result = flat_data @ masks
         # '+' is the correct merge for dot product
         self.results.intensity[:] += result
+
+    def merge(self, dest, src):
+        dest.intensity[:] += src.intensity

--- a/src/libertem/viz/bqp.py
+++ b/src/libertem/viz/bqp.py
@@ -109,8 +109,12 @@ class BQLive2DPlot(Live2DPlot):
         dtype = np.result_type(self.data, np.int8)
         # Map on dtype that supports subtraction
         valid_data = self.data[damage].astype(dtype)
-        mmin = valid_data.min()
-        mmax = valid_data.max()
+        if valid_data.size > 0:
+            mmin = valid_data.min()
+            mmax = valid_data.max()
+        else:
+            mmin = 1
+            mmax = 1 + 1e-12
         delta = mmax - mmin
         if delta <= 0:
             delta = 1

--- a/src/libertem/viz/bqp.py
+++ b/src/libertem/viz/bqp.py
@@ -91,15 +91,18 @@ class BQLive2DPlot(Live2DPlot):
             title=self.title
         )
 
+        color_scale = ColorScale(min=0, max=1)
+
         scales_image = {'x': scale_x,
                         'y': scale_y,
-                        'image': ColorScale(min=0, max=1)}
+                        'image': color_scale}
 
         dtype = np.result_type(self.data, np.int8)
         image = ImageGL(image=self.data.astype(dtype), scales=scales_image)
         figure.marks = (image,)
         self.figure = figure
         self.image = image
+        self.color_scale = color_scale
 
     def display(self):
         from IPython.display import display

--- a/tests/common/test_bufferwrapper.py
+++ b/tests/common/test_bufferwrapper.py
@@ -27,7 +27,7 @@ def test_new_for_partition():
 
     for idx, partition in enumerate(dataset.get_partitions()):
         print("partition number", idx)
-        new_buf = buf.new_for_partition(partition, roi=roi)
+        new_buf = buf.new_for_partition(partition_slice=partition.slice, roi=roi)
         ps = partition.slice.get(nav_only=True)
         roi_part = roi.reshape(-1)[ps]
 
@@ -175,11 +175,11 @@ def test_sig_slicing():
 
     udf.set_meta(meta)
     udf.init_result_buffers()
-    udf.allocate_for_part(partition=partition, roi=None)
+    udf.allocate_for_part(partition_slice=partition.slice, roi=None)
     udf.init_task_data()
 
     udf.set_contiguous_views_for_tile(
-        partition=partition,
+        partition_slice=partition.slice,
         tile=tile,
     )
     udf.process_tile(tile)
@@ -231,9 +231,9 @@ def test_sig_slicing_2():
         where=None,
         use=None,
     )
-    buf.set_shape_partition(partition, roi)
+    buf.set_shape_partition(partition.slice, roi)
     buf.allocate(lib=None)
-    view = buf.get_contiguous_view_for_tile(partition, tile)
+    view = buf.get_contiguous_view_for_tile(partition.slice, tile)
     assert view.size > 0
 
 
@@ -285,7 +285,7 @@ def test_sig_slicing_views_for_partition():
     )
     buf.set_shape_ds(dataset_shape, roi)
     buf.allocate(lib=None)
-    view_p = buf.get_view_for_partition(partition)
+    view_p = buf.get_view_for_partition(partition_slice=partition.slice)
     view_p[:] = 1
 
     # FIXME: this works for now, as the dataset parameter is not used yet. we
@@ -373,7 +373,7 @@ def test_sig_slicing_views_for_partition_2():
         )
     })
     for k, buf in ud_p._get_buffers():
-        buf.set_shape_partition(partition, roi)
+        buf.set_shape_partition(partition_slice=partition.slice, roi=roi)
     for k, buf in ud_p._get_buffers(filter_allocated=True):
         buf.allocate(lib=None)
 
@@ -385,7 +385,7 @@ def test_sig_slicing_views_for_partition_2():
     ud_p.export()
 
     # prepare ds result buffer:
-    ud_ds.set_view_for_partition(partition)
+    ud_ds.set_view_for_partition(partition_slice=partition.slice)
 
     # now, simulate a merge:
     dest = ud_ds.get_proxy()

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -403,7 +403,7 @@ def test_udf_pickle(lt_ctx):
     pixelsum.set_backend("numpy")
     pixelsum.set_meta(meta)
     pixelsum.init_result_buffers()
-    pixelsum.allocate_for_part(partition, None)
+    pixelsum.allocate_for_part(partition.slice, None)
     pickle.loads(pickle.dumps(pixelsum))
 
 
@@ -554,7 +554,7 @@ def test_noncontiguous_tiles(lt_ctx, backend):
         udf = ReshapedViewUDF()
         res = lt_ctx.run_udf(udf=udf, dataset=dataset)
         partition = next(dataset.get_partitions())
-        p_udf = udf.copy_for_partition(partition=partition, roi=None)
+        p_udf = udf.copy_for_partition(partition_slice=partition.slice, roi=None)
         # Enabling debug=True checks for disjoint cache keys
         UDFRunner([p_udf], debug=True).run_for_partition(
             partition=partition,


### PR DESCRIPTION
This is needed for tiled processing of (live) data from detectors that deliver their data as independent streams for each detector part. It works by only allocating for the signal slice, and then shifting the tile slices to the local coordinate system of the partition (in signal dims).

The tests are not minimal yet - I'll work on implementing support in the memory dataset for this kind - then we can test at the interfaces.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

## Please remove this section

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
