### PR TITLE
Centralized max partition size

### DIFF
--- a/src/libertem/io/dataset/base/__init__.py
+++ b/src/libertem/io/dataset/base/__init__.py
@@ -5,7 +5,7 @@ from .backend import IOBackend
 from .backend_mmap import MMapBackend
 from .backend_buffered import BufferedBackend
 from .backend_direct import DirectBackend
-from .dataset import DataSet, WritableDataSet, MAX_PARTITION_SIZE
+from .dataset import DataSet, WritableDataSet
 from .partition import Partition, BasePartition, WritablePartition
 from .utils import FileTree
 from .fileset import FileSet

--- a/src/libertem/io/dataset/base/dataset.py
+++ b/src/libertem/io/dataset/base/dataset.py
@@ -9,10 +9,10 @@ from libertem.corrections.corrset import CorrectionSet
 from .partition import BasePartition
 
 
-MAX_PARTITION_SIZE = 512*1024*1024
-
-
 class DataSet:
+    # The default partition size in bytes
+    MAX_PARTITION_SIZE = 512*1024*1024
+
     def __init__(self, io_backend=None):
         self._cores = 1
         self._sync_offset = 0
@@ -63,9 +63,17 @@ class DataSet:
 
     def get_num_partitions(self):
         """
-        Returns the number of partitions the dataset should be split into
+        Returns the number of partitions the dataset should be split into.
+
+        The default implementation sizes partition such that they
+        fit into 512MB of float data in memory, regardless of their
+        native dtype. At least :code:`self._cores` partitions
+        are created.
         """
-        raise NotImplementedError()
+        partition_size_float_px = self.MAX_PARTITION_SIZE // 4
+        dataset_size_px = np.prod(self.shape, dtype=np.int64)
+        num = max(self._cores, dataset_size_px // partition_size_float_px)
+        return num
 
     def get_slices(self):
         """

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -237,16 +237,6 @@ class BloDataSet(DataSet):
             "sync_offset": self._sync_offset,
         }
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE (converted float32 data) per partition
-        partition_size_px = MAX_PARTITION_SIZE // 4
-        total_size_px = np.prod(self.shape, dtype=np.int64)
-        res = max(self._cores, total_size_px // partition_size_px)
-        return res
-
     def _get_fileset(self):
         return BloFileSet([
             File(

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -273,14 +273,6 @@ class DMDataSet(DataSet):
         except OSError as e:
             raise DataSetException("invalid dataset: %s" % e)
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE per partition
-        res = max(self._cores, self._filesize // MAX_PARTITION_SIZE)
-        return res
-
     def get_partitions(self):
         for part_slice, start, stop in self.get_slices():
             yield BasePartition(

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -263,14 +263,6 @@ class EMPADDataSet(DataSet):
             "sync_offset": self._sync_offset,
         }
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE per partition
-        res = max(self._cores, self._filesize // (MAX_PARTITION_SIZE))
-        return res
-
     def get_partitions(self):
         fileset = self._get_fileset()
         for part_slice, start, stop in self.get_slices():

--- a/src/libertem/io/dataset/frms6.py
+++ b/src/libertem/io/dataset/frms6.py
@@ -636,16 +636,6 @@ class FRMS6DataSet(DataSet):
     def raw_dtype(self):
         return self._meta.raw_dtype
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE (converted float32 data) per partition
-        partition_size_px = MAX_PARTITION_SIZE // 4
-        total_size_px = np.prod(self.shape, dtype=np.int64)
-        res = max(self._cores, total_size_px // partition_size_px)
-        return res
-
     def _get_fileset(self, headers=None):
         files = []
         start_idx = 0

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -1011,16 +1011,6 @@ class K2ISDataSet(DataSet):
         ]
         return K2FileSet(files=files)
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE (converted float32 data) per partition
-        partition_size_px = MAX_PARTITION_SIZE // 4
-        total_size_px = np.prod(self.shape, dtype=np.int64)
-        res = max(self._cores, total_size_px // partition_size_px)
-        return res
-
     def get_partitions(self):
         io_backend = self.get_io_backend()
         fileset = self._get_fileset()

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -701,16 +701,6 @@ class MIBDataSet(DataSet):
             for f in self._files_sorted
         ], dtype=dtype, kind=kind, bit_depth=bit_depth, frame_header_bytes=header_size)
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE (converted float32 data) per partition
-        partition_size_px = MAX_PARTITION_SIZE // 4
-        total_size_px = np.prod(self.shape, dtype=np.int64)
-        res = max(self._cores, total_size_px // partition_size_px)
-        return res
-
     def get_partitions(self):
         first_file = self._files_sorted[0]
         fileset = self._get_fileset()

--- a/src/libertem/io/dataset/mrc.py
+++ b/src/libertem/io/dataset/mrc.py
@@ -216,14 +216,6 @@ class MRCDataSet(DataSet):
             "sync_offset": self._sync_offset,
         }
 
-    def _get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE per partition
-        res = max(self._cores, self._filesize // (MAX_PARTITION_SIZE))
-        return res
-
     def _get_fileset(self):
         assert self._image_count is not None
         return FileSet([
@@ -247,7 +239,7 @@ class MRCDataSet(DataSet):
         fileset = self._get_fileset()
         for part_slice, start, stop in MRCPartition.make_slices(
                 shape=self.shape,
-                num_partitions=self._get_num_partitions(),
+                num_partitions=self.get_num_partitions(),
                 sync_offset=self._sync_offset):
             yield MRCPartition(
                 meta=self._meta,

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -225,16 +225,6 @@ class RawFileDataSet(DataSet):
             "sync_offset": self._sync_offset,
         }
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for MAX_PARTITION_SIZE (converted float32 data) per partition
-        partition_size_px = MAX_PARTITION_SIZE // 4
-        total_size_px = np.prod(self.shape, dtype=np.int64)
-        res = max(self._cores, total_size_px // partition_size_px)
-        return res
-
     def get_partitions(self):
         fileset = self._get_fileset()
         for part_slice, start, stop in self.get_slices():

--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -668,13 +668,6 @@ class SEQDataSet(DataSet):
             "sync_offset": self._sync_offset,
         }
 
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        res = max(self._cores, self._filesize // MAX_PARTITION_SIZE)
-        return res
-
     def get_partitions(self):
         fileset = self._get_fileset()
         for part_slice, start, stop in self.get_slices():

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -10,7 +10,7 @@ from libertem.common import Shape, Slice
 from libertem.web.messages import MessageConverter
 from .base import (
     DataSet, FileSet, BasePartition, DataSetException, DataSetMeta,
-    _roi_to_indices, DataTile, MAX_PARTITION_SIZE,
+    _roi_to_indices, DataTile,
 )
 
 log = logging.getLogger(__name__)
@@ -224,14 +224,6 @@ class SERDataSet(DataSet):
             "shape": tuple(self.shape),
             "sync_offset": self._sync_offset,
         }
-
-    def get_num_partitions(self):
-        """
-        returns the number of partitions the dataset should be split into
-        """
-        # let's try to aim for 512MB per partition
-        res = max(self._cores, self._filesize // (MAX_PARTITION_SIZE//8))
-        return res
 
     def _get_fileset(self):
         assert self._num_frames is not None

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -78,6 +78,7 @@ def test_roi(lt_ctx):
     roi = np.zeros(ds.shape.nav, dtype=bool)
     roi[0, 1] = True
 
+    ds.set_num_cores(2)
     parts = ds.get_partitions()
 
     p = next(parts)


### PR DESCRIPTION
Refs #https://github.com/LiberTEM/LiberTEM/issues/382#issuecomment-937680666

1 GB is quite a lot for `process_partition()` on machines with many workers.
512 MB should be a bit friendlier for the worker memory budget.

Furthermore, a central constant allows to adjust the value more easily.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
