### PR TITLE
Left over link fix

### DIFF
--- a/client/src/cluster/components/GPUSelector.tsx
+++ b/client/src/cluster/components/GPUSelector.tsx
@@ -30,7 +30,7 @@ export const GPUSelector: React.FC<GPUSelectorProps> = ({
                     <Message.Header>No cupy installation found</Message.Header>
                     <p>
                         To make use of the built-in GPU support, make
-                        sure to install <a href="https://cupy.chainer.org/" rel="noreferrer noopener" target="_blank">cupy</a>
+                        sure to install <a href="https://cupy.dev/" rel="noreferrer noopener" target="_blank">cupy</a>
                     </p>
                 </Message> : ''
             }


### PR DESCRIPTION
Rebuilt client is left out, this can be fixed with some other GUI client

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
