### PR TITLE
Only count CPU workers

### DIFF
--- a/docs/source/changelog/bugfix/workercount.rst
+++ b/docs/source/changelog/bugfix/workercount.rst
@@ -1,0 +1,5 @@
+[Bugfix] Calculate worker count for partitioning correctly
+==========================================================
+
+* Only count CPU workers to make sure we don't have residual
+  partitions (:issue:`1086`, :pr:`1103`).

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -24,6 +24,13 @@ def test_start_local_default(hdf5_ds_1, local_cluster_ctx):
         dataset=hdf5_ds_1, factories=[lambda: mask]
     )
 
+    num_cores_ds = ctx.load('memory', data=np.zeros((2, 3, 4, 5)))
+    workers = ctx.executor.get_available_workers()
+    cpu_count = len(workers.has_cpu())
+    gpu_count = len(workers.has_cuda())
+
+    assert num_cores_ds._cores == max(cpu_count, gpu_count)
+
     # Based on ApplyMasksUDF, which is CuPy-enabled
     hybrid = ctx.run(analysis)
     _ = ctx.run_udf(udf=DebugDeviceUDF(), dataset=hdf5_ds_1)


### PR DESCRIPTION
This may be slower than necessary for UDFs that support mixed GPU + CPU processing,
but the penalty is probably less than having a residual partition.

Closes #1086

Thx @matbryan52 for reporting!

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
