### PR TITLE
warmup: run tiling scheme negotiation w/ roi

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -78,6 +78,11 @@ def hdf5_5d(tmpdir_factory):
     yield from get_or_create_hdf5(tmpdir_factory, "hdf5-test-5d.h5",
                                   data=np.ones((3, 5, 9, 16, 16)))
 
+@pytest.fixture(scope='session')
+def random_hdf5_large_sig(tmpdir_factory):
+    yield from get_or_create_hdf5(tmpdir_factory, "hdf5-test-random.h5",
+                                  data=np.random.randn(16, 16, 512, 512))
+
 
 @pytest.fixture(scope='session')
 def random_hdf5(tmpdir_factory):
@@ -155,6 +160,15 @@ def hdf5_ds_1(hdf5):
 
 @pytest.fixture
 def hdf5_ds_2(random_hdf5):
+    ds = H5DataSet(
+        path=random_hdf5.filename, ds_path="data",
+    )
+    ds = ds.initialize(InlineJobExecutor())
+    return ds
+
+
+@pytest.fixture
+def hdf5_ds_large_sig(random_hdf5):
     ds = H5DataSet(
         path=random_hdf5.filename, ds_path="data",
     )

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import contextlib
 import warnings
 import logging
@@ -498,7 +497,7 @@ class H5Partition(Partition):
             return
         self._corrections.apply(tile_data, tile_slice)
 
-    def _get_read_cache_size(self) -> Tuple[int, int]:
+    def _get_read_cache_size(self) -> int:
         chunks = self._chunks
         if chunks is None:
             return 1*1024*1024
@@ -547,7 +546,7 @@ class H5Partition(Partition):
     def _get_tiles_with_roi(self, roi, dest_dtype, tiling_scheme):
         # we currently don't chop up the frames when reading with a roi, so
         # the tiling scheme also must not contain more than one slice:
-        assert len(tiling_scheme) == 1, "incompatible tiling scheme!"
+        assert len(tiling_scheme) == 1, "incompatible tiling scheme! (%r)" % (tiling_scheme)
 
         flat_roi = roi.reshape((-1,))
         roi = roi.reshape(self.meta.shape.nav)

--- a/src/libertem/web/messageconverter.py
+++ b/src/libertem/web/messageconverter.py
@@ -1,8 +1,9 @@
+from typing import Dict, Optional
 import jsonschema
 
 
 class MessageConverter:
-    SCHEMA = None
+    SCHEMA: Optional[Dict] = None
 
     def validate(self, raw_data):
         if self.SCHEMA is None:

--- a/tests/common/test_numba.py
+++ b/tests/common/test_numba.py
@@ -83,5 +83,13 @@ def test_numba_cache(tmpdir_factory):
     assert len(cache_contents[1].keys()) == 2
 
 
-def test_numba_prime(lt_ctx, default_raw):
+def test_numba_prime(default_raw):
     prime_numba_cache(default_raw)
+
+
+def test_numba_prime_hdf5_1(hdf5_ds_1):
+    prime_numba_cache(hdf5_ds_1)
+
+
+def test_numba_prime_hdf5_2(hdf5_ds_large_sig):
+    prime_numba_cache(hdf5_ds_large_sig)


### PR DESCRIPTION
This fixes cache warmup for HDF5 files, that have different requirements for the tiling scheme depending on roi/non-roi runs.

Also run warmup with both SumUDF and PickUDF

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
