### PR TITLE
Refactor UDF parameter handling

### DIFF
--- a/docs/source/changelog/misc/large-parameters.rst
+++ b/docs/source/changelog/misc/large-parameters.rst
@@ -1,0 +1,6 @@
+Improve performance with large parameters
+=========================================
+
+* Previously, parameters were baked into the :code:`UDFTask` objects, so they were
+  transferred multiple times for a single UDF run. To allow for larger parameters,
+  they are now handled separately from the function that is run (:pr:`1143`).

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,8 @@ setup(
         'autopep8',
         'empyre>=0.3.0',
         'defusedxml',
+        'async_generator',  # backwards-compat. for contextlib.asynccontextmanager
+        'typing-extensions',  # backwards-compatibility for newer typing constructs
     ],
     extras_require={
         'torch': 'torch',

--- a/src/libertem/executor/base.py
+++ b/src/libertem/executor/base.py
@@ -56,7 +56,7 @@ class Environment:
 
 
 class TaskProtocol(Protocol):
-    def __call__(self, env: Environment, params: Any, const: Any):
+    def __call__(self, env: Environment, params: Any):
         pass
 
 
@@ -89,11 +89,10 @@ class JobExecutor:
         self,
         tasks: Iterable[TaskProtocol],
         params_handle: Any,
-        const_handle: Any,
         cancel_id: Any,
     ):
         """
-        Run the tasks with the given parameters and constant parameters.
+        Run the tasks with the given parameters
 
         Parameters
         ----------
@@ -101,8 +100,6 @@ class JobExecutor:
             The tasks to be run
         params_handle : [type]
             A handle for the task parameters, as returned from :meth:`JobExecutor.scatter`
-        const_handle : [type]
-            A handle for the constant task parameters, as returned from :meth:`JobExecutor.scatter`
         cancel_id
             An identifier which can be used for cancelling all tasks together. The
             same identifier should be passed to :meth:`AsyncJobExecutor.cancel`
@@ -232,7 +229,7 @@ class JobExecutor:
 
 
 class AsyncJobExecutor:
-    async def run_tasks(self, tasks, params_handle, const_handle, cancel_id):
+    async def run_tasks(self, tasks, params_handle, cancel_id):
         """
         Run a number of Tasks, yielding (result, task) tuples
         """
@@ -345,11 +342,11 @@ class AsyncAdapter(AsyncJobExecutor):
             )
             await sync_to_async(exit_fn, self._pool)
 
-    async def run_tasks(self, tasks, params_handle, const_handle, cancel_id):
+    async def run_tasks(self, tasks, params_handle, cancel_id):
         """
         run a number of Tasks
         """
-        gen = self._wrapped.run_tasks(tasks, params_handle, const_handle, cancel_id)
+        gen = self._wrapped.run_tasks(tasks, params_handle, cancel_id)
         agen = async_generator_eager(gen, self._pool)
         async for i in agen:
             yield i

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -3,13 +3,14 @@ from copy import deepcopy
 import functools
 import logging
 import signal
+from typing import Iterable, Any
 
 from dask import distributed as dd
 
 from libertem.utils.threading import set_num_threads_env
 
 from .base import (
-    JobExecutor, JobCancelledError, sync_to_async, AsyncAdapter,
+    JobExecutor, JobCancelledError, TaskProtocol, sync_to_async, AsyncAdapter,
     Environment,
 )
 from .scheduler import Worker, WorkerSet
@@ -257,7 +258,13 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
     def scatter(self, obj):
         yield self.client.scatter(obj, broadcast=True)
 
-    def run_tasks(self, tasks, params_handle, const_handle, cancel_id):
+    def run_tasks(
+        self,
+        tasks: Iterable[TaskProtocol],
+        params_handle: Any,
+        const_handle: Any,
+        cancel_id: Any,
+    ):
         tasks = list(tasks)
         tasks_w_index = list(enumerate(tasks))
 

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -1,3 +1,4 @@
+import contextlib
 from copy import deepcopy
 import functools
 import logging
@@ -8,7 +9,7 @@ from dask import distributed as dd
 from libertem.utils.threading import set_num_threads_env
 
 from .base import (
-    JobExecutor, JobCancelledError, sync_to_async, AsyncAdapter, TaskProxy,
+    JobExecutor, JobCancelledError, sync_to_async, AsyncAdapter,
     Environment,
 )
 from .scheduler import Worker, WorkerSet
@@ -88,33 +89,25 @@ def cluster_spec(cpus, cudas, has_cupy, name='default', num_service=1, options=N
     return workers_spec
 
 
-class DaskTaskProxy(TaskProxy):
-    def __init__(self, task, task_id):
-        super().__init__(task)
-        self.task_id = task_id
-
-    def __call__(self, *args, **kwargs):
-        env = Environment(threads_per_worker=1)
-        task_result = self.task(env=env)
-        return {
-            "task_result": task_result,
-            "task_id": self.task_id,
-        }
-
-    def __repr__(self):
-        return f"<TaskProxy: {self.task!r} (id={self.task_id})>"
-
-
-def _run_task(what):
+def _run_task(task, params, const, task_id):
     """
     Very simple wrapper function. As dask internally caches functions that are
     submitted to the cluster in various ways, we need to make sure to
     consistently use the same function, and not build one on the fly.
 
-    Without this function, DaskTaskProxy->UDFTask->UDF->UDFData ends up in the
+    Without this function, UDFTask->UDF->UDFData ends up in the
     cache, which blows up memory usage over time.
     """
-    return what()
+    env = Environment(threads_per_worker=1)
+    task_result = task(env=env, params=params, const=const)
+    return {
+        "task_result": task_result,
+        "task_id": task_id,
+    }
+
+
+def _simple_run_task(task):
+    return task()
 
 
 class CommonDaskMixin:
@@ -124,7 +117,9 @@ class CommonDaskMixin:
         host = hosts[host_idx]
         return workers.filter(lambda w: w.host == host)
 
-    def _future_for_location(self, task, locations, resources, workers):
+    def _future_for_location(
+        self, task, locations, resources, workers, task_args=None, wrap_fn=_run_task,
+    ):
         """
         Submit tasks and return the resulting futures
 
@@ -140,6 +135,8 @@ class CommonDaskMixin:
             Available workers in the cluster
         """
         submit_kwargs = {}
+        if task_args is None:
+            task_args = {}
         if locations is not None:
             if len(locations) == 0:
                 raise ValueError("no workers found for task")
@@ -149,7 +146,9 @@ class CommonDaskMixin:
             'workers': locations,
             'pure': False,
         })
-        return self.client.submit(_run_task, task, **submit_kwargs)
+        return self.client.submit(
+            wrap_fn, task, *task_args, **submit_kwargs
+        )
 
     def _validate_resources(self, workers, resources):
         # This is set in the constructor of DaskJobExecutor
@@ -180,16 +179,21 @@ class CommonDaskMixin:
 
         return len(workers.filter(has_resources)) > 0
 
-    def _get_future(self, task, workers):
+    def _get_future(self, task, workers, idx, params_handle, const_handle):
         if len(workers) == 0:
             raise RuntimeError("no workers available!")
         return self._future_for_location(
             task,
             task.get_locations() or self._task_idx_to_workers(
-                workers, task.idx
+                workers, idx
             ),
             task.get_resources(),
-            workers
+            workers,
+            task_args=(
+                params_handle,
+                const_handle,
+                idx,
+            )
         )
 
     def get_available_workers(self):
@@ -249,15 +253,16 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         self.lt_resources = lt_resources
         self._futures = {}
 
-    def run_tasks(self, tasks, cancel_id):
+    @contextlib.contextmanager
+    def scatter(self, obj):
+        yield self.client.scatter(obj, broadcast=True)
+
+    def run_tasks(self, tasks, params_handle, const_handle, cancel_id):
         tasks = list(tasks)
-        tasks_wrapped = []
+        tasks_w_index = list(enumerate(tasks))
 
         def _id_to_task(task_id):
             return tasks[task_id]
-
-        for idx, orig_task in enumerate(tasks):
-            tasks_wrapped.append(DaskTaskProxy(orig_task, idx))
 
         workers = self.get_available_workers()
 
@@ -265,10 +270,10 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
         initial = []
 
         for w in range(int(len(workers))):
-            if not tasks_wrapped:
+            if not tasks_w_index:
                 break
-            wrapped_task = tasks_wrapped.pop(0)
-            future = self._get_future(wrapped_task, workers)
+            idx, wrapped_task = tasks_w_index.pop(0)
+            future = self._get_future(wrapped_task, workers, idx, params_handle, const_handle)
             initial.append(future)
             self._futures[cancel_id].append(future)
 
@@ -280,9 +285,11 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
                     raise JobCancelledError()
                 result = result_wrap['task_result']
                 task = _id_to_task(result_wrap['task_id'])
-                if tasks_wrapped:
-                    wrapped_task = tasks_wrapped.pop(0)
-                    future = self._get_future(wrapped_task, workers)
+                if tasks_w_index:
+                    idx, wrapped_task = tasks_w_index.pop(0)
+                    future = self._get_future(
+                        wrapped_task, workers, idx, params_handle, const_handle
+                    )
                     as_completed.add(future)
                     self._futures[cancel_id].append(future)
                 yield result, task
@@ -329,7 +336,10 @@ class DaskJobExecutor(CommonDaskMixin, JobExecutor):
             items = ((lambda: fn(p), p.get_locations(), {})
                      for p in partitions)
         workers = self.get_available_workers()
-        futures = [self._future_for_location(*item, workers) for item in items]
+        futures = [
+            self._future_for_location(*item, workers, wrap_fn=_simple_run_task)
+            for item in items
+        ]
         # TODO: do we need cancellation and all that good stuff?
         for future, result in dd.as_completed(futures, with_results=True, loop=self.client.loop):
             if future.cancelled():

--- a/src/libertem/executor/inline.py
+++ b/src/libertem/executor/inline.py
@@ -33,7 +33,6 @@ class InlineJobExecutor(JobExecutor):
         self,
         tasks: Iterable[TaskProtocol],
         params_handle: Any,
-        const_handle: Any,
         cancel_id: Any,
     ):
         threads = self._inline_threads
@@ -43,7 +42,7 @@ class InlineJobExecutor(JobExecutor):
         for task in tasks:
             if self._debug:
                 cloudpickle.loads(cloudpickle.dumps(task))
-            result = task(env=env, params=params_handle, const=const_handle)
+            result = task(env=env, params=params_handle)
             if self._debug:
                 cloudpickle.loads(cloudpickle.dumps(result))
             yield result, task

--- a/src/libertem/executor/inline.py
+++ b/src/libertem/executor/inline.py
@@ -1,8 +1,9 @@
+from typing import Any, Iterable
 import cloudpickle
 import psutil
 import contextlib
 
-from .base import JobExecutor, Environment
+from .base import JobExecutor, Environment, TaskProtocol
 from .scheduler import Worker, WorkerSet
 from libertem.common.backend import get_use_cuda
 
@@ -28,7 +29,13 @@ class InlineJobExecutor(JobExecutor):
     def scatter(self, obj):
         yield obj
 
-    def run_tasks(self, tasks, params_handle, const_handle, cancel_id):
+    def run_tasks(
+        self,
+        tasks: Iterable[TaskProtocol],
+        params_handle: Any,
+        const_handle: Any,
+        cancel_id: Any,
+    ):
         threads = self._inline_threads
         if threads is None:
             threads = psutil.cpu_count(logical=False)

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Optional
 import logging
 import warnings
 
@@ -452,7 +452,7 @@ class Negotiator:
                 )
 
     def get_scheme(
-            self, udfs, partition, read_dtype: np.dtype, roi: np.ndarray,
+            self, udfs, partition, read_dtype: np.dtype, roi: Optional[np.ndarray],
             corrections: CorrectionSet = None):
         """
         Generate a :class:`TilingScheme` instance that is

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1704,7 +1704,7 @@ class UDFRunner:
         Make per-worker constant data (constant for the whole UDF run, as
         opposed to the constant-per-partition task data).
 
-        This is run on the worker itself.
+        This is run on workers or on the main node at the discretion of the executor.
         """
         # TODO: this data can be put into shared memory, which is something
         # our interface should allow for.

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, List, Type, Iterable, Union
+from typing_extensions import Protocol, runtime_checkable
 import warnings
 import logging
 import uuid
@@ -6,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import cloudpickle
 import numpy as np
+from libertem.io.dataset.base.tiling import DataTile
 
 from libertem.warnings import UseDiscouragedWarning
 from libertem.exceptions import UDFException
@@ -20,9 +22,12 @@ from libertem.corrections import CorrectionSet
 from libertem.common.backend import get_use_cuda, get_device_class
 from libertem.utils.async_utils import async_generator_eager
 from libertem.executor.inline import InlineJobExecutor
+from libertem.executor.base import Environment, JobExecutor
 
 
 log = logging.getLogger(__name__)
+
+BackendSpec = Union[str, Iterable[str]]
 
 
 class UDFMeta:
@@ -37,10 +42,15 @@ class UDFMeta:
         Information on compute backend, corrections, coordinates and tiling scheme added
     """
 
-    def __init__(self, partition_slice: Slice, dataset_shape: Shape, roi: np.ndarray,
-                 dataset_dtype: np.dtype, input_dtype: np.dtype, tiling_scheme: TilingScheme = None,
-                 tiling_index: int = 0, corrections=None, device_class: str = None,
-                 threads_per_worker: Optional[int] = None):
+    def __init__(
+        self,
+        partition_slice: Optional[Slice],
+        dataset_shape: Shape,
+        roi: Optional[np.ndarray],
+        dataset_dtype: np.dtype, input_dtype: np.dtype, tiling_scheme: TilingScheme = None,
+        tiling_index: int = 0, corrections=None, device_class: str = None,
+        threads_per_worker: Optional[int] = None
+    ):
         self._partition_slice = partition_slice
         self._dataset_shape = dataset_shape
         self._dataset_dtype = dataset_dtype
@@ -53,7 +63,7 @@ class UDFMeta:
         if roi is not None:
             roi = roi.reshape(dataset_shape.nav)
         self._roi = roi
-        self._slice = None
+        self._slice: Optional[Slice] = None
         self._cached_coordinates = None
         if corrections is None:
             corrections = CorrectionSet()
@@ -61,7 +71,7 @@ class UDFMeta:
         self._threads_per_worker = threads_per_worker
 
     @property
-    def slice(self) -> Slice:
+    def slice(self) -> Optional[Slice]:
         """
         Slice : A :class:`~libertem.common.slice.Slice` instance that describes the location
                 within the dataset with navigation dimension flattened and reduced to the ROI.
@@ -78,6 +88,8 @@ class UDFMeta:
         Shape : The shape of the partition this UDF currently works on.
                 If a ROI was applied, the shape will be modified accordingly.
         """
+        if self._partition_slice is None:
+            raise ValueError("cannot get partition_shape if partition_slice is None")
         return self._partition_slice.shape
 
     @property
@@ -88,7 +100,7 @@ class UDFMeta:
         return self._dataset_shape
 
     @property
-    def tiling_scheme(self) -> Shape:
+    def tiling_scheme(self) -> Optional[TilingScheme]:
         """
         TilingScheme : the tiling scheme that was negotiated
 
@@ -97,7 +109,7 @@ class UDFMeta:
         return self._tiling_scheme
 
     @property
-    def roi(self) -> np.ndarray:
+    def roi(self) -> Optional[np.ndarray]:
         """
         numpy.ndarray : Boolean array which limits the elements the UDF is working on.
                      Has a shape of :attr:`dataset_shape.nav`.
@@ -365,7 +377,8 @@ class UDFData:
         self._views = {}
 
 
-class UDFFrameMixin:
+@runtime_checkable
+class UDFFrameMixin(Protocol):
     '''
     Implement :code:`process_frame` for per-frame processing.
     '''
@@ -391,7 +404,8 @@ class UDFFrameMixin:
         raise NotImplementedError()
 
 
-class UDFTileMixin:
+@runtime_checkable
+class UDFTileMixin(Protocol):
     '''
     Implement :code:`process_tile` for per-tile processing.
     '''
@@ -417,7 +431,8 @@ class UDFTileMixin:
         raise NotImplementedError()
 
 
-class UDFPartitionMixin:
+@runtime_checkable
+class UDFPartitionMixin(Protocol):
     '''
     Implement :code:`process_partition` for per-partition processing.
     '''
@@ -451,7 +466,8 @@ class UDFPartitionMixin:
         raise NotImplementedError()
 
 
-class UDFPreprocessMixin:
+@runtime_checkable
+class UDFPreprocessMixin(Protocol):
     '''
     Implement :code:`preprocess` to initialize the result buffers of a partition on the worker
     before the partition data is processed.
@@ -475,7 +491,8 @@ class UDFPreprocessMixin:
         raise NotImplementedError()
 
 
-class UDFPostprocessMixin:
+@runtime_checkable
+class UDFPostprocessMixin(Protocol):
     '''
     Implement :code:`postprocess` to modify the resulf buffers of a partition on the worker
     after the partition data has been completely processed, but before it is returned to the
@@ -696,14 +713,18 @@ class UDF(UDFBase):
     def copy(self):
         return self.__class__(**self._kwargs)
 
-    def copy_for_partition(self, partition: np.ndarray, roi: np.ndarray):
+    @classmethod
+    def new_for_partition(cls, kwargs, partition: Partition, roi: np.ndarray):
+        new_instance = cls(**kwargs)
+        new_instance.params.new_for_partition(partition, roi)
+        return new_instance
+
+    def copy_for_partition(self, partition: Partition, roi: np.ndarray):
         """
         create a copy of the UDF, specifically slicing aux data to the
         specified pratition and roi
         """
-        new_instance = self.__class__(**self._kwargs)
-        new_instance.params.new_for_partition(partition, roi)
-        return new_instance
+        return self.__class__.new_for_partition(self._kwargs, partition, roi)
 
     def get_task_data(self):
         """
@@ -1034,6 +1055,48 @@ def check_cast(fromvar, tovar):
         raise TypeError(f"Unsafe automatic casting from {fromvar.dtype} to {tovar.dtype}")
 
 
+class UDFParams:
+    def __init__(
+        self,
+        udfs: List[UDF],
+        roi: Optional[np.ndarray],
+        corrections: Optional[CorrectionSet],
+    ):
+        """
+        Container class for UDF parameters for multiple UDFs
+
+        Parameters
+        ----------
+        udfs : List[UDF]
+            [description]
+        roi : [type]
+            [description]
+        corrections : [type]
+            [description]
+        """
+        self._kwargs = [udf._kwargs for udf in udfs]
+        self._roi = roi
+        self._corrections = corrections
+
+    @property
+    def roi(self):
+        return self._roi
+
+    @property
+    def corrections(self):
+        return self._corrections
+
+    @property
+    def kwargs(self):
+        return self._kwargs
+
+
+class UDFConst:
+    # TODO fill with life late, pass around as "item" for now
+    # to develop the correct executor - UDFRunner - UDF relationship
+    pass
+
+
 class Task:
     """
     A computation on a partition. Inherit from this class and implement ``__call__``
@@ -1108,21 +1171,51 @@ class Task:
         # No CUDA support for the deprecated Job interface
         return {'CPU': 1, 'compute': 1, 'ndarray': 1}
 
-    def __call__(self):
+    def __call__(self, params: UDFParams, const: UDFConst, env: Environment):
         raise NotImplementedError()
 
 
 class UDFTask(Task):
-    def __init__(self, partition: Partition, idx, udfs, roi, backends, corrections=None):
-        super().__init__(partition=partition, idx=idx)
-        self._roi = roi
-        self._udfs = udfs
-        self._backends = backends
-        self._corrections = corrections
+    def __init__(
+        self,
+        partition: Partition,
+        idx: int,
+        udf_classes: List[Type[UDF]],
+        udf_backends: List[BackendSpec],
+        backends: Optional[BackendSpec],
+    ):
+        """
+        A computation for a single partition. The parameters that stay the same
+        for the whole dataset are excluded here and supplied by the executor in
+        __call__.
 
-    def __call__(self, env=None):
-        return UDFRunner(self._udfs).run_for_partition(
-            self.partition, self._roi, self._corrections, env,
+        Parameters
+        ----------
+        partition : Partition
+            The partition to work on
+        idx : int
+            the index of the task, used to identify results (?)
+        udf_classes : List[Type[UDF]]
+            The UDFs to run
+        backends : List[str]
+            The specified backends we want to run on
+        """
+        super().__init__(partition=partition, idx=idx)
+        self._backends = backends
+        self._udf_classes = udf_classes
+        self._udf_backends = []
+        for backends_for_udf in udf_backends:
+            if isinstance(backends_for_udf, str):
+                backends_for_udf = (backends_for_udf,)
+            self._udf_backends.append(set(backends_for_udf))
+
+    def __call__(self, params: UDFParams, const: UDFConst, env: Environment):
+        udfs = [
+            cls.new_for_partition(kwargs, self.partition, params.roi)
+            for cls, kwargs in zip(self._udf_classes, params.kwargs)
+        ]
+        return UDFRunner(udfs).run_for_partition(
+            self.partition, params, const, env,
         )
 
     def get_resources(self):
@@ -1134,15 +1227,9 @@ class UDFTask(Task):
         needs_cuda = 0
         needs_cpu = 0
         needs_ndarray = 0
-        backends_for_udfs = []
-        for udf in self._udfs:
-            b = udf.get_backends()
-            if isinstance(b, str):
-                b = (b, )
-            backends_for_udfs.append(set(b))
 
         # Limit to externally specified backends
-        for backend_set in backends_for_udfs:
+        for backend_set in self._udf_backends:
             if self._backends is not None:
                 b = self._backends
                 if isinstance(b, str):
@@ -1156,7 +1243,7 @@ class UDFTask(Task):
         if needs_cuda and needs_cpu:
             raise ValueError(
                 "There is no common supported UDF backend (have: %r, limited to %r)"
-                % (backends_for_udfs, self._backends)
+                % (self._udf_backends, self._backends)
             )
         result = {'compute': 1}
         if needs_cpu:
@@ -1168,7 +1255,7 @@ class UDFTask(Task):
         return result
 
     def __repr__(self):
-        return f"<UDFTask {self._udfs!r}>"
+        return f"<UDFTask {self._udf_classes!r}>"
 
 
 class UDFRunner:
@@ -1234,7 +1321,16 @@ class UDFRunner:
             )
         return tmp_dtype
 
-    def _init_udfs(self, numpy_udfs, cupy_udfs, partition, roi, corrections, device_class, env):
+    def _init_udfs(
+        self,
+        numpy_udfs: List[UDF],
+        cupy_udfs: List[UDF],
+        partition: Partition,
+        roi: Optional[np.ndarray],
+        corrections: CorrectionSet,
+        device_class,
+        env: Environment,
+    ):
         dtype = self._get_dtype(partition.dtype, corrections)
         meta = UDFMeta(
             partition_slice=partition.slice.adjust_for_roi(roi),
@@ -1263,7 +1359,7 @@ class UDFRunner:
             udf.allocate_for_part(partition, roi)
             udf.init_task_data()
             # TODO: preprocess doesn't have access to the tiling scheme - is this ok?
-            if hasattr(udf, 'preprocess'):
+            if isinstance(udf, UDFPreprocessMixin):
                 udf.clear_views()
                 udf.preprocess()
         neg = Negotiator()
@@ -1295,14 +1391,19 @@ class UDFRunner:
             udf.set_meta(meta)
         return (meta, tiling_scheme, dtype)
 
-    def _run_tile(self, udfs, partition, tile, device_tile):
+    def _run_tile(
+        self,
+        udfs: List[UDF],
+        partition: Partition,
+        tile: DataTile,
+        device_tile: DataTile
+    ):
         for udf in udfs:
-            method = udf.get_method()
-            if method == 'tile':
+            if isinstance(udf, UDFTileMixin):
                 udf.set_contiguous_views_for_tile(partition, tile)
                 udf.set_slice(tile.tile_slice)
                 udf.process_tile(device_tile)
-            elif method == 'frame':
+            elif isinstance(udf, UDFFrameMixin):
                 tile_slice = tile.tile_slice
                 for frame_idx, frame in enumerate(device_tile):
                     frame_slice = Slice(
@@ -1313,12 +1414,20 @@ class UDFRunner:
                     udf.set_slice(frame_slice)
                     udf.set_views_for_frame(partition, tile, frame_idx)
                     udf.process_frame(frame)
-            elif method == 'partition':
+            elif isinstance(udf, UDFPartitionMixin):
                 udf.set_views_for_tile(partition, tile)
                 udf.set_slice(tile.tile_slice)
                 udf.process_partition(device_tile)
 
-    def _run_udfs(self, numpy_udfs, cupy_udfs, partition, tiling_scheme, roi, dtype):
+    def _run_udfs(
+        self,
+        numpy_udfs: List[UDF],
+        cupy_udfs: List[UDF],
+        partition: Partition,
+        tiling_scheme: TilingScheme,
+        roi: Optional[np.ndarray],
+        dtype,
+    ):
         # FIXME pass information on target location (numpy or cupy)
         # to dataset so that is can already move it there.
         # In the future, it might even decode data on the device instead of CPU
@@ -1337,11 +1446,11 @@ class UDFRunner:
                 device_tile = xp.asanyarray(tile)
                 self._run_tile(cupy_udfs, partition, tile, device_tile)
 
-    def _wrapup_udfs(self, numpy_udfs, cupy_udfs, partition):
+    def _wrapup_udfs(self, numpy_udfs: List[UDF], cupy_udfs: List[UDF], partition: Partition):
         udfs = numpy_udfs + cupy_udfs
         for udf in udfs:
             udf.flush(self._debug)
-            if hasattr(udf, 'postprocess'):
+            if isinstance(udf, UDFPostprocessMixin):
                 udf.clear_views()
                 udf.postprocess()
 
@@ -1382,7 +1491,15 @@ class UDFRunner:
                 "supported are 'cpu' and 'cuda'")
         return (numpy_udfs, cupy_udfs)
 
-    def run_for_partition(self, partition: Partition, roi, corrections, env):
+    def run_for_partition(
+        self,
+        partition: Partition,
+        params: UDFParams,
+        const: UDFConst,
+        env: Environment
+    ):
+        roi = params.roi
+        corrections = params.corrections
         with env.enter():
             try:
                 previous_id = None
@@ -1399,11 +1516,14 @@ class UDFRunner:
                     previous_id = cupy.cuda.Device().id
                     cupy.cuda.Device(device).use()
                 (meta, tiling_scheme, dtype) = self._init_udfs(
+                    # TODO pass in const
                     numpy_udfs, cupy_udfs, partition, roi, corrections, device_class, env,
                 )
                 # print("UDF TilingScheme: %r" % tiling_scheme.shape)
                 partition.set_corrections(corrections)
+                # TODO pass in const
                 self._run_udfs(numpy_udfs, cupy_udfs, partition, tiling_scheme, roi, dtype)
+                # TODO pass in const
                 self._wrapup_udfs(numpy_udfs, cupy_udfs, partition)
             finally:
                 if previous_id is not None:
@@ -1424,7 +1544,13 @@ class UDFRunner:
             )
 
     def _prepare_run_for_dataset(
-        self, dataset: DataSet, executor, roi, corrections, backends, dry
+        self,
+        dataset: DataSet,
+        executor: JobExecutor,
+        roi: Optional[np.ndarray],
+        corrections: Optional[CorrectionSet],
+        backends: Optional[BackendSpec],
+        dry: bool,
     ):
         self._check_preconditions(dataset, roi)
         meta = UDFMeta(
@@ -1435,6 +1561,7 @@ class UDFRunner:
             input_dtype=self._get_dtype(dataset.dtype, corrections),
             corrections=corrections,
         )
+        const = []
         for udf in self._udfs:
             udf.set_meta(meta)
             udf.init_result_buffers()
@@ -1443,11 +1570,18 @@ class UDFRunner:
             if hasattr(udf, 'preprocess'):
                 udf.set_views_for_dataset(dataset)
                 udf.preprocess()
+            # TODO fill with life later
+            const.append(UDFConst())
+        params = UDFParams(
+            udfs=self._udfs,
+            roi=roi,
+            corrections=corrections
+        )
         if dry:
             tasks = []
         else:
-            tasks = list(self._make_udf_tasks(dataset, roi, corrections, backends))
-        return tasks
+            tasks = list(self._make_udf_tasks(dataset, roi, backends))
+        return (tasks, params, const)
 
     def run_for_dataset(self, dataset: DataSet, executor,
                         roi=None, progress=False, corrections=None, backends=None, dry=False):
@@ -1463,61 +1597,84 @@ class UDFRunner:
             pass
         return res
 
-    def run_for_dataset_sync(self, dataset: DataSet, executor,
-                        roi=None, progress=False, corrections=None, backends=None, dry=False):
-        tasks = self._prepare_run_for_dataset(
+    def run_for_dataset_sync(
+        self,
+        dataset: DataSet,
+        executor: JobExecutor,
+        roi: Optional[np.ndarray] = None,
+        progress: bool = False,
+        corrections: Optional[CorrectionSet] = None,
+        backends: Optional[BackendSpec] = None,
+        dry: bool = False
+    ):
+        tasks, params, const = self._prepare_run_for_dataset(
             dataset, executor, roi, corrections, backends, dry
         )
         cancel_id = str(uuid.uuid4())
         self._debug_task_pickling(tasks)
-
-        if progress:
-            from tqdm import tqdm
-            t = tqdm(total=len(tasks))
 
         executor = executor.ensure_sync()
 
         damage = BufferWrapper(kind='nav', dtype=bool)
         damage.set_shape_ds(dataset.shape, roi)
         damage.allocate()
-        if tasks:
-            for part_results, task in executor.run_tasks(tasks, cancel_id):
-                if progress:
-                    t.update(1)
-                for results, udf in zip(part_results, self._udfs):
-                    udf.set_views_for_partition(task.partition)
-                    udf.merge(
-                        dest=udf.results.get_proxy(),
-                        src=results.get_proxy()
+        try:
+            if progress:
+                from tqdm import tqdm
+                t = tqdm(total=len(tasks))
+            with executor.scatter(params) as params_handle,\
+                    executor.scatter(const) as const_handle:
+                if tasks:
+                    result_iter = executor.run_tasks(
+                        tasks,
+                        params_handle,
+                        const_handle,
+                        cancel_id,
                     )
-                    udf.clear_views()
-                v = damage.get_view_for_partition(task.partition)
-                v[:] = True
-                yield UDFResults(
-                    buffers=tuple(
-                        udf._do_get_results()
-                        for udf in self._udfs
-                    ),
-                    damage=damage
-                )
-        else:
-            # yield at least one result (which should be empty):
-            for udf in self._udfs:
-                udf.clear_views()
-            yield UDFResults(
-                buffers=tuple(
-                    udf._do_get_results()
-                    for udf in self._udfs
-                ),
-                damage=damage
-            )
-
-        if progress:
-            t.close()
+                    for part_results, task in result_iter:
+                        if progress:
+                            t.update(1)
+                        for results, udf in zip(part_results, self._udfs):
+                            udf.set_views_for_partition(task.partition)
+                            udf.merge(
+                                dest=udf.results.get_proxy(),
+                                src=results.get_proxy()
+                            )
+                            udf.clear_views()
+                        v = damage.get_view_for_partition(task.partition)
+                        v[:] = True
+                        yield UDFResults(
+                            buffers=tuple(
+                                udf._do_get_results()
+                                for udf in self._udfs
+                            ),
+                            damage=damage
+                        )
+                else:
+                    # yield at least one result (which should be empty):
+                    for udf in self._udfs:
+                        udf.clear_views()
+                    yield UDFResults(
+                        buffers=tuple(
+                            udf._do_get_results()
+                            for udf in self._udfs
+                        ),
+                        damage=damage
+                    )
+        finally:
+            if progress:
+                t.close()
 
     async def run_for_dataset_async(
-        self, dataset: DataSet, executor, cancel_id, roi=None, corrections=None, backends=None,
-        progress=False, dry=False
+        self,
+        dataset: DataSet,
+        executor: JobExecutor,
+        cancel_id,
+        roi: Optional[np.ndarray] = None,
+        corrections: Optional[CorrectionSet] = None,
+        backends: Optional[BackendSpec] = None,
+        progress: bool = False,
+        dry: bool = False
     ):
         gen = self.run_for_dataset_sync(
             dataset=dataset,
@@ -1535,21 +1692,49 @@ class UDFRunner:
     def _roi_for_partition(self, roi, partition: Partition):
         return roi.reshape(-1)[partition.slice.get(nav_only=True)]
 
-    def _make_udf_tasks(self, dataset: DataSet, roi, corrections, backends):
+    def _make_udf_const_data(self, udf_classes, dataset: DataSet, roi, corrections, backends):
+        """
+        Make per-worker constant data (constant for the whole UDF run, as
+        opposed to the constant-per-partition task data).
+
+        This is run on the worker itself.
+        """
+        # TODO: this data can be put into shared memory, which is something
+        # our interface should allow for.
+        data = UDFConst(
+            # udf_classes=udf_classes,
+            roi=roi,
+            corrections=corrections,
+            backends=backends,
+        )
+        return data
+
+    def _make_udf_tasks(
+        self,
+        dataset: DataSet,
+        roi: Optional[np.ndarray],
+        backends: Optional[BackendSpec]
+    ):
+        udf_backends = [
+            udf.get_backends()
+            for udf in self._udfs
+        ]
         for idx, partition in enumerate(dataset.get_partitions()):
             if roi is not None:
                 roi_for_part = self._roi_for_partition(roi, partition)
                 if np.count_nonzero(roi_for_part) == 0:
                     # roi is empty for this partition, ignore
                     continue
-            udfs = [
-                udf.copy_for_partition(partition, roi)
+            udf_classes = [
+                udf.__class__
                 for udf in self._udfs
             ]
-            yield UDFTask(
-                partition=partition, idx=idx, udfs=udfs, roi=roi, corrections=corrections,
+            tasks = UDFTask(
+                partition=partition, idx=idx, udf_classes=udf_classes,
+                udf_backends=udf_backends,
                 backends=backends,
             )
+            yield tasks
 
 
 class UDFResults:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1068,11 +1068,12 @@ class UDFParams:
         Parameters
         ----------
         kwargs : List[dict]
-            [description]
-        roi : [type]
-            [description]
-        corrections : [type]
-            [description]
+            List of kwargs which can be used to re-create the UDF instances
+            that were passed to `run_for_dataset`
+        roi
+            Boolean array to select parts of the navigation space
+        corrections
+            Corrections to apply
         """
         self._kwargs = kwargs
         self._roi = roi

--- a/tests/udf/test_memleak.py
+++ b/tests/udf/test_memleak.py
@@ -83,7 +83,12 @@ def test_executor_memleak(local_cluster_ctx, lt_ctx_fast, default_raw, ctx_selec
     def mask_factory():
         return masks
 
-    udf = ApplyMasksUDF(mask_factories=mask_factory, mask_count=mask_count, mask_dtype=masks.dtype, use_torch=False)
+    udf = ApplyMasksUDF(
+        mask_factories=mask_factory,
+        mask_count=mask_count,
+        mask_dtype=masks.dtype,
+        use_torch=False
+    )
 
     # warm-up
     for _ in ctx.run_udf_iter(dataset=default_raw, udf=udf):

--- a/tests/udf/test_memleak.py
+++ b/tests/udf/test_memleak.py
@@ -1,0 +1,141 @@
+import sys
+import time
+from itertools import chain
+import gc
+
+import numpy as np
+import pytest
+
+from libertem.udf.masks import ApplyMasksUDF
+
+
+# based on https://code.activestate.com/recipes/577504/
+def total_size(o):
+    def dict_handler(d):
+        return chain.from_iterable(d.items())
+
+    def object_handler(o):
+        if hasattr(o, '__dict__'):
+            return dict_handler(o.__dict__)
+        else:
+            return tuple()
+
+    all_handlers = {
+        tuple: iter,
+        list: iter,
+        # deque: iter, Triggers RuntimeError with Dask client
+        dict: dict_handler,
+        set: iter,
+        frozenset: iter,
+        object: object_handler,
+    }
+    seen = set()                      # track which object id's have already been seen
+    default_size = sys.getsizeof(0)       # estimate sizeof object without __sizeof__
+
+    def sizeof(o):
+        if id(o) in seen:       # do not double count the same object
+            return 0
+        seen.add(id(o))
+        s = sys.getsizeof(o, default_size)
+
+        for typ, handler in all_handlers.items():
+            if isinstance(o, typ):
+                s += sum(map(sizeof, handler(o)))
+                break
+        return s
+
+    return sizeof(o)
+
+
+def worker_memory(client):
+    info = client.scheduler_info()
+    memory = 0
+    for name, w_info in info['workers'].items():
+        memory += w_info['metrics']['memory']
+    return memory
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    'ctx_select', ('dask', 'inline')
+)
+def test_executor_memleak(local_cluster_ctx, lt_ctx_fast, default_raw, ctx_select):
+    if ctx_select == 'dask':
+        ctx = local_cluster_ctx
+        rounds = 3
+
+        def get_worker_mem(ctx):
+            return worker_memory(ctx.executor.client)
+
+    elif ctx_select == 'inline':
+        ctx = lt_ctx_fast
+        rounds = 1
+
+        def get_worker_mem(ctx):
+            return 0
+
+    mask_count = 8*1014*1024 // np.prod(default_raw.shape.sig)
+
+    mask_shape = (mask_count, *default_raw.shape.sig)
+    masks = np.zeros(mask_shape)
+
+    # Intentionally "bad" factory function: make it large by closing over masks
+    def mask_factory():
+        return masks
+
+    udf = ApplyMasksUDF(mask_factories=mask_factory, mask_count=mask_count, mask_dtype=masks.dtype, use_torch=False)
+
+    # warm-up
+    for _ in ctx.run_udf_iter(dataset=default_raw, udf=udf):
+        pass
+
+    cumulative_worker_delta = 0
+    cumulative_executor_delta = 0
+
+    for round in range(rounds):
+        gc.collect()
+
+        # Allow to settle
+        time.sleep(1)
+
+        ctx.executor.run_each_worker(gc.collect)
+
+        executor_size_before = total_size(ctx)
+        worker_mem_before = get_worker_mem(ctx)
+
+        executor_size_during = None
+
+        for res in ctx.run_udf_iter(dataset=default_raw, udf=udf):
+            if executor_size_during is None:
+                executor_size_during = total_size(ctx)
+                worker_mem_during = get_worker_mem(ctx)
+
+        gc.collect()
+
+        # Allow to settle
+        time.sleep(1)
+
+        ctx.executor.run_each_worker(gc.collect)
+
+        executor_size_after = total_size(ctx)
+        worker_mem_after = get_worker_mem(ctx)
+
+        active_use = worker_mem_during - worker_mem_before
+
+        # Memory use does increase slowly. Just make sure it is not caused by keeping
+        # a big array around
+        worker_delta = worker_mem_after - worker_mem_before
+        executor_delta = executor_size_after - executor_size_before
+
+        print(f"Round {round}")
+        print(f"Memory use during UDF run: {active_use}.")
+        print(f"Memory increase worker: {worker_delta}.")
+        print(f"Memory increase executor: {executor_delta}.")
+
+        cumulative_worker_delta += worker_delta
+        cumulative_executor_delta += executor_delta
+
+    worker_count = len(ctx.executor.get_available_workers())
+
+    assert cumulative_worker_delta/rounds/worker_count < sys.getsizeof(masks) * 0.1
+    assert cumulative_executor_delta/rounds < sys.getsizeof(masks) * 0.1

--- a/tests/udf/test_resources_for_backends.py
+++ b/tests/udf/test_resources_for_backends.py
@@ -1,0 +1,90 @@
+import pytest
+
+
+from libertem.udf.base import get_resources_for_backends
+
+
+def test_no_common_backends():
+    with pytest.raises(ValueError):
+        get_resources_for_backends(
+            [('numpy',), ('cupy',)], user_backends=None,
+        )
+
+
+def test_no_common_backends_with_user():
+    with pytest.raises(ValueError):
+        get_resources_for_backends(
+            [('numpy', 'cupy'), ('cupy',)], user_backends=('numpy',),
+        )
+
+
+def test_common_backends_cpu_1():
+    resources = get_resources_for_backends(
+        [('numpy', 'cupy'), ('numpy',)], user_backends=None,
+    )
+    assert resources == {
+        'CPU': 1, 'compute': 1, 'ndarray': 1
+    }
+
+
+def test_common_backends_cpu_2():
+    resources = get_resources_for_backends(
+        [('numpy', 'cupy'), ('numpy', 'cupy',)], user_backends=('numpy',),
+    )
+    assert resources == {
+        'CPU': 1, 'compute': 1, 'ndarray': 1
+    }
+
+
+def test_common_backends_compute_1():
+    resources = get_resources_for_backends(
+        [('numpy', 'cupy'), ('numpy', 'cupy',)], user_backends=None,
+    )
+    assert resources == {
+        'compute': 1, 'ndarray': 1
+    }
+
+
+def test_common_backends_compute_2():
+    resources = get_resources_for_backends(
+        [('numpy', 'cupy'), ('numpy', 'cupy',)], user_backends=('numpy', 'cupy'),
+    )
+    assert resources == {
+        'compute': 1, 'ndarray': 1
+    }
+
+
+def test_common_backends_gpu_1():
+    resources = get_resources_for_backends(
+        [('cupy',), ('cuda',)], user_backends=None,
+    )
+    assert resources == {
+        'CUDA': 1, 'compute': 1, 'ndarray': 1
+    }
+
+
+def test_common_backends_gpu_2():
+    resources = get_resources_for_backends(
+        [('cuda',), ('cupy',)], user_backends=('cupy', 'cuda'),
+    )
+    assert resources == {
+        'CUDA': 1, 'compute': 1, 'ndarray': 1
+    }
+
+
+def test_common_backends_gpu_3():
+    resources = get_resources_for_backends(
+        [('cupy',), ('cupy',)], user_backends=('cupy',),
+    )
+    assert resources == {
+        'CUDA': 1, 'compute': 1, 'ndarray': 1
+    }
+
+
+def test_common_backends_as_string():
+    resources = get_resources_for_backends(
+        ['cupy', ('cupy',)], user_backends='cupy',
+    )
+    assert resources == {
+        'CUDA': 1, 'compute': 1, 'ndarray': 1
+    }

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -3,7 +3,7 @@ import pickle
 import numpy as np
 import pytest
 
-from libertem.udf.base import UDF, UDFRunner, UDFParams, UDFConst
+from libertem.udf.base import UDF, UDFRunner, UDFParams
 from libertem.udf.base import UDFMeta
 from libertem.executor.base import Environment
 from libertem.io.dataset.memory import MemoryDataSet
@@ -561,12 +561,9 @@ def test_noncontiguous_tiles(lt_ctx, backend):
             roi=None,
             corrections=None
         )
-        # TODO fill with actual implementation later
-        const = [UDFConst()]
         UDFRunner([p_udf], debug=True).run_for_partition(
             partition=partition,
             params=params,
-            const=const,
             env=Environment(threads_per_worker=1),
         )
 

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -556,7 +556,7 @@ def test_noncontiguous_tiles(lt_ctx, backend):
         partition = next(dataset.get_partitions())
         p_udf = udf.copy_for_partition(partition=partition, roi=None)
         # Enabling debug=True checks for disjoint cache keys
-        params = UDFParams(
+        params = UDFParams.from_udfs(
             udfs=[udf],
             roi=None,
             corrections=None

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -3,7 +3,7 @@ import pickle
 import numpy as np
 import pytest
 
-from libertem.udf.base import UDF, UDFRunner
+from libertem.udf.base import UDF, UDFRunner, UDFParams, UDFConst
 from libertem.udf.base import UDFMeta
 from libertem.executor.base import Environment
 from libertem.io.dataset.memory import MemoryDataSet
@@ -556,10 +556,17 @@ def test_noncontiguous_tiles(lt_ctx, backend):
         partition = next(dataset.get_partitions())
         p_udf = udf.copy_for_partition(partition=partition, roi=None)
         # Enabling debug=True checks for disjoint cache keys
+        params = UDFParams(
+            udfs=[udf],
+            roi=None,
+            corrections=None
+        )
+        # TODO fill with actual implementation later
+        const = [UDFConst()]
         UDFRunner([p_udf], debug=True).run_for_partition(
             partition=partition,
-            roi=None,
-            corrections=None,
+            params=params,
+            const=const,
             env=Environment(threads_per_worker=1),
         )
 

--- a/tests/udf/test_udf_runner.py
+++ b/tests/udf/test_udf_runner.py
@@ -100,7 +100,7 @@ class UDF5(UDF):
 def test_no_common_backends(default_raw, lt_ctx):
     runner = UDFRunner([UDF1(), UDF2()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         with pytest.raises(ValueError) as e:
@@ -111,7 +111,7 @@ def test_no_common_backends(default_raw, lt_ctx):
 def test_no_common_backends_2(default_raw, lt_ctx):
     runner = UDFRunner([UDF1(), UDF4()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         with pytest.raises(ValueError) as e:
@@ -122,7 +122,7 @@ def test_no_common_backends_2(default_raw, lt_ctx):
 def test_common_backends_cpu(default_raw, lt_ctx):
     runner = UDFRunner([UDF1(), UDF3()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         assert task.get_resources() == {'CPU': 1, 'compute': 1, 'ndarray': 1}
@@ -131,7 +131,7 @@ def test_common_backends_cpu(default_raw, lt_ctx):
 def test_common_backends_gpu(default_raw, lt_ctx):
     runner = UDFRunner([UDF2(), UDF3()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         assert task.get_resources() == {'CUDA': 1, 'compute': 1, 'ndarray': 1}
@@ -140,7 +140,7 @@ def test_common_backends_gpu(default_raw, lt_ctx):
 def test_common_backends_gpu_2(default_raw, lt_ctx):
     runner = UDFRunner([UDF2(), UDF4()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         assert task.get_resources() == {'CUDA': 1, 'compute': 1, 'ndarray': 1}
@@ -149,7 +149,7 @@ def test_common_backends_gpu_2(default_raw, lt_ctx):
 def test_common_backends_gpu_3(default_raw, lt_ctx):
     runner = UDFRunner([UDF3(), UDF4()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         assert task.get_resources() == {'CUDA': 1, 'compute': 1, 'ndarray': 1}
@@ -158,7 +158,7 @@ def test_common_backends_gpu_3(default_raw, lt_ctx):
 def test_common_backends_compute(default_raw, lt_ctx):
     runner = UDFRunner([UDF3(), UDF3()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         assert task.get_resources() == {'compute': 1, 'ndarray': 1}
@@ -167,7 +167,7 @@ def test_common_backends_compute(default_raw, lt_ctx):
 def test_common_backends_string(default_raw, lt_ctx):
     runner = UDFRunner([UDF4(), UDF5()])
     tasks = list(runner._make_udf_tasks(
-        dataset=default_raw, roi=None, corrections=None, backends=None,
+        dataset=default_raw, roi=None, backends=None,
     ))
     for task in tasks:
         assert task.get_resources() == {'CUDA': 1, 'compute': 1}


### PR DESCRIPTION
Parameters that are constant for the whole `UDF` run are now handled separately from other task-related data that actually changes for each partition. Executors can implement efficient scattering/broadcasting of parameters now, as implemented here for the `DaskJobExecutor`.

# TODO
- [x] better testing for the backend selection code?
- [x] test that resources that are scattered are cleaned up properly
- [x] `UDFConst` stuff
- [x] any tests to update/add?

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
