### PR TITLE
CI: switch to Mac OS X 10.14 for Python 3.6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,23 +231,26 @@ stages:
           testRunTitle: 'Publish test results for Python $(python.version)'
 
     - job: macos_tests
-      pool:
-        vmImage: 'macOS-latest'
       strategy:
         matrix:
           Python36:
             python.version: '3.6'
             TOXENV: 'py36'
-            vmImage: 'macos-10.14'
+            imageName: 'macos-10.14'
           Python37:
             python.version: '3.7'
             TOXENV: 'py37'
+            imageName: 'macos-latest'
           Python38:
             python.version: '3.8'
             TOXENV: 'py38'
+            imageName: 'macos-latest'
           Python39:
             python.version: '3.9'
             TOXENV: 'py39'
+            imageName: 'macos-latest'
+      pool:
+        vmImage: '$(imageName)'
       variables:
         TOXENV: '$(TOXENV)'
       steps:


### PR DESCRIPTION
The Mac OS X 11 images don't contain EOL Python versions anymore, like
3.6, and macos-latest will soon be switched to Mac OS X 11.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
