### PR TITLE
Support both `.seq` and `.seq.seq` as extension for the main SEQ file

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -48,7 +48,9 @@ New features
   later (:pr:`1074`, :issue:`1097`). Please comment on :issue:`1097` if local/manual use
   would be beneficial for you so that it is prioritized accordingly.
 * SEQ dataset: Added support for loading excluded pixels from XML (:issue:`805`, :pr:`1077`).
-  See :class:`~libertem.io.dataset.seq.SEQDataSet` for more information.
+  See :class:`~libertem.io.dataset.seq.SEQDataSet` for more information. Also
+  support both :code:`*.seq.seq` and :code:`*.seq` as extension for the main SEQ file
+  to find files with matching base name that contain correction data (:issue:`1120`, :pr:`1121`).
 
 Bugfixes
 --------


### PR DESCRIPTION
to find `.seq.*` with correction data.

Closes #1120

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
