### PR TITLE
Fix hard-coded paths and addresses in some dist tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -346,7 +346,12 @@ def raw_data_8x8x8x8_path(tmpdir_factory):
 
 
 @pytest.fixture
-def dist_ctx():
+def scheduler_addr():
+    return os.environ['DASK_SCHEDULER_ADDRESS']
+
+
+@pytest.fixture
+def dist_ctx(scheduler_addr):
     """
     This Context needs to have an external dask cluster running, with the following
     assumptions:
@@ -354,9 +359,7 @@ def dist_ctx():
      - two workers: hostnames worker-1 and worker-2
      - one scheduler node
      - data availability TBD
-     - the address of the dask scheduler is passed in as DASK_SCHEDULER_ADDRESS
     """
-    scheduler_addr = os.environ['DASK_SCHEDULER_ADDRESS']
     executor = DaskJobExecutor.connect(scheduler_addr)
     with lt.Context(executor=executor) as ctx:
         yield ctx

--- a/data/temp_data/.placeholder
+++ b/data/temp_data/.placeholder
@@ -1,0 +1,1 @@
+This file just exists to make sure this directory exists in git.

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -162,7 +162,7 @@ def test_cache_key_json_serializable(default_blo):
 
 @pytest.mark.dist
 def test_blo_dist(dist_ctx):
-    ds = BloDataSet(path="/data/default.blo")
+    ds = BloDataSet(path=BLO_TESTDATA_PATH)
     ds = ds.initialize(dist_ctx.executor)
     analysis = dist_ctx.create_sum_analysis(dataset=ds)
     results = dist_ctx.run(analysis)

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -21,10 +21,11 @@ from libertem import masks
 
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF
 
-K2IS_TESTDATA_PATH = os.path.join(get_testdata_path(), 'Capture52', 'Capture52_.gtg')
+
+K2IS_TESTDATA_DIR = os.path.join(get_testdata_path(), 'Capture52')
+K2IS_TESTDATA_PATH = os.path.join(K2IS_TESTDATA_DIR, 'Capture52_.gtg')
 K2IS_TESTDATA_RAW = os.path.join(
-    get_testdata_path(),
-    'Capture52',
+    K2IS_TESTDATA_DIR,
     'Capture52_.gtg_(34, 35, 1860, 2048)_uint16.raw'
 )
 HAVE_K2IS_TESTDATA = os.path.exists(K2IS_TESTDATA_PATH)
@@ -353,8 +354,8 @@ def test_cache_key_json_serializable(default_k2is):
 def test_k2is_dist(dist_ctx):
     ds = K2ISDataSet(path=K2IS_TESTDATA_PATH)
     import glob
-    print(dist_ctx.executor.run_function(lambda: os.listdir("/data/Capture52/")))
-    print(dist_ctx.executor.run_function(lambda: list(sorted(glob.glob("/data/Capture52/*")))))
+    print(dist_ctx.executor.run_function(lambda: os.listdir(K2IS_TESTDATA_DIR)))
+    print(dist_ctx.executor.run_function(lambda: list(sorted(glob.glob(K2IS_TESTDATA_DIR)))))
     ds = ds.initialize(dist_ctx.executor)
     roi = np.zeros(ds.shape.nav, dtype=bool)
     roi[0, 5] = 1

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -355,7 +355,7 @@ def test_k2is_dist(dist_ctx):
     ds = K2ISDataSet(path=K2IS_TESTDATA_PATH)
     import glob
     print(dist_ctx.executor.run_function(lambda: os.listdir(K2IS_TESTDATA_DIR)))
-    print(dist_ctx.executor.run_function(lambda: list(sorted(glob.glob(K2IS_TESTDATA_DIR)))))
+    print(dist_ctx.executor.run_function(lambda: list(sorted(glob.glob(K2IS_TESTDATA_DIR+'/*')))))
     ds = ds.initialize(dist_ctx.executor)
     roi = np.zeros(ds.shape.nav, dtype=bool)
     roi[0, 5] = 1

--- a/tests/template/test_ring_template.py
+++ b/tests/template/test_ring_template.py
@@ -15,7 +15,6 @@ from temp_utils import _get_hdf5_params, create_random_hdf5
 
 pytestmark = [pytest.mark.functional]
 
-
 TMP_TESTDATA_PATH = os.path.join(get_testdata_path(), 'temp_data')
 HAVE_TMP_TESTDATA = os.path.exists(TMP_TESTDATA_PATH)
 
@@ -74,7 +73,7 @@ def random_hdf5_1():
 
 @pytest.mark.dist
 @pytest.mark.asyncio
-#@pytest.mark.skipif(not HAVE_TMP_TESTDATA, reason="need temporary directory for testdata")  # NOQA
+@pytest.mark.skipif(not HAVE_TMP_TESTDATA, reason="need temporary directory for testdata")  # NOQA
 def test_ring_tcp_cluster(lt_ctx, random_hdf5_1, scheduler_addr):
 
     conn = {"connection": {

--- a/tests/template/test_ring_template.py
+++ b/tests/template/test_ring_template.py
@@ -1,6 +1,6 @@
 import io
 import os
-import shutil
+import glob
 
 import nbformat
 import pytest
@@ -74,7 +74,7 @@ def random_hdf5_1():
 
 @pytest.mark.dist
 @pytest.mark.asyncio
-@pytest.mark.skipif(not HAVE_TMP_TESTDATA, reason="need temporary directory for testdata")  # NOQA
+#@pytest.mark.skipif(not HAVE_TMP_TESTDATA, reason="need temporary directory for testdata")  # NOQA
 def test_ring_tcp_cluster(lt_ctx, random_hdf5_1, scheduler_addr):
 
     conn = {"connection": {
@@ -123,3 +123,11 @@ def test_ring_tcp_cluster(lt_ctx, random_hdf5_1, scheduler_addr):
         results,
         expected['intensity'].raw_data,
     )
+
+
+@pytest.mark.dist
+def test_datadir_inspection():
+    print("get_testdata_path():", get_testdata_path())
+    print(list(sorted(glob.glob(get_testdata_path() + '/*'))))
+    print(list(sorted(glob.glob(TMP_TESTDATA_PATH + '/*'))))
+    assert HAVE_TMP_TESTDATA

--- a/tests/template/test_ring_template.py
+++ b/tests/template/test_ring_template.py
@@ -4,7 +4,7 @@ import shutil
 import nbformat
 import pytest
 import numpy as np
-from temp_utils import _get_hdf5_params, create_random_hdf5
+from temp_utils import _get_hdf5_params
 from libertem.web.notebook_generator.notebook_generator import notebook_generator
 from nbconvert.preprocessors import ExecutePreprocessor
 
@@ -53,26 +53,16 @@ def test_ring_default(hdf5_ds_2, tmpdir_factory, lt_ctx, local_cluster_url):
     )
 
 
-@pytest.fixture(scope='function')
-def random_hdf5_1():
-    tmp_dir = '/data/temp_data/tmp'
-    os.makedirs(tmp_dir)
-    ds_path = os.path.join(tmp_dir, 'tmp_random_hdf5.h5')
-    ds = create_random_hdf5(ds_path)
-    yield ds
-    shutil.rmtree(tmp_dir, ignore_errors=True)
-
-
 @pytest.mark.dist
 @pytest.mark.asyncio
-def test_ring_tcp_cluster(lt_ctx, random_hdf5_1):
+def test_ring_tcp_cluster(lt_ctx, hdf5_ds_2, scheduler_addr):
 
     conn = {"connection": {
                     "type": "TCP",
-                    "address": "tcp://scheduler:8786"
+                    "address": scheduler_addr
                     }
             }
-    ds = random_hdf5_1
+    ds = hdf5_ds_2
     ds_path = ds.path
     tmp_dir = os.path.dirname(ds_path)
     dataset = _get_hdf5_params(ds_path)


### PR DESCRIPTION
This should allow to run these tests with any Dask scheduler that
is passed via DASK_SCHEDULER_ADDRESS and data via TESTDATA_BASE_PATH.
In particular, make sure that the tests don't write to hardcoded absolute
paths that could accidentally overwrite files on a user's system.

Let's see if it still works in CI!

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if
changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
