### PR TITLE
Allow extra dimensions for plot data compared to damage

### DIFF
--- a/docs/source/changelog/bugfix/rgb.rst
+++ b/docs/source/changelog/bugfix/rgb.rst
@@ -1,0 +1,5 @@
+[Bugfix] Allow RGB plotting
+===========================
+
+* Allow custom plots to return RGB as plot data, for example a color
+  wheel for vector fields (:issue:`1052`, :pr:`1101`).

--- a/tests/viz/test_viz_base.py
+++ b/tests/viz/test_viz_base.py
@@ -64,3 +64,17 @@ def test_live_autoextraction(lt_ctx, default_raw, udf_cls):
     udf = udf_cls()
     plots = [Dummy2DPlot(dataset=default_raw, udf=udf, channel=('intensity', np.abs))]
     lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=plots)
+
+
+def test_live_RGB(lt_ctx, default_raw):
+    udf = SumSigUDF()
+
+    def RGB_plot(udf_result, damage):
+        data = udf_result['intensity'].data
+        plot = viz.CMAP_CIRCULAR_DEFAULT.rgb_from_vector((data, 0, 0))
+        return (plot, damage)
+
+    plots = [Dummy2DPlot(dataset=default_raw, udf=udf, channel=RGB_plot)]
+    lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=plots)
+
+    assert plots[0].data.shape == tuple(default_raw.shape.nav) + (3, )


### PR DESCRIPTION
For example RGB plots for colorwheel visualization for vector fields.

Closes #1052

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
