### PR TITLE
Set correct slice info for partition

### DIFF
--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1302,7 +1302,7 @@ class UDFRunner:
                     udf.process_frame(frame)
             elif method == 'partition':
                 udf.set_views_for_tile(partition, tile)
-                udf.set_slice(partition.slice)
+                udf.set_slice(tile.tile_slice)
                 udf.process_partition(device_tile)
 
     def _run_udfs(self, numpy_udfs, cupy_udfs, partition, tiling_scheme, roi, dtype):

--- a/tests/udf/test_by_partition.py
+++ b/tests/udf/test_by_partition.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from libertem.udf import UDF
 from libertem.io.dataset.memory import MemoryDataSet
@@ -18,13 +19,52 @@ class PixelsumUDF(UDF):
         self.results.pixelsum[:] += np.sum(partition, axis=(-1, -2))
 
 
-def test_sum_tiles(lt_ctx):
+@pytest.mark.parametrize(
+    'tileshape', (None, (7, 16, 16))
+)
+def test_sum_tiles(lt_ctx, tileshape):
     data = _mk_random(size=(16, 16, 16, 16), dtype="float32")
-    dataset = MemoryDataSet(data=data, tileshape=(7, 16, 16),
-                            num_partitions=2, sig_dims=2)
+    # The dataset can force a different tile size even for process_partition!
+    # At least MemoryDataSet does that and we should check that everything is ok...
+    dataset = MemoryDataSet(
+        data=data, num_partitions=7, sig_dims=2, tileshape=tileshape
+    )
 
     pixelsum = PixelsumUDF()
     res = lt_ctx.run_udf(dataset=dataset, udf=pixelsum)
     assert 'pixelsum' in res
     print(data.shape, res['pixelsum'].data.shape)
     assert np.allclose(res['pixelsum'].data, np.sum(data, axis=(2, 3)))
+
+
+class TouchUDF(UDF):
+    def get_result_buffers(self):
+        return {
+            'touched': self.buffer(
+                kind="nav", dtype="int"
+            )
+        }
+
+    def process_partition(self, partition):
+        print(partition.shape)
+        self.results.touched[:] += 1
+        assert partition.shape[0] == self.meta.coordinates.shape[0]
+
+
+@pytest.mark.parametrize(
+    'use_roi', (False, True)
+)
+@pytest.mark.parametrize(
+    'tileshape', (None, (7, 16, 16))
+)
+def test_partition_roi(lt_ctx, use_roi, tileshape):
+    data = _mk_random(size=(16, 16, 16, 16), dtype="float32")
+    dataset = MemoryDataSet(data=data, num_partitions=2, sig_dims=2, tileshape=tileshape)
+    if use_roi:
+        roi = np.random.choice([True, False], dataset.shape.nav)
+    else:
+        roi = None
+    udf = TouchUDF()
+    res = lt_ctx.run_udf(dataset=dataset, udf=udf, roi=roi)
+    print(data.shape, res['touched'].data.shape)
+    assert np.all(res['touched'].raw_data == 1)

--- a/tests/udf/test_coords.py
+++ b/tests/udf/test_coords.py
@@ -32,7 +32,7 @@ class SimpleTestByPartitionUDF(UDF):
 
 def test_tiles_by_partition(lt_ctx):
     data = _mk_random(size=(8, 8, 8, 8), dtype="float32")
-    dataset = MemoryDataSet(data=data, tileshape=(4, 8, 8),
+    dataset = MemoryDataSet(data=data, tileshape=(32, 8, 8),
                             num_partitions=2, sig_dims=2)
 
     test = SimpleTestByPartitionUDF()


### PR DESCRIPTION
The tile can still be overridden by the dataset, it is not guaranteed to
actually be a partition!

Amends #1107 

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
