### PR TITLE
Caching threadpoolctl modules

### DIFF
--- a/benchmarks/udf/test_simple_udf.py
+++ b/benchmarks/udf/test_simple_udf.py
@@ -56,9 +56,12 @@ def test_udf_noncontiguous_tiles(lt_ctx, backend, benchmark):
     group="udf overheads"
 )
 def test_overhead(shared_dist_ctx, benchmark):
-    ds = shared_dist_ctx.load('memory', data=np.zeros((1024, 1024, 2)), sig_dims=1)
-    # many partitions
-    ds.set_num_cores(32*1024)
+    ds = shared_dist_ctx.load(
+        'memory',
+        data=np.zeros((1024, 1024, 2)),
+        sig_dims=1,
+        num_partitions=32
+    )
     benchmark(
         shared_dist_ctx.run_udf,
         dataset=ds,

--- a/benchmarks/udf/test_simple_udf.py
+++ b/benchmarks/udf/test_simple_udf.py
@@ -58,7 +58,7 @@ def test_udf_noncontiguous_tiles(lt_ctx, backend, benchmark):
 def test_overhead(shared_dist_ctx, benchmark):
     ds = shared_dist_ctx.load(
         'memory',
-        data=np.zeros((1024, 1024, 2)),
+        data=np.zeros((1024, 2)),
         sig_dims=1,
         num_partitions=32
     )

--- a/docs/source/acknowledgments.rst
+++ b/docs/source/acknowledgments.rst
@@ -122,6 +122,36 @@ notebook project, which has the following license:
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+An unreleased development version of :code:`threadpoolctl` with a critical
+feature is copied for the time being. It has the following license:
+
+.. code-block:: text
+
+    Copyright (c) 2019, threadpoolctl contributors
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+        * Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+        * Neither the name of copyright holder nor the names of its contributors
+        may be used to endorse or promote products derived from this software
+        without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 Funding
 ~~~~~~~
 

--- a/docs/source/changelog/misc/threadcount.rst
+++ b/docs/source/changelog/misc/threadcount.rst
@@ -1,0 +1,4 @@
+[Misc] Overhead of setting thread count reduced
+===============================================
+
+* Cache loaded libraries to reduce overhead of setting the thread count (:issue:`1117`, :pr:`1118`).

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -373,7 +373,24 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         return result_map
 
     def run_each_worker(self, fn, *args, **kwargs):
-        return self.client.run(fn, *args, **kwargs)
+        # Client.run() creates issues on Windows and OS X with Python 3.6
+        available_workers = self.get_available_workers()
+
+        future_map = {}
+        for worker in available_workers:
+            future_map[worker.name] = self.client.submit(
+                functools.partial(fn, *args, **kwargs),
+                priority=1,
+                workers=[worker.name],
+                # NOTE: need pure=False, otherwise the functions will all map to the same
+                # scheduler key and will only run once
+                pure=False,
+            )
+        result_map = {
+            name: future.result()
+            for name, future in future_map.items()
+        }
+        return result_map
 
     def close(self):
         if self.is_local:

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -373,23 +373,7 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         return result_map
 
     def run_each_worker(self, fn, *args, **kwargs):
-        available_workers = self.get_available_workers()
-
-        future_map = {}
-        for worker in available_workers:
-            future_map[worker.name] = self.client.submit(
-                functools.partial(fn, *args, **kwargs),
-                priority=1,
-                workers=[worker.name],
-                # NOTE: need pure=False, otherwise the functions will all map to the same
-                # scheduler key and will only run once
-                pure=False,
-            )
-        result_map = {
-            name: future.result()
-            for name, future in future_map.items()
-        }
-        return result_map
+        return self.client.run(fn, *args, **kwargs)
 
     def close(self):
         if self.is_local:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -169,11 +169,24 @@ class UDFMeta:
     def threads_per_worker(self) -> Optional[int]:
         """
         int or None : number of threads that a UDF is allowed to use in the `process_*` method.
-                      For numba, pyfftw, OMP, MKL, OpenBLAS, this limit is set automatically;
-                      this property can be used for other cases, like manually creating
-                      thread pools.
+                      For numba, pyfftw, NumPy and SciPy (OMP, MKL, OpenBLAS), this limit is set
+                      automatically; this property can be used for other cases, like manually
+                      creating thread pools or setting limits for unsupported modules.
                       None means no limit is set, and the UDF can use any number of threads
                       it deems necessary (should be limited to system limits, of course).
+
+        Note
+        ----
+
+        .. versionchanged:: 0.8.0
+            Since discovery of loaded libraries can be slow with :mod:`threadpoolctl`
+            (:issue:`1117`), they are cached now. In case an UDF triggers loading of a new
+            library or instance of a library that is supported by :mod:`threadpoolctl`,
+            it will only be discovered in the first run on a :class:`~libertem.api.Context`.
+            The threading settings for such other libraries or instances can therefore depend on the
+            execution order. In such cases the thread count for affected libraries should be
+            set in the UDF based on :code:`threads_per_worker`. NumPy and SciPy should not be
+            affected since they are loaded before the first discovery.
 
         See also: :func:`libertem.utils.threading.set_num_threads`
 

--- a/src/libertem/utils/threading.py
+++ b/src/libertem/utils/threading.py
@@ -5,7 +5,9 @@ import warnings
 
 # NOTE: most imports are performed locally in the functions, to
 # make sure these functions are usable as early as possible in the
-# start-up of libertem (i.e. before numpy/numba/... are imported)
+# start-up of libertem (i.e. before numpy/numba/... are imported).
+# In particular, that makes sure the environment variables can be set
+# with set_num_threads_env() before the libraries are loaded.
 
 
 log = logging.getLogger(__name__)
@@ -70,11 +72,59 @@ def set_numba_threads(n):
         numba.set_num_threads(numba_threads)
 
 
+class ThreadpoolWrapper:
+    def __init__(self, repeats=2):
+        # FIXME switch to released version as soon as ThreadpoolController is available
+        from . import threadpoolctl
+        self._info = threadpoolctl.threadpool_info()
+        self._controller = threadpoolctl.ThreadpoolController()
+        self._stable = 0
+        self.repeats = repeats
+
+    def check_update(self):
+        # FIXME switch to released version as soon as ThreadpoolController is available
+        from . import threadpoolctl
+        new_info = threadpoolctl.threadpool_info()
+        if new_info != self._info:
+            self._stable = 0
+            self._controller = threadpoolctl.ThreadpoolController()
+            self._info = new_info
+        else:
+            self._stable += 1
+
+    # Currently not used due to executor overhead
+    # def reset(self):
+    #     self ._stable = 0
+
+    def __call__(self, limits):
+        if self._stable < self.repeats:
+            self.check_update()
+        return self._controller.limit(limits=limits)
+
+
+# Make sure we don't load threadpoolctl when importing,
+# just to be sure no C library gets loaded!
+__threadpool_wrapper = None
+
+
+# Currently not used due to executor overhead
+# def reset_module_cache():
+#     if __threadpool_wrapper is not None:
+#         __threadpool_wrapper.reset()
+
+
 @contextmanager
 def set_num_threads(n):
-    import threadpoolctl
-    with threadpoolctl.threadpool_limits(n), set_fftw_threads(n),\
-            set_torch_threads(n), set_numba_threads(n):
+    # Make sure modules that use BLAS are loaded
+    import scipy  # noqa: F401
+    import numpy as np  # noqa: F401
+    global __threadpool_wrapper
+    if __threadpool_wrapper is None:
+        __threadpool_wrapper = ThreadpoolWrapper()
+    # We use __threadpool_wrapper last so that it can cover
+    # libraries that the other ones load
+    with set_fftw_threads(n), set_torch_threads(n),\
+            set_numba_threads(n), __threadpool_wrapper(n):
         yield
 
 

--- a/src/libertem/utils/threadpoolctl.py
+++ b/src/libertem/utils/threadpoolctl.py
@@ -1,0 +1,901 @@
+"""threadpoolctl
+This module provides utilities to introspect native libraries that relies on
+thread pools (notably BLAS and OpenMP implementations) and dynamically set the
+maximal number of threads they can use.
+"""
+# License: BSD 3-Clause
+
+# This is a temporary copy of
+# https://github.com/joblib/threadpoolctl/blob/master/threadpoolctl.py from
+# 2021-09-30 to mitigate https://github.com/LiberTEM/LiberTEM/issues/1117 in
+# LiberTEM until a version of threadpoolctl with ThreadpoolController is
+# released, likely 2.3.0.
+
+# FIXME delete as soon as released upstream!
+
+# The code to introspect dynamically loaded libraries on POSIX systems is
+# adapted from code by Intel developper @anton-malakhov available at
+# https://github.com/IntelPython/smp (Copyright (c) 2017, Intel Corporation)
+# and also published under the BSD 3-Clause license
+import os
+import re
+import sys
+import ctypes
+import textwrap
+import warnings
+from ctypes.util import find_library
+from abc import ABC, abstractmethod
+from functools import lru_cache
+
+__version__ = "2.3.0.dev0"
+__all__ = ["threadpool_limits", "threadpool_info", "ThreadpoolController"]
+
+
+# One can get runtime errors or even segfaults due to multiple OpenMP libraries
+# loaded simultaneously which can happen easily in Python when importing and
+# using compiled extensions built with different compilers and therefore
+# different OpenMP runtimes in the same program. In particular libiomp (used by
+# Intel ICC) and libomp used by clang/llvm tend to crash. This can happen for
+# instance when calling BLAS inside a prange. Setting the following environment
+# variable allows multiple OpenMP libraries to be loaded. It should not degrade
+# performances since we manually take care of potential over-subscription
+# performance issues, in sections of the code where nested OpenMP loops can
+# happen, by dynamically reconfiguring the inner OpenMP runtime to temporarily
+# disable it while under the scope of the outer OpenMP parallel section.
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
+
+# Structure to cast the info on dynamically loaded library. See
+# https://linux.die.net/man/3/dl_iterate_phdr for more details.
+_SYSTEM_UINT = ctypes.c_uint64 if sys.maxsize > 2 ** 32 else ctypes.c_uint32
+_SYSTEM_UINT_HALF = ctypes.c_uint32 if sys.maxsize > 2 ** 32 else ctypes.c_uint16
+
+
+class _dl_phdr_info(ctypes.Structure):
+    _fields_ = [
+        ("dlpi_addr", _SYSTEM_UINT),  # Base address of object
+        ("dlpi_name", ctypes.c_char_p),  # path to the library
+        ("dlpi_phdr", ctypes.c_void_p),  # pointer on dlpi_headers
+        ("dlpi_phnum", _SYSTEM_UINT_HALF),  # number of elements in dlpi_phdr
+    ]
+
+
+# The RTLD_NOLOAD flag for loading shared libraries is not defined on Windows.
+try:
+    _RTLD_NOLOAD = os.RTLD_NOLOAD
+except AttributeError:
+    _RTLD_NOLOAD = ctypes.DEFAULT_MODE
+
+
+# List of the supported libraries. The items are indexed by the name of the
+# class to instanciate to create the library controller objects. The items hold
+# the possible prefixes of loaded shared objects, the name of the internal_api
+# to call and the name of the user_api.
+_SUPPORTED_LIBRARIES = {
+    "OpenMPController": {
+        "user_api": "openmp",
+        "internal_api": "openmp",
+        "filename_prefixes": ("libiomp", "libgomp", "libomp", "vcomp"),
+    },
+    "OpenBLASController": {
+        "user_api": "blas",
+        "internal_api": "openblas",
+        "filename_prefixes": ("libopenblas",),
+    },
+    "MKLController": {
+        "user_api": "blas",
+        "internal_api": "mkl",
+        "filename_prefixes": ("libmkl_rt", "mkl_rt"),
+    },
+    "BLISController": {
+        "user_api": "blas",
+        "internal_api": "blis",
+        "filename_prefixes": ("libblis",),
+    },
+}
+
+# Helpers for the doc and test names
+_ALL_USER_APIS = list({lib["user_api"] for lib in _SUPPORTED_LIBRARIES.values()})
+_ALL_INTERNAL_APIS = [lib["internal_api"] for lib in _SUPPORTED_LIBRARIES.values()]
+_ALL_PREFIXES = [
+    prefix
+    for lib in _SUPPORTED_LIBRARIES.values()
+    for prefix in lib["filename_prefixes"]
+]
+_ALL_BLAS_LIBRARIES = [
+    lib["internal_api"]
+    for lib in _SUPPORTED_LIBRARIES.values()
+    if lib["user_api"] == "blas"
+]
+_ALL_OPENMP_LIBRARIES = list(
+    _SUPPORTED_LIBRARIES["OpenMPController"]["filename_prefixes"]
+)
+
+
+def _format_docstring(*args, **kwargs):
+    def decorator(o):
+        if o.__doc__ is not None:
+            o.__doc__ = o.__doc__.format(*args, **kwargs)
+        return o
+
+    return decorator
+
+
+@lru_cache(maxsize=10000)
+def _realpath(filepath):
+    """Small caching wrapper around os.path.realpath to limit system calls"""
+    return os.path.realpath(filepath)
+
+
+@_format_docstring(USER_APIS=list(_ALL_USER_APIS), INTERNAL_APIS=_ALL_INTERNAL_APIS)
+def threadpool_info():
+    """Return the maximal number of threads for each detected library.
+    Return a list with all the supported libraries that have been found. Each
+    library is represented by a dict with the following information:
+      - "user_api" : user API. Possible values are {USER_APIS}.
+      - "internal_api": internal API. Possible values are {INTERNAL_APIS}.
+      - "prefix" : filename prefix of the specific implementation.
+      - "filepath": path to the loaded library.
+      - "version": version of the library (if available).
+      - "num_threads": the current thread limit.
+    In addition, each library may contain internal_api specific entries.
+    """
+    return ThreadpoolController().info()
+
+
+@_format_docstring(
+    USER_APIS=", ".join(f'"{api}"' for api in _ALL_USER_APIS),
+    BLAS_LIBS=", ".join(_ALL_BLAS_LIBRARIES),
+    OPENMP_LIBS=", ".join(_ALL_OPENMP_LIBRARIES),
+)
+def threadpool_limits(limits=None, user_api=None):
+    """Change the maximal number of threads that can be used in thread pools.
+    This function returns an object that can be used either as a callable (the
+    construction of this object limits the number of threads) or as a context manager,
+    in a `with` block to automatically restore the original state of the controlled
+    libraries when exiting the block.
+    Set the maximal number of threads that can be used in thread pools used in
+    the supported libraries to `limit`. This function works for libraries that
+    are already loaded in the interpreter and can be changed dynamically.
+    Parameters
+    ----------
+    limits : int, dict or None (default=None)
+        The maximal number of threads that can be used in thread pools
+        - If int, sets the maximum number of threads to `limits` for each
+          library selected by `user_api`.
+        - If it is a dictionary `{{key: max_threads}}`, this function sets a
+          custom maximum number of threads for each `key` which can be either a
+          `user_api` or a `prefix` for a specific library.
+        - If None, this function does not do anything.
+    user_api : {USER_APIS} or None (default=None)
+        APIs of libraries to limit. Used only if `limits` is an int.
+        - If "blas", it will only limit BLAS supported libraries ({BLAS_LIBS}).
+        - If "openmp", it will only limit OpenMP supported libraries
+          ({OPENMP_LIBS}). Note that it can affect the number of threads used
+          by the BLAS libraries if they rely on OpenMP.
+        - If None, this function will apply to all supported libraries.
+    """
+    return ThreadpoolController().limit(limits=limits, user_api=user_api)
+
+
+class _threadpool_limits:
+    """The guts of ThreadpoolController.limit
+    Refer to the docstring of ThreadpoolController.limit for more details.
+    It will only act on the library controllers held by the provided `controller`.
+    """
+
+    def __init__(self, controller, *, limits=None, user_api=None):
+        self._limits, self._user_api, self._prefixes = self._check_params(
+            limits, user_api
+        )
+        self._controller = controller
+        self._original_info = self._controller.info()
+        self._set_threadpool_limits()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.restore_original_limits()
+
+    def restore_original_limits(self):
+        """Set the limits back to their original values"""
+        for lib_controller, original_info in zip(
+            self._controller.lib_controllers, self._original_info
+        ):
+            lib_controller.set_num_threads(original_info["num_threads"])
+
+    # Alias of `restore_original_limits` for backward compatibility
+    unregister = restore_original_limits
+
+    def get_original_num_threads(self):
+        """Original num_threads from before calling threadpool_limits
+        Return a dict `{user_api: num_threads}`.
+        """
+        num_threads = {}
+        warning_apis = []
+
+        for user_api in self._user_api:
+            limits = [
+                lib_info["num_threads"]
+                for lib_info in self._original_info
+                if lib_info["user_api"] == user_api
+            ]
+            limits = set(limits)
+            n_limits = len(limits)
+
+            if n_limits == 1:
+                limit = limits.pop()
+            elif n_limits == 0:
+                limit = None
+            else:
+                limit = min(limits)
+                warning_apis.append(user_api)
+
+            num_threads[user_api] = limit
+
+        if warning_apis:
+            warnings.warn(
+                "Multiple value possible for following user apis: "
+                + ", ".join(warning_apis)
+                + ". Returning the minimum."
+            )
+
+        return num_threads
+
+    def _check_params(self, limits, user_api):
+        """Suitable values for the _limits, _user_api and _prefixes attributes"""
+        if limits is None or isinstance(limits, int):
+            if user_api is None:
+                user_api = _ALL_USER_APIS
+            elif user_api in _ALL_USER_APIS:
+                user_api = [user_api]
+            else:
+                raise ValueError(
+                    f"user_api must be either in {_ALL_USER_APIS} or None. Got "
+                    f"{user_api} instead."
+                )
+
+            if limits is not None:
+                limits = {api: limits for api in user_api}
+            prefixes = []
+        else:
+            if isinstance(limits, list):
+                # This should be a list of dicts of library info, for
+                # compatibility with the result from threadpool_info.
+                limits = {
+                    lib_info["prefix"]: lib_info["num_threads"] for lib_info in limits
+                }
+            elif isinstance(limits, ThreadpoolController):
+                # To set the limits from the library controllers of a
+                # ThreadpoolController object.
+                limits = {
+                    lib_controller.prefix: lib_controller.num_threads
+                    for lib_controller in limits.lib_controllers
+                }
+
+            if not isinstance(limits, dict):
+                raise TypeError(
+                    "limits must either be an int, a list or a "
+                    f"dict. Got {type(limits)} instead"
+                )
+
+            # With a dictionary, can set both specific limit for given
+            # libraries and global limit for user_api. Fetch each separately.
+            prefixes = [prefix for prefix in limits if prefix in _ALL_PREFIXES]
+            user_api = [api for api in limits if api in _ALL_USER_APIS]
+
+        return limits, user_api, prefixes
+
+    def _set_threadpool_limits(self):
+        """Change the maximal number of threads in selected thread pools.
+        Return a list with all the supported libraries that have been found
+        matching `self._prefixes` and `self._user_api`.
+        """
+        if self._limits is None:
+            return None
+
+        for lib_controller in self._controller.lib_controllers:
+            # self._limits is a dict {key: num_threads} where key is either
+            # a prefix or a user_api. If a library matches both, the limit
+            # corresponding to the prefix is chosen.
+            if lib_controller.prefix in self._limits:
+                num_threads = self._limits[lib_controller.prefix]
+            elif lib_controller.user_api in self._limits:
+                num_threads = self._limits[lib_controller.user_api]
+            else:
+                continue
+
+            if num_threads is not None:
+                lib_controller.set_num_threads(num_threads)
+
+
+@_format_docstring(
+    PREFIXES=", ".join(f'"{prefix}"' for prefix in _ALL_PREFIXES),
+    USER_APIS=", ".join(f'"{api}"' for api in _ALL_USER_APIS),
+    BLAS_LIBS=", ".join(_ALL_BLAS_LIBRARIES),
+    OPENMP_LIBS=", ".join(_ALL_OPENMP_LIBRARIES),
+)
+class ThreadpoolController:
+    """Collection of LibController objects for all loaded supported libraries
+    Attributes
+    ----------
+    lib_controllers : list of `LibController` objects
+        The list of library controllers of all loaded supported libraries.
+    """
+
+    # Cache for libc under POSIX and a few system libraries under Windows.
+    # We use a class level cache instead of an instance level cache because
+    # it's very unlikely that a shared library will be unloaded and reloaded
+    # during the lifetime of a program.
+    _system_libraries = dict()
+
+    def __init__(self):
+        self.lib_controllers = []
+        self._load_libraries()
+        self._warn_if_incompatible_openmp()
+
+    @classmethod
+    def _from_controllers(cls, lib_controllers):
+        new_controller = cls.__new__(cls)
+        new_controller.lib_controllers = lib_controllers
+        return new_controller
+
+    def info(self):
+        """Return lib_controllers info as a list of dicts"""
+        return [lib_controller.info() for lib_controller in self.lib_controllers]
+
+    def select(self, **kwargs):
+        """Return a ThreadpoolController containing a subset of its current
+        library controllers
+        It will select all libraries matching at least one pair (key, value) from kwargs
+        where key is an entry of the library info dict (like "user_api", "internal_api",
+        "prefix", ...) and value is the value or a list of acceptable values for that
+        entry.
+        For instance, `ThreadpoolController().select(internal_api=["blis", "openblas"])`
+        will select all library controllers whose internal_api is either "blis" or
+        "openblas".
+        """
+        for key, vals in kwargs.items():
+            kwargs[key] = [vals] if not isinstance(vals, list) else vals
+
+        lib_controllers = [
+            lib_controller
+            for lib_controller in self.lib_controllers
+            if any(
+                getattr(lib_controller, key, None) in vals
+                for key, vals in kwargs.items()
+            )
+        ]
+
+        return ThreadpoolController._from_controllers(lib_controllers)
+
+    @_format_docstring(
+        USER_APIS=", ".join(f'"{api}"' for api in _ALL_USER_APIS),
+        BLAS_LIBS=", ".join(_ALL_BLAS_LIBRARIES),
+        OPENMP_LIBS=", ".join(_ALL_OPENMP_LIBRARIES),
+    )
+    def limit(self, *, limits=None, user_api=None):
+        """Change the maximal number of threads that can be used in thread pools.
+        This function returns an object that can be used either as a callable (the
+        construction of this object limits the number of threads) or as a context
+        manager, in a `with` block to automatically restore the original state of the
+        controlled libraries when exiting the block.
+        Set the maximal number of threads that can be used in thread pools used in
+        the supported libraries to `limits`. This function works for libraries that
+        are already loaded in the interpreter and can be changed dynamically.
+        Parameters
+        ----------
+        limits : int, dict or None (default=None)
+            The maximal number of threads that can be used in thread pools
+            - If int, sets the maximum number of threads to `limits` for each
+              library selected by `user_api`.
+            - If it is a dictionary `{{key: max_threads}}`, this function sets a
+              custom maximum number of threads for each `key` which can be either a
+              `user_api` or a `prefix` for a specific library.
+            - If None, this function does not do anything.
+        user_api : {USER_APIS} or None (default=None)
+            APIs of libraries to limit. Used only if `limits` is an int.
+            - If "blas", it will only limit BLAS supported libraries ({BLAS_LIBS}).
+            - If "openmp", it will only limit OpenMP supported libraries
+              ({OPENMP_LIBS}). Note that it can affect the number of threads used
+              by the BLAS libraries if they rely on OpenMP.
+            - If None, this function will apply to all supported libraries.
+        """
+        return _threadpool_limits(self, limits=limits, user_api=user_api)
+
+    def __len__(self):
+        return len(self.lib_controllers)
+
+    def _load_libraries(self):
+        """Loop through loaded shared libraries and store the supported ones"""
+        if sys.platform == "darwin":
+            self._find_libraries_with_dyld()
+        elif sys.platform == "win32":
+            self._find_libraries_with_enum_process_module_ex()
+        else:
+            self._find_libraries_with_dl_iterate_phdr()
+
+    def _find_libraries_with_dl_iterate_phdr(self):
+        """Loop through loaded libraries and return binders on supported ones
+        This function is expected to work on POSIX system only.
+        This code is adapted from code by Intel developper @anton-malakhov
+        available at https://github.com/IntelPython/smp
+        Copyright (c) 2017, Intel Corporation published under the BSD 3-Clause
+        license
+        """
+        libc = self._get_libc()
+        if not hasattr(libc, "dl_iterate_phdr"):  # pragma: no cover
+            return []
+
+        # Callback function for `dl_iterate_phdr` which is called for every
+        # library loaded in the current process until it returns 1.
+        def match_library_callback(info, size, data):
+            # Get the path of the current library
+            filepath = info.contents.dlpi_name
+            if filepath:
+                filepath = filepath.decode("utf-8")
+
+                # Store the library controller if it is supported and selected
+                self._make_controller_from_path(filepath)
+            return 0
+
+        c_func_signature = ctypes.CFUNCTYPE(
+            ctypes.c_int,  # Return type
+            ctypes.POINTER(_dl_phdr_info),
+            ctypes.c_size_t,
+            ctypes.c_char_p,
+        )
+        c_match_library_callback = c_func_signature(match_library_callback)
+
+        data = ctypes.c_char_p(b"")
+        libc.dl_iterate_phdr(c_match_library_callback, data)
+
+    def _find_libraries_with_dyld(self):
+        """Loop through loaded libraries and return binders on supported ones
+        This function is expected to work on OSX system only
+        """
+        libc = self._get_libc()
+        if not hasattr(libc, "_dyld_image_count"):  # pragma: no cover
+            return []
+
+        n_dyld = libc._dyld_image_count()
+        libc._dyld_get_image_name.restype = ctypes.c_char_p
+
+        for i in range(n_dyld):
+            filepath = ctypes.string_at(libc._dyld_get_image_name(i))
+            filepath = filepath.decode("utf-8")
+
+            # Store the library controller if it is supported and selected
+            self._make_controller_from_path(filepath)
+
+    def _find_libraries_with_enum_process_module_ex(self):
+        """Loop through loaded libraries and return binders on supported ones
+        This function is expected to work on windows system only.
+        This code is adapted from code by Philipp Hagemeister @phihag available
+        at https://stackoverflow.com/questions/17474574
+        """
+        from ctypes.wintypes import DWORD, HMODULE, MAX_PATH
+
+        PROCESS_QUERY_INFORMATION = 0x0400
+        PROCESS_VM_READ = 0x0010
+
+        LIST_LIBRARIES_ALL = 0x03
+
+        ps_api = self._get_windll("Psapi")
+        kernel_32 = self._get_windll("kernel32")
+
+        h_process = kernel_32.OpenProcess(
+            PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, False, os.getpid()
+        )
+        if not h_process:  # pragma: no cover
+            raise OSError(f"Could not open PID {os.getpid()}")
+
+        try:
+            buf_count = 256
+            needed = DWORD()
+            # Grow the buffer until it becomes large enough to hold all the
+            # module headers
+            while True:
+                buf = (HMODULE * buf_count)()
+                buf_size = ctypes.sizeof(buf)
+                if not ps_api.EnumProcessModulesEx(
+                    h_process,
+                    ctypes.byref(buf),
+                    buf_size,
+                    ctypes.byref(needed),
+                    LIST_LIBRARIES_ALL,
+                ):
+                    raise OSError("EnumProcessModulesEx failed")
+                if buf_size >= needed.value:
+                    break
+                buf_count = needed.value // (buf_size // buf_count)
+
+            count = needed.value // (buf_size // buf_count)
+            h_modules = map(HMODULE, buf[:count])
+
+            # Loop through all the module headers and get the library path
+            buf = ctypes.create_unicode_buffer(MAX_PATH)
+            n_size = DWORD()
+            for h_module in h_modules:
+
+                # Get the path of the current module
+                if not ps_api.GetModuleFileNameExW(
+                    h_process, h_module, ctypes.byref(buf), ctypes.byref(n_size)
+                ):
+                    raise OSError("GetModuleFileNameEx failed")
+                filepath = buf.value
+
+                # Store the library controller if it is supported and selected
+                self._make_controller_from_path(filepath)
+        finally:
+            kernel_32.CloseHandle(h_process)
+
+    def _make_controller_from_path(self, filepath):
+        """Store a library controller if it is supported and selected"""
+        # Required to resolve symlinks
+        filepath = _realpath(filepath)
+        # `lower` required to take account of OpenMP dll case on Windows
+        # (vcomp, VCOMP, Vcomp, ...)
+        filename = os.path.basename(filepath).lower()
+
+        # Loop through supported libraries to find if this filename corresponds
+        # to a supported one.
+        for controller_class, candidate_lib in _SUPPORTED_LIBRARIES.items():
+            # check if filename matches a supported prefix
+            prefix = self._check_prefix(filename, candidate_lib["filename_prefixes"])
+
+            # filename does not match any of the prefixes of the candidate
+            # library. move to next library.
+            if prefix is None:
+                continue
+
+            # filename matches a prefix. Create and store the library
+            # controller.
+            user_api = candidate_lib["user_api"]
+            internal_api = candidate_lib["internal_api"]
+
+            lib_controller_class = globals()[controller_class]
+            lib_controller = lib_controller_class(
+                filepath=filepath,
+                prefix=prefix,
+                user_api=user_api,
+                internal_api=internal_api,
+            )
+            self.lib_controllers.append(lib_controller)
+
+    def _check_prefix(self, library_basename, filename_prefixes):
+        """Return the prefix library_basename starts with
+        Return None if none matches.
+        """
+        for prefix in filename_prefixes:
+            if library_basename.startswith(prefix):
+                return prefix
+        return None
+
+    def _warn_if_incompatible_openmp(self):
+        """Raise a warning if llvm-OpenMP and intel-OpenMP are both loaded"""
+        if sys.platform != "linux":
+            # Only raise the warning on linux
+            return
+
+        prefixes = [lib_controller.prefix for lib_controller in self.lib_controllers]
+        msg = textwrap.dedent(
+            """
+            Found Intel OpenMP ('libiomp') and LLVM OpenMP ('libomp') loaded at
+            the same time. Both libraries are known to be incompatible and this
+            can cause random crashes or deadlocks on Linux when loaded in the
+            same Python program.
+            Using threadpoolctl may cause crashes or deadlocks. For more
+            information and possible workarounds, please see
+                https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md
+            """
+        )
+        if "libomp" in prefixes and "libiomp" in prefixes:
+            warnings.warn(msg, RuntimeWarning)
+
+    @classmethod
+    def _get_libc(cls):
+        """Load the lib-C for unix systems."""
+        libc = cls._system_libraries.get("libc")
+        if libc is None:
+            libc_name = find_library("c")
+            if libc_name is None:  # pragma: no cover
+                return None
+            libc = ctypes.CDLL(libc_name, mode=_RTLD_NOLOAD)
+            cls._system_libraries["libc"] = libc
+        return libc
+
+    @classmethod
+    def _get_windll(cls, dll_name):
+        """Load a windows DLL"""
+        dll = cls._system_libraries.get(dll_name)
+        if dll is None:
+            dll = ctypes.WinDLL(f"{dll_name}.dll")
+            cls._system_libraries[dll_name] = dll
+        return dll
+
+
+@_format_docstring(
+    USER_APIS=", ".join(f'"{api}"' for api in _ALL_USER_APIS),
+    INTERNAL_APIS=", ".join(f'"{api}"' for api in _ALL_INTERNAL_APIS),
+)
+class LibController(ABC):
+    """Abstract base class for the individual library controllers
+    A library controller is represented by the following information:
+      - "user_api" : user API. Possible values are {USER_APIS}.
+      - "internal_api" : internal API. Possible values are {INTERNAL_APIS}.
+      - "prefix" : prefix of the shared library's name.
+      - "filepath" : path to the loaded library.
+      - "version" : version of the library (if available).
+      - "num_threads" : the current thread limit.
+    In addition, each library controller may contain internal_api specific
+    entries.
+    """
+
+    def __init__(self, *, filepath=None, prefix=None, user_api=None, internal_api=None):
+        self.user_api = user_api
+        self.internal_api = internal_api
+        self.prefix = prefix
+        self.filepath = filepath
+        self._dynlib = ctypes.CDLL(filepath, mode=_RTLD_NOLOAD)
+        self.version = self.get_version()
+
+    def info(self):
+        """Return relevant info wrapped in a dict"""
+        all_attrs = dict(vars(self), **{"num_threads": self.num_threads})
+        return {k: v for k, v in all_attrs.items() if not k.startswith("_")}
+
+    @property
+    def num_threads(self):
+        return self.get_num_threads()
+
+    @abstractmethod
+    def get_num_threads(self):
+        """Return the maximum number of threads available to use"""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def set_num_threads(self, num_threads):
+        """Set the maximum number of threads to use"""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def get_version(self):
+        """Return the version of the shared library"""
+        pass  # pragma: no cover
+
+
+class OpenBLASController(LibController):
+    """Controller class for OpenBLAS"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.threading_layer = self._get_threading_layer()
+        self.architecture = self._get_architecture()
+
+    def get_num_threads(self):
+        get_func = getattr(
+            self._dynlib,
+            "openblas_get_num_threads",
+            # Symbols differ when built for 64bit integers in Fortran
+            getattr(self._dynlib, "openblas_get_num_threads64_", lambda: None),
+        )
+
+        return get_func()
+
+    def set_num_threads(self, num_threads):
+        set_func = getattr(
+            self._dynlib,
+            "openblas_set_num_threads",
+            # Symbols differ when built for 64bit integers in Fortran
+            getattr(
+                self._dynlib, "openblas_set_num_threads64_", lambda num_threads: None
+            ),
+        )
+        return set_func(num_threads)
+
+    def get_version(self):
+        # None means OpenBLAS is not loaded or version < 0.3.4, since OpenBLAS
+        # did not expose its version before that.
+        get_config = getattr(
+            self._dynlib,
+            "openblas_get_config",
+            getattr(self._dynlib, "openblas_get_config64_", None),
+        )
+        if get_config is None:
+            return None
+
+        get_config.restype = ctypes.c_char_p
+        config = get_config().split()
+        if config[0] == b"OpenBLAS":
+            return config[1].decode("utf-8")
+        return None
+
+    def _get_threading_layer(self):
+        """Return the threading layer of OpenBLAS"""
+        openblas_get_parallel = getattr(
+            self._dynlib,
+            "openblas_get_parallel",
+            getattr(self._dynlib, "openblas_get_parallel64_", None),
+        )
+        if openblas_get_parallel is None:
+            return "unknown"
+        threading_layer = openblas_get_parallel()
+        if threading_layer == 2:
+            return "openmp"
+        elif threading_layer == 1:
+            return "pthreads"
+        return "disabled"
+
+    def _get_architecture(self):
+        """Return the architecture detected by OpenBLAS"""
+        get_corename = getattr(
+            self._dynlib,
+            "openblas_get_corename",
+            getattr(self._dynlib, "openblas_get_corename64_", None),
+        )
+        if get_corename is None:
+            return None
+
+        get_corename.restype = ctypes.c_char_p
+        return get_corename().decode("utf-8")
+
+
+class BLISController(LibController):
+    """Controller class for BLIS"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.threading_layer = self._get_threading_layer()
+        self.architecture = self._get_architecture()
+
+    def get_num_threads(self):
+        get_func = getattr(self._dynlib, "bli_thread_get_num_threads", lambda: None)
+        num_threads = get_func()
+        # by default BLIS is single-threaded and get_num_threads
+        # returns -1. We map it to 1 for consistency with other libraries.
+        return 1 if num_threads == -1 else num_threads
+
+    def set_num_threads(self, num_threads):
+        set_func = getattr(
+            self._dynlib, "bli_thread_set_num_threads", lambda num_threads: None
+        )
+        return set_func(num_threads)
+
+    def get_version(self):
+        get_version_ = getattr(self._dynlib, "bli_info_get_version_str", None)
+        if get_version_ is None:
+            return None
+
+        get_version_.restype = ctypes.c_char_p
+        return get_version_().decode("utf-8")
+
+    def _get_threading_layer(self):
+        """Return the threading layer of BLIS"""
+        if self._dynlib.bli_info_get_enable_openmp():
+            return "openmp"
+        elif self._dynlib.bli_info_get_enable_pthreads():
+            return "pthreads"
+        return "disabled"
+
+    def _get_architecture(self):
+        """Return the architecture detected by BLIS"""
+        bli_arch_query_id = getattr(self._dynlib, "bli_arch_query_id", None)
+        bli_arch_string = getattr(self._dynlib, "bli_arch_string", None)
+        if bli_arch_query_id is None or bli_arch_string is None:
+            return None
+
+        # the true restype should be BLIS' arch_t (enum) but int should work
+        # for us:
+        bli_arch_query_id.restype = ctypes.c_int
+        bli_arch_string.restype = ctypes.c_char_p
+        return bli_arch_string(bli_arch_query_id()).decode("utf-8")
+
+
+class MKLController(LibController):
+    """Controller class for MKL"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.threading_layer = self._get_threading_layer()
+
+    def get_num_threads(self):
+        get_func = getattr(self._dynlib, "MKL_Get_Max_Threads", lambda: None)
+        return get_func()
+
+    def set_num_threads(self, num_threads):
+        set_func = getattr(
+            self._dynlib, "MKL_Set_Num_Threads", lambda num_threads: None
+        )
+        return set_func(num_threads)
+
+    def get_version(self):
+        if not hasattr(self._dynlib, "MKL_Get_Version_String"):
+            return None
+
+        res = ctypes.create_string_buffer(200)
+        self._dynlib.MKL_Get_Version_String(res, 200)
+
+        version = res.value.decode("utf-8")
+        group = re.search(r"Version ([^ ]+) ", version)
+        if group is not None:
+            version = group.groups()[0]
+        return version.strip()
+
+    def _get_threading_layer(self):
+        """Return the threading layer of MKL"""
+        # The function mkl_set_threading_layer returns the current threading
+        # layer. Calling it with an invalid threading layer allows us to safely
+        # get the threading layer
+        set_threading_layer = getattr(
+            self._dynlib, "MKL_Set_Threading_Layer", lambda layer: -1
+        )
+        layer_map = {
+            0: "intel",
+            1: "sequential",
+            2: "pgi",
+            3: "gnu",
+            4: "tbb",
+            -1: "not specified",
+        }
+        return layer_map[set_threading_layer(-1)]
+
+
+class OpenMPController(LibController):
+    """Controller class for OpenMP"""
+
+    def get_num_threads(self):
+        get_func = getattr(self._dynlib, "omp_get_max_threads", lambda: None)
+        return get_func()
+
+    def set_num_threads(self, num_threads):
+        set_func = getattr(
+            self._dynlib, "omp_set_num_threads", lambda num_threads: None
+        )
+        return set_func(num_threads)
+
+    def get_version(self):
+        # There is no way to get the version number programmatically in OpenMP.
+        return None
+
+
+def _main():
+    """Commandline interface to display thread-pool information and exit."""
+    import argparse
+    import importlib
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(
+        usage="python -m threadpoolctl -i numpy scipy.linalg xgboost",
+        description="Display thread-pool information and exit.",
+    )
+    parser.add_argument(
+        "-i",
+        "--import",
+        dest="modules",
+        nargs="*",
+        default=(),
+        help="Python modules to import before introspecting thread-pools.",
+    )
+    parser.add_argument(
+        "-c",
+        "--command",
+        help="a Python statement to execute before introspecting thread-pools.",
+    )
+
+    options = parser.parse_args(sys.argv[1:])
+    for module in options.modules:
+        try:
+            importlib.import_module(module, package=None)
+        except ImportError:
+            print("WARNING: could not import", module, file=sys.stderr)
+
+    if options.command:
+        exec(options.command)
+
+    print(json.dumps(threadpool_info(), indent=2))
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
Closes #1117

Resetting the module cache on a distributed executor causes
so much overhead that it negates any benefits. For that reason
this change accepts that the threading settings might
depend on UDF execution order under some circumstances.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
