### PR TITLE
Fix benchmark code that used old direct_io=True param

### DIFF
--- a/benchmarks/io/utils.py
+++ b/benchmarks/io/utils.py
@@ -1,7 +1,7 @@
 import os
 import platform
 
-from libertem.io.dataset.base import MMapBackend, BufferedBackend
+from libertem.io.dataset.base import MMapBackend, BufferedBackend, DirectBackend
 
 
 def warmup_cache(flist):
@@ -64,5 +64,5 @@ backends_by_name = {
     "mmap": MMapBackend(),
     "mmap_readahead": MMapBackend(enable_readahead_hints=True),
     "buffered": BufferedBackend(),
-    "direct": BufferedBackend(direct_io=True),
+    "direct": DirectBackend(),
 }


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
