### PR TITLE
ipyparallel: use `Client.wait_for_engines(...)`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -385,12 +385,8 @@ def dist_ctx(scheduler_addr):
 def ipy_ctx():
     import ipyparallel
     client = ipyparallel.Client()
-    retries = 10
-    while retries > 0:
-        retries -= 1
-        if len(client.ids) > 0:
-            break
-        time.sleep(1)
+    # wait for two engines: see also docker-compose.yml where the engines are started
+    client.wait_for_engines(2)
     dask_client = client.become_dask()
     executor = DaskJobExecutor(client=dask_client, is_local=False)
     with lt.Context(executor=executor) as ctx:

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import time
 import importlib.util
 import platform
 import threading

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN /venv/bin/pip install --no-cache wheel && /venv/bin/pip install --no-cache -
 RUN /venv/bin/pip install -e 'git+https://github.com/pyFFTW/pyFFTW.git#egg=pyfftw'
 # Include https://github.com/ipython/ipyparallel/pull/415
 # FIXME switch to release version as soon as included
-RUN /venv/bin/pip install -e 'git+https://github.com/ipython/ipyparallel.git@3638a89d7eb6b4969ed0a6f44a4e8b234d574005#egg=ipyparallel'
+RUN /venv/bin/pip install -e 'git+https://github.com/ipython/ipyparallel.git@7.0.0a3#egg=ipyparallel'
 
 COPY . /code/
 RUN venv/bin/pip install --no-cache /code/


### PR DESCRIPTION
Updated to 7.0.0a3

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
