### PR TITLE
Work around memory leak, fixes #894

### DIFF
--- a/docs/source/changelog/bugfix/memleak-fn-caching.rst
+++ b/docs/source/changelog/bugfix/memleak-fn-caching.rst
@@ -1,0 +1,5 @@
+[Bugfix] Fix memory leak
+========================
+
+* Don't submit dynamically generated callables directly to the distributed cluster,
+  as they are cached in an unbounded cache (:issue:`894`, :pr:`1118`).

--- a/docs/source/changelog/bugfix/memleak-fn-caching.rst
+++ b/docs/source/changelog/bugfix/memleak-fn-caching.rst
@@ -2,4 +2,4 @@
 ========================
 
 * Don't submit dynamically generated callables directly to the distributed cluster,
-  as they are cached in an unbounded cache (:issue:`894`, :pr:`1118`).
+  as they are cached in an unbounded cache (:issue:`894`, :pr:`1119`).


### PR DESCRIPTION
The root cause for #894 is (unbounded) caching of functions that are submitted to the dask cluster - we need to make sure we use a consistent function and not directly submit callables that are generated on the fly.

Closes #964, closes #894

## Contributor Checklist:

* [N/A] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
