### PR TITLE
Replace NumPy `prod()` with infinite width integer `prod()`

### DIFF
--- a/.mypy-checked
+++ b/.mypy-checked
@@ -3,3 +3,4 @@ src/libertem/common/slice.py
 src/libertem/common/shape.py
 src/libertem/common/__init__.py
 src/libertem/common/backend.py
+src/libertem/common/math.py

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -11,6 +11,10 @@ def main():
     with open(os.path.join(BASE_DIR, "../.mypy-checked")) as f:
         files_project = set(f.read().split())
 
+    for i, f in enumerate(files_project):
+        if not os.path.exists(f):
+            raise RuntimeError(f"File {f} on line {i} in .mypy-checked does not exist.")
+
     files_cmdline = set(sys.argv[1:])
 
     args = []

--- a/src/libertem/analysis/radialfourier.py
+++ b/src/libertem/analysis/radialfourier.py
@@ -6,6 +6,7 @@ import numpy as np
 import sparse
 
 from libertem import masks
+from libertem.common.math import prod
 from .base import AnalysisResult, AnalysisResultSet
 from .masks import BaseMasksAnalysis
 from .helper import GeneratorHelper
@@ -129,7 +130,7 @@ class RadialFourierAnalysis(BaseMasksAnalysis, id_="RADIAL_FOURIER"):
         '''
         shape = tuple(self.dataset.shape.nav)
         # NOTE: transposed for historical reasons
-        udf_results = udf_results['intensity'].data.reshape((np.prod(shape), -1)).T
+        udf_results = udf_results['intensity'].data.reshape((prod(shape), -1)).T
         orders = self.parameters['max_order'] + 1
         n_bins = self.parameters['n_bins']
         udf_results = udf_results.reshape((n_bins, orders, *shape))

--- a/src/libertem/common/math.py
+++ b/src/libertem/common/math.py
@@ -1,8 +1,12 @@
 from typing import Iterable, Union
-from typing_extensions import get_args
 
 import numpy as np
 
+
+_prod_accepted = (
+    int, bool,
+    np.bool_, np.signedinteger, np.unsignedinteger
+)
 
 ProdAccepted = Union[
     int, bool,
@@ -21,7 +25,7 @@ def prod(iterable: Iterable[ProdAccepted]):
     result = 1
 
     for item in iterable:
-        if isinstance(item, get_args(ProdAccepted)):
+        if isinstance(item, _prod_accepted):
             result *= int(item)
         else:
             raise ValueError()

--- a/src/libertem/common/math.py
+++ b/src/libertem/common/math.py
@@ -1,0 +1,15 @@
+try:
+    from math import prod
+except ImportError:
+    def prod(iterable):
+        '''
+        Safe product for large size calculations.
+
+        :meth:`numpy.prod` uses 32 bit for default :code:`int` on Windows 64 bit. This
+        function is a replacement for :meth:`math.prod` for versions < Python 3.8
+        that uses infinite width integers.
+        '''
+        result = 1
+        for item in iterable:
+            result *= item
+        return result

--- a/src/libertem/common/math.py
+++ b/src/libertem/common/math.py
@@ -1,15 +1,27 @@
-try:
-    from math import prod
-except ImportError:
-    def prod(iterable):
-        '''
-        Safe product for large size calculations.
+from typing import Iterable, Union, get_args
 
-        :meth:`numpy.prod` uses 32 bit for default :code:`int` on Windows 64 bit. This
-        function is a replacement for :meth:`math.prod` for versions < Python 3.8
-        that uses infinite width integers.
-        '''
-        result = 1
-        for item in iterable:
-            result *= item
-        return result
+import numpy as np
+
+
+ProdAccepted = Union[
+    int, bool,
+    np.bool_, np.signedinteger, np.unsignedinteger
+]
+
+
+def prod(iterable: Iterable[ProdAccepted]):
+    '''
+    Safe product for large integer size calculations.
+
+    :meth:`numpy.prod` uses 32 bit for default :code:`int` on Windows 64 bit. This
+    function uses infinite width integers to calculate the product and
+    throws a ValueError if it encounters types other than the supported ones.
+    '''
+    result = 1
+
+    for item in iterable:
+        if isinstance(item, get_args(ProdAccepted)):
+            result *= int(item)
+        else:
+            raise ValueError()
+    return result

--- a/src/libertem/common/math.py
+++ b/src/libertem/common/math.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Union, get_args
+from typing import Iterable, Union
+from typing_extensions import get_args
 
 import numpy as np
 

--- a/src/libertem/common/slice.py
+++ b/src/libertem/common/slice.py
@@ -1,6 +1,9 @@
 import math
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple, overload
+
 import numpy as np
+
+from libertem.common.math import prod
 from libertem.common.shape import Shape, ShapeLike
 
 
@@ -323,7 +326,7 @@ class Slice:
             origin,
             containing_shape
         )
-        nav_shape = np.product(tuple(self.shape.nav))
+        nav_shape = prod(self.shape.nav)
         return Slice(
             origin=(nav_origin,) + self.origin[nav_dims:],
             shape=Shape((nav_shape,) + tuple(self.shape.sig), sig_dims=sig_dims)

--- a/src/libertem/corrections/corrset.py
+++ b/src/libertem/corrections/corrset.py
@@ -19,6 +19,7 @@ def factorizations(n, primes):
     while np.any(n > 1):
         zero_modulos = (n[:, np.newaxis] % primes[np.newaxis, :]) == 0
         factorization[zero_modulos] += 1
+        # NumPy is probably faster than common.math.prod here
         f = np.prod(primes[np.newaxis, :]**zero_modulos, axis=1, dtype=np.int64)
         n = n // f
 

--- a/src/libertem/corrections/corrset.py
+++ b/src/libertem/corrections/corrset.py
@@ -19,7 +19,7 @@ def factorizations(n, primes):
     while np.any(n > 1):
         zero_modulos = (n[:, np.newaxis] % primes[np.newaxis, :]) == 0
         factorization[zero_modulos] += 1
-        f = np.prod(primes[np.newaxis, :]**zero_modulos, axis=1)
+        f = np.prod(primes[np.newaxis, :]**zero_modulos, axis=1, dtype=np.int64)
         n = n // f
 
     return factorization

--- a/src/libertem/corrections/detector.py
+++ b/src/libertem/corrections/detector.py
@@ -2,6 +2,7 @@ import numpy as np
 import numba
 import sparse
 
+from libertem.common.math import prod
 from libertem.masks import is_sparse
 from libertem.common.numba import (
     numba_ravel_multi_index_multi, numba_unravel_index_multi
@@ -254,7 +255,7 @@ def correct(
             raise ValueError("Invalid arguments: Bot repair_descriptor and excluded_pixels set")
 
     _correct_numba_inplace(
-        buffer=out.reshape((np.prod(nav_shape), np.prod(sig_shape))),
+        buffer=out.reshape((prod(nav_shape), prod(sig_shape))),
         dark_image=dark_image,
         gain_map=gain_map,
         exclude_pixels=repair_descriptor.exclude_flat,
@@ -293,7 +294,7 @@ class RepairDescriptor:
 def correct_dot_masks(masks, gain_map, excluded_pixels=None, allow_empty=False):
     mask_shape = masks.shape
     sig_shape = gain_map.shape
-    masks = masks.reshape((-1, np.prod(sig_shape)))
+    masks = masks.reshape((-1, prod(sig_shape)))
 
     if excluded_pixels is not None:
         if is_sparse(masks):

--- a/src/libertem/io/dataset/base/backend_buffered.py
+++ b/src/libertem/io/dataset/base/backend_buffered.py
@@ -301,6 +301,7 @@ class BufferedBackendImpl(IOBackendImpl):
         need_clear = decoder.do_clear()
 
         slices = read_ranges[0]
+        # Use NumPy prod for multidimensional array and axis parameter
         shape_prods = np.prod(slices[..., 1, :], axis=1, dtype=np.int64)
         ranges = read_ranges[1]
         scheme_indices = read_ranges[2]

--- a/src/libertem/io/dataset/base/backend_buffered.py
+++ b/src/libertem/io/dataset/base/backend_buffered.py
@@ -6,6 +6,7 @@ import numba
 from numba.typed import Dict
 import contextlib
 
+from libertem.common.math import prod
 from libertem.io.dataset.base.backend import IOBackend, IOBackendImpl
 from libertem.io.dataset.base.fileset import FileSet
 from libertem.common import Shape, Slice
@@ -291,7 +292,7 @@ class BufferedBackendImpl(IOBackendImpl):
         ds_shape = np.array(tiling_scheme.dataset_shape)
 
         largest_slice = sorted((
-            (np.prod(s_.shape), s_)
+            (prod(s_.shape), s_)
             for _, s_ in tiling_scheme.slices
         ), key=lambda x: x[0], reverse=True)[0][1]
 
@@ -300,7 +301,7 @@ class BufferedBackendImpl(IOBackendImpl):
         need_clear = decoder.do_clear()
 
         slices = read_ranges[0]
-        shape_prods = np.prod(slices[..., 1, :], axis=1)
+        shape_prods = np.prod(slices[..., 1, :], axis=1, dtype=np.int64)
         ranges = read_ranges[1]
         scheme_indices = read_ranges[2]
         tile_block_size = len(tiling_scheme)

--- a/src/libertem/io/dataset/base/backend_mmap.py
+++ b/src/libertem/io/dataset/base/backend_mmap.py
@@ -288,6 +288,7 @@ class MMapBackendImpl(IOBackendImpl):
         with self._buffer_pool.empty(buf_shape, dtype=read_dtype) as out_decoded:
             out_decoded = out_decoded.reshape((-1,))
             slices = read_ranges[0]
+            # Use NumPy prod for multidimensional array and axis parameter
             shape_prods = np.prod(slices[..., 1, :], axis=1, dtype=np.int64)
             ranges = read_ranges[1]
             scheme_indices = read_ranges[2]

--- a/src/libertem/io/dataset/base/backend_mmap.py
+++ b/src/libertem/io/dataset/base/backend_mmap.py
@@ -7,6 +7,7 @@ import numpy as np
 from numba.typed import List
 import numba
 
+from libertem.common.math import prod
 from libertem.io.dataset.base.backend import IOBackend, IOBackendImpl
 from libertem.io.dataset.base.fileset import FileSet
 from libertem.common import Shape, Slice
@@ -277,7 +278,7 @@ class MMapBackendImpl(IOBackendImpl):
         ds_shape = np.array(tiling_scheme.dataset_shape)
 
         largest_slice = sorted((
-            (np.prod(s_.shape), s_)
+            (prod(s_.shape), s_)
             for _, s_ in tiling_scheme.slices
         ), key=lambda x: x[0], reverse=True)[0][1]
 
@@ -287,7 +288,7 @@ class MMapBackendImpl(IOBackendImpl):
         with self._buffer_pool.empty(buf_shape, dtype=read_dtype) as out_decoded:
             out_decoded = out_decoded.reshape((-1,))
             slices = read_ranges[0]
-            shape_prods = np.prod(slices[..., 1, :], axis=1)
+            shape_prods = np.prod(slices[..., 1, :], axis=1, dtype=np.int64)
             ranges = read_ranges[1]
             scheme_indices = read_ranges[2]
             for idx in range(slices.shape[0]):

--- a/src/libertem/io/dataset/base/coordinates.py
+++ b/src/libertem/io/dataset/base/coordinates.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.common import Shape, Slice
 from libertem.io.dataset.base import _roi_to_nd_indices
 
@@ -28,7 +29,7 @@ def get_coordinates(slice_: Slice, ds_shape: Shape, roi=None) -> np.ndarray:
     end_idx = o[0] + s[0]
     nav_shape = ds_shape[:-sig_dims]
     if roi is None:
-        flat_nav_shape = tuple((int(np.prod(nav_shape)),))
+        flat_nav_shape = tuple((int(prod(nav_shape)),))
         coordinates = np.stack(
             np.unravel_index(
                 np.ravel_multi_index([np.arange(start_idx, end_idx)], flat_nav_shape),

--- a/src/libertem/io/dataset/base/dataset.py
+++ b/src/libertem/io/dataset/base/dataset.py
@@ -4,6 +4,7 @@ from typing import Generator, Optional
 import numpy as np
 from libertem.common.shape import Shape
 
+from libertem.common.math import prod
 from libertem.io.utils import get_partition_shape
 from libertem.io.dataset.base import DataSetException, MMapBackend
 from libertem.web.messageconverter import MessageConverter
@@ -78,7 +79,7 @@ class DataSet:
         are created.
         """
         partition_size_float_px = self.MAX_PARTITION_SIZE // 4
-        dataset_size_px = np.prod(self.shape, dtype=np.int64)
+        dataset_size_px = prod(self.shape)
         num = max(self._cores, dataset_size_px // partition_size_float_px)
         return num
 

--- a/src/libertem/io/dataset/base/file.py
+++ b/src/libertem/io/dataset/base/file.py
@@ -1,6 +1,8 @@
 from typing import NamedTuple, Tuple
 import numpy as np
 
+from libertem.common.math import prod
+
 
 class OffsetsSizes(NamedTuple):
     """
@@ -111,13 +113,13 @@ class File:
         itemsize = np.dtype(self._native_dtype).itemsize
         assert self._frame_header % itemsize == 0
         assert self._frame_footer % itemsize == 0
-        frame_size = int(np.prod(self._sig_shape, dtype=np.int64))
+        frame_size = int(prod(self._sig_shape))
         frame_offset = self._frame_header // itemsize
         file_offset = self._file_header
         skip_end = 0
 
         # cut off any extra data at the end of the file:
-        if size % int(np.prod(self._sig_shape)):
+        if size % int(prod(self._sig_shape)):
             new_mmap_size = self.num_frames * (
                 (itemsize * frame_size) + self._frame_header + self._frame_footer
             )

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -279,7 +279,7 @@ def make_get_read_ranges(
         bpp, sync_offset=0, extra=None, frame_header_bytes=0, frame_footer_bytes=0,
     ):
         result = NumbaList()
-
+        # Use NumPy prod for Numba compilation
         sig_size = np.prod(np.array(sig_shape).astype(np.int64))
 
         if roi is None:
@@ -308,6 +308,7 @@ def make_get_read_ranges(
         # this should be `prod(..., axis=-1)``, which is not supported by numba yet:
         # slices that divide the signal dimensions:
         slice_sig_sizes = np.array([
+            # Use NumPy prod for Numba compilation
             np.prod(slices_arr[slice_idx, 1, :].astype(np.int64))
             for slice_idx in range(slices_arr.shape[0])
         ])

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.common import Shape
 from .base import (
     DataSet, DataSetException, DataSetMeta,
@@ -148,11 +149,11 @@ class BloDataSet(DataSet):
             self._nav_shape = (NY, NX)
         if self._sig_shape is None:
             self._sig_shape = (DP_SZ, DP_SZ)
-        elif int(np.prod(self._sig_shape)) != (DP_SZ * DP_SZ):
+        elif int(prod(self._sig_shape)) != (DP_SZ * DP_SZ):
             raise DataSetException(
                 "sig_shape must be of size: %s" % (DP_SZ * DP_SZ)
             )
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self.get_sync_offset_info()
         self._shape = Shape(self._nav_shape + self._sig_shape, sig_dims=len(self._sig_shape))
         self._meta = DataSetMeta(
@@ -180,7 +181,7 @@ class BloDataSet(DataSet):
                     "endianess": "<",
                 },
                 "info": {
-                    "image_count": int(np.prod(ds.shape.nav)),
+                    "image_count": int(prod(ds.shape.nav)),
                     "native_sig_shape": tuple(ds.shape.sig),
                 }
             }

--- a/src/libertem/io/dataset/cluster.py
+++ b/src/libertem/io/dataset/cluster.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 import numpy as np
 
+from libertem.common.math import prod
 from .base import (
     DataSet, BasePartition, DataSetMeta, DataSetException,
     WritablePartition, WritableDataSet
@@ -50,7 +51,7 @@ class ClusterDataSet(WritableDataSet, DataSet):
             shape=structure.shape,
             raw_dtype=np.dtype(structure.dtype),
             sync_offset=0,
-            image_count=int(np.prod(structure.shape.nav)),
+            image_count=int(prod(structure.shape.nav)),
         )
         self._executor = None
 

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -6,6 +6,7 @@ import warnings
 from ncempy.io.dm import fileDM
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.common import Shape
 from libertem.io.dataset.base.file import OffsetsSizes
 from libertem.web.messageconverter import MessageConverter
@@ -43,7 +44,7 @@ class StackedDMFile(File):
         mem = mem[slicing.file_offset:-slicing.skip_end]
         res = np.frombuffer(mem, dtype="uint8")
         itemsize = np.dtype(self._native_dtype).itemsize
-        sigsize = int(np.prod(self._sig_shape, dtype=np.int64))
+        sigsize = int(prod(self._sig_shape))
         cutoff = 0
         cutoff += (
             self.num_frames * itemsize * sigsize
@@ -220,12 +221,12 @@ class DMDataSet(DataSet):
         native_sig_shape, native_dtype = executor.run_function(self._get_sig_shape_and_native_dtype)
         if self._sig_shape is None:
             self._sig_shape = tuple(native_sig_shape)
-        elif int(np.prod(self._sig_shape)) != int(np.prod(native_sig_shape)):
+        elif int(prod(self._sig_shape)) != int(prod(native_sig_shape)):
             raise DataSetException(
-                "sig_shape must be of size: %s" % int(np.prod(native_sig_shape))
+                "sig_shape must be of size: %s" % int(prod(native_sig_shape))
             )
         shape = self._nav_shape + self._sig_shape
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self.get_sync_offset_info()
         self._meta = DataSetMeta(
             shape=Shape(shape, sig_dims=len(self._sig_shape)),

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -4,6 +4,7 @@ import warnings
 import defusedxml.ElementTree as ET
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.common import Shape
 from libertem.web.messages import MessageConverter
 from .base import DataSet, DataSetException, DataSetMeta, BasePartition, IOBackend
@@ -162,7 +163,7 @@ class EMPADDataSet(DataSet):
         self._image_count = int(
             self._filesize / (
                 int(np.dtype("float32").itemsize) * int(
-                    np.prod(EMPAD_DETECTOR_SIZE_RAW, dtype=np.int64)
+                    prod(EMPAD_DETECTOR_SIZE_RAW)
                 )
             )
         )
@@ -172,14 +173,14 @@ class EMPADDataSet(DataSet):
             raise ValueError(
                     "either nav_shape needs to be passed, or path needs to point to the .xml file"
                 )
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         if nav_shape_from_XML:
-            self._image_count = int(np.prod(nav_shape_from_XML))
+            self._image_count = int(prod(nav_shape_from_XML))
         if self._sig_shape is None:
             self._sig_shape = EMPAD_DETECTOR_SIZE
-        elif int(np.prod(self._sig_shape)) != int(np.prod(EMPAD_DETECTOR_SIZE)):
+        elif int(prod(self._sig_shape)) != int(prod(EMPAD_DETECTOR_SIZE)):
             raise DataSetException(
-                "sig_shape must be of size: %s" % int(np.prod(EMPAD_DETECTOR_SIZE))
+                "sig_shape must be of size: %s" % int(prod(EMPAD_DETECTOR_SIZE))
             )
         self._sync_offset_info = self.get_sync_offset_info()
         self._meta = DataSetMeta(

--- a/src/libertem/io/dataset/frms6.py
+++ b/src/libertem/io/dataset/frms6.py
@@ -12,6 +12,7 @@ import scipy.io as sio
 import numpy as np
 import numba
 
+from libertem.common.math import prod
 from libertem.corrections import CorrectionSet
 from libertem.common import Shape, Slice
 from libertem.web.messages import MessageConverter
@@ -477,11 +478,11 @@ class FRMS6DataSet(DataSet):
             self._nav_shape = tuple(hdr['stemimagesize'])
         if self._sig_shape is None:
             self._sig_shape = frame_size
-        elif int(np.prod(self._sig_shape)) != int(np.prod(frame_size)):
+        elif int(prod(self._sig_shape)) != int(prod(frame_size)):
             raise DataSetException(
-                "sig_shape must be of size: %s" % int(np.prod(frame_size))
+                "sig_shape must be of size: %s" % int(prod(frame_size))
             )
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self.get_sync_offset_info()
 
         if self._enable_offset_correction:
@@ -512,7 +513,7 @@ class FRMS6DataSet(DataSet):
             hdr = executor.run_function(_read_dataset_hdr, hdr_filename)
             bin_factor = hdr['readoutmode']['bin']
             nav_shape = tuple(hdr['stemimagesize'])
-            image_count = int(np.prod(nav_shape))
+            image_count = int(prod(nav_shape))
             sig_shape = executor.run_function(_get_sig_shape, path, bin_factor)
         except Exception:
             return False

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -6,6 +6,7 @@ import time
 import numpy as np
 import h5py
 
+from libertem.common.math import prod
 from libertem.common import Slice, Shape
 from libertem.common.buffers import zeros_aligned
 from libertem.corrections import CorrectionSet
@@ -88,7 +89,7 @@ def _have_contig_chunks(chunks, ds_shape):
     False
     """
     # In other terms:
-    # There exists an index `i` such that `np.prod(chunks[:i]) == 1` and
+    # There exists an index `i` such that `prod(chunks[:i]) == 1` and
     # chunks[i+1:] == ds_shape[i+1:], limited to the nav part of chunks and ds_shape
     #
     nav_shape = tuple(ds_shape.nav)
@@ -97,7 +98,7 @@ def _have_contig_chunks(chunks, ds_shape):
 
     for i in range(nav_dims):
         left = chunks_nav[:i]
-        left_prod = np.prod(left, dtype=np.uint64)
+        left_prod = prod(left)
         if left_prod == 1 and chunks_nav[i + 1:] == nav_shape[i + 1:]:
             return True
     return False
@@ -626,7 +627,7 @@ class H5Partition(Partition):
             # switch to full frames:
             if any(t > c for t, c in zip(sig_ts, sig_chunks)):
                 # try to keep total tileshape size:
-                tileshape_size = np.prod(tileshape, dtype=np.int64)
+                tileshape_size = prod(tileshape)
                 depth = max(1, tileshape_size // self.shape.sig.size)
                 return (depth,) + self.shape.sig
             else:

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -11,6 +11,7 @@ import numba
 from numba.typed import List
 from ncempy.io import dm
 
+from libertem.common.math import prod
 from libertem.common.buffers import zeros_aligned
 from libertem.common import Shape
 from libertem.web.messages import MessageConverter
@@ -764,11 +765,11 @@ class K2ISDataSet(DataSet):
         self._set_skip_frames_and_nav_shape()
         if self._sig_shape is None:
             self._sig_shape = (SECTOR_SIZE[0], NUM_SECTORS * SECTOR_SIZE[1])
-        elif int(np.prod(self._sig_shape)) != int(np.prod(
+        elif int(prod(self._sig_shape)) != int(prod(
                     (SECTOR_SIZE[0], NUM_SECTORS * SECTOR_SIZE[1])
                 )):
             raise DataSetException(
-                "sig_shape must be of size: %s" % int(np.prod(
+                "sig_shape must be of size: %s" % int(prod(
                     (SECTOR_SIZE[0], NUM_SECTORS * SECTOR_SIZE[1])
                 ))
             )
@@ -813,7 +814,7 @@ class K2ISDataSet(DataSet):
         self._native_sync_offset = self._image_count - self._num_frames_w_shutter_active_flag_set
         if self._user_sync_offset is None:
             self._user_sync_offset = self._native_sync_offset
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self._get_sync_offset_info()
         if not self._is_time_series:
             if self._user_sync_offset == self._native_sync_offset:

--- a/src/libertem/io/dataset/memory.py
+++ b/src/libertem/io/dataset/memory.py
@@ -4,6 +4,7 @@ import logging
 import psutil
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.web.messages import MessageConverter
 from libertem.io.dataset.base import (
     FileSet, BasePartition, DataSet, DataSetMeta, TilingScheme,
@@ -218,8 +219,8 @@ class MemoryDataSet(DataSet):
         # if tileshape is None:
         #     sig_shape = data.shape[-sig_dims:]
         #     target = 2**20
-        #     framesize = np.prod(sig_shape)
-        #     framecount = max(1, min(np.prod(data.shape[:-sig_dims]), int(target / framesize)))
+        #     framesize = prod(sig_shape)
+        #     framecount = max(1, min(prod(data.shape[:-sig_dims]), int(target / framesize)))
         #     tileshape = (framecount, ) + sig_shape
         self.data = data
         self._base_shape = base_shape
@@ -238,7 +239,7 @@ class MemoryDataSet(DataSet):
         self._check_cast = check_cast
         self._tiledelay = tiledelay
         self._force_need_decode = force_need_decode
-        self._image_count = int(np.prod(self._nav_shape))
+        self._image_count = int(prod(self._nav_shape))
         self._shape = Shape(
             tuple(self._nav_shape) + tuple(self._sig_shape), sig_dims=self.sig_dims
         )
@@ -247,7 +248,7 @@ class MemoryDataSet(DataSet):
         else:
             assert len(tileshape) == self.sig_dims + 1
             self.tileshape = Shape(tileshape, sig_dims=self.sig_dims)
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self.get_sync_offset_info()
         self._meta = DataSetMeta(
             shape=self._shape,

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -8,6 +8,7 @@ import warnings
 import numba
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.common import Shape
 from libertem.io.dataset.base.file import OffsetsSizes
 from libertem.web.messages import MessageConverter
@@ -561,9 +562,9 @@ class MIBDataSet(DataSet):
             self._nav_shape = nav_shape_from_hdr(hdr)
         if self._sig_shape is None:
             self._sig_shape = first_file.fields['image_size']
-        elif int(np.prod(self._sig_shape)) != int(np.prod(first_file.fields['image_size'])):
+        elif int(prod(self._sig_shape)) != int(prod(first_file.fields['image_size'])):
             raise DataSetException(
-                "sig_shape must be of size: %s" % int(np.prod(first_file.fields['image_size']))
+                "sig_shape must be of size: %s" % int(prod(first_file.fields['image_size']))
             )
         self._sig_dims = len(self._sig_shape)
         shape = Shape(self._nav_shape + self._sig_shape, sig_dims=self._sig_dims)
@@ -576,7 +577,7 @@ class MIBDataSet(DataSet):
         self._files_sorted = list(sorted(self._files(),
                                          key=lambda f: f.fields['sequence_first_image']))
         self._image_count = self._num_images()
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self.get_sync_offset_info()
         self._meta = DataSetMeta(
             shape=shape,

--- a/src/libertem/io/dataset/mrc.py
+++ b/src/libertem/io/dataset/mrc.py
@@ -1,9 +1,9 @@
 import os
 import logging
 
-import numpy as np
 from ncempy.io.mrc import fileMRC
 
+from libertem.common.math import prod
 from libertem.common import Shape
 from libertem.web.messages import MessageConverter
 from .base import DataSet, FileSet, BasePartition, DataSetException, DataSetMeta, File
@@ -144,9 +144,9 @@ class MRCDataSet(DataSet):
         )
         if self._sig_shape is None:
             self._sig_shape = native_sig_shape
-        elif int(np.prod(self._sig_shape)) != int(np.prod(native_sig_shape)):
+        elif int(prod(self._sig_shape)) != int(prod(native_sig_shape)):
             raise DataSetException(
-                "sig_shape must be of size: %s" % int(np.prod(native_sig_shape))
+                "sig_shape must be of size: %s" % int(prod(native_sig_shape))
             )
 
         self._sig_dims = len(self._sig_shape)

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -2,6 +2,7 @@ import os
 import warnings
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.common import Shape
 from libertem.web.messages import MessageConverter
 from .base import (
@@ -158,7 +159,7 @@ class RawFileDataSet(DataSet):
 
     def initialize(self, executor):
         self._filesize = executor.run_function(self._get_filesize)
-        if int(np.prod(self._sig_shape)) > int(self._filesize / np.dtype(self._dtype).itemsize):
+        if int(prod(self._sig_shape)) > int(self._filesize / np.dtype(self._dtype).itemsize):
             raise DataSetException(
                 "sig_shape must be less than size: %s" % (
                     int(self._filesize / np.dtype(self._dtype).itemsize)
@@ -166,10 +167,10 @@ class RawFileDataSet(DataSet):
             )
         self._image_count = int(
             self._filesize / (
-                np.dtype(self._dtype).itemsize * np.prod(self._sig_shape, dtype=np.int64)
+                np.dtype(self._dtype).itemsize * prod(self._sig_shape)
             )
         )
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self.get_sync_offset_info()
         shape = Shape(self._nav_shape + self._sig_shape, sig_dims=self._sig_dims)
         self._meta = DataSetMeta(

--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -36,6 +36,7 @@ import numpy as np
 import sparse
 from ncempy.io.mrc import mrcReader
 
+from libertem.common.math import prod
 from libertem.common import Shape
 from libertem.web.messages import MessageConverter
 from libertem.io.dataset.base import (
@@ -512,12 +513,12 @@ class SEQDataSet(DataSet):
 
         if self._sig_shape is None:
             self._sig_shape = tuple((header['height'], header['width']))
-        elif int(np.prod(self._sig_shape)) != (header['height'] * header['width']):
+        elif int(prod(self._sig_shape)) != (header['height'] * header['width']):
             raise DataSetException(
                 "sig_shape must be of size: %s" % (header['height'] * header['width'])
             )
 
-        self._nav_shape_product = int(np.prod(self._nav_shape))
+        self._nav_shape_product = int(prod(self._nav_shape))
         self._sync_offset_info = self.get_sync_offset_info()
         shape = Shape(self._nav_shape + self._sig_shape, sig_dims=len(self._sig_shape))
 

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -6,6 +6,7 @@ import contextlib
 import numpy as np
 from ncempy.io.ser import fileSER
 
+from libertem.common.math import prod
 from libertem.common import Shape, Slice
 from libertem.web.messages import MessageConverter
 from .base import (
@@ -151,11 +152,11 @@ class SERDataSet(DataSet):
                 self._nav_shape = nav_dims
             if self._sig_shape is None:
                 self._sig_shape = tuple(data.shape)
-            elif int(np.prod(self._sig_shape)) != int(np.prod(data.shape)):
+            elif int(prod(self._sig_shape)) != int(prod(data.shape)):
                 raise DataSetException(
-                    "sig_shape must be of size: %s" % int(np.prod(data.shape))
+                    "sig_shape must be of size: %s" % int(prod(data.shape))
                 )
-            self._nav_shape_product = int(np.prod(self._nav_shape))
+            self._nav_shape_product = int(prod(self._nav_shape))
             self._sync_offset_info = self.get_sync_offset_info()
             self._shape = Shape(self._nav_shape + self._sig_shape, sig_dims=len(self._sig_shape))
             self._meta = DataSetMeta(
@@ -193,7 +194,7 @@ class SERDataSet(DataSet):
                     "sig_shape": tuple(ds.shape.sig),
                 },
                 "info": {
-                    "image_count": int(np.prod(ds.shape.nav)),
+                    "image_count": int(prod(ds.shape.nav)),
                     "native_sig_shape": tuple(ds.shape.sig),
                 }
             }

--- a/src/libertem/io/utils.py
+++ b/src/libertem/io/utils.py
@@ -1,5 +1,5 @@
-import numpy as np
 from libertem.common import Shape
+from libertem.common.math import prod
 
 try:
     import pwd
@@ -38,7 +38,7 @@ def get_partition_shape(dataset_shape: Shape, target_size_items: int, min_num: i
 
     for dim in reversed(dataset_shape.nav):
         proposed_shape = (dim,) + current_p_shape
-        proposed_size = np.prod(proposed_shape, dtype=np.int64) * sig_size
+        proposed_size = prod(proposed_shape) * sig_size
         if proposed_size <= target_size_items:
             current_p_shape = proposed_shape
         else:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -21,6 +21,7 @@ from libertem.common.buffers import (
     BufferKind, BufferUse, BufferLocation,
 )
 from libertem.common import Shape, Slice
+from libertem.common.math import prod
 from libertem.io.dataset.base import (
     TilingScheme, Negotiator, Partition, DataSet, get_coordinates
 )
@@ -1669,7 +1670,7 @@ class UDFRunner:
             cloudpickle.loads(cloudpickle.dumps(tasks))
 
     def _check_preconditions(self, dataset: DataSet, roi: Optional[np.ndarray]) -> None:
-        if roi is not None and np.product(roi.shape) != np.product(dataset.shape.nav):
+        if roi is not None and prod(roi.shape) != prod(dataset.shape.nav):
             raise ValueError(
                 "roi: incompatible shapes: {} (roi) vs {} (dataset)".format(
                     roi.shape, dataset.shape.nav

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1089,7 +1089,7 @@ class UDF(UDFBase):
         ...
         >>> # for each frame, provide three values from a sequential series:
         >>> aux1 = MyUDF.aux_data(
-        ...     data=np.arange(prod(dataset.shape.nav) * 3, dtype=np.float32),
+        ...     data=np.arange(np.prod(dataset.shape.nav) * 3, dtype=np.float32),
         ...     kind="nav", extra_shape=(3,), dtype="float32"
         ... )
         >>> udf = MyUDF(aux_data=aux1)

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import cloudpickle
 import numpy as np
+
 from libertem.io.dataset.base.tiling import DataTile
 
 from libertem.warnings import UseDiscouragedWarning
@@ -1088,7 +1089,7 @@ class UDF(UDFBase):
         ...
         >>> # for each frame, provide three values from a sequential series:
         >>> aux1 = MyUDF.aux_data(
-        ...     data=np.arange(np.prod(dataset.shape.nav) * 3, dtype=np.float32),
+        ...     data=np.arange(prod(dataset.shape.nav) * 3, dtype=np.float32),
         ...     kind="nav", extra_shape=(3,), dtype="float32"
         ... )
         >>> udf = MyUDF(aux_data=aux1)

--- a/src/libertem/udf/holography.py
+++ b/src/libertem/udf/holography.py
@@ -25,6 +25,7 @@
 
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.udf import UDF
 
 
@@ -198,14 +199,14 @@ class HoloReconstructUDF(UDF):
         aperture = self.task_data.aperture
         slice_fft = self.task_data.slice
 
-        fft_frame = self.xp.fft.fft2(frame) / np.prod(frame_size)
+        fft_frame = self.xp.fft.fft2(frame) / prod(frame_size)
         fft_frame = self.xp.roll(fft_frame, sb_pos, axis=(0, 1))
 
         fft_frame = self.xp.fft.fftshift(self.xp.fft.fftshift(fft_frame)[slice_fft])
 
         fft_frame = fft_frame * aperture
 
-        wav = self.xp.fft.ifft2(fft_frame) * np.prod(frame_size)
+        wav = self.xp.fft.ifft2(fft_frame) * prod(frame_size)
         # FIXME check if result buffer with where='device' and export is faster
         # than exporting frame by frame, as implemented now.
         if self.meta.device_class == 'cuda':

--- a/src/libertem/udf/raw.py
+++ b/src/libertem/udf/raw.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 
+from libertem.common.math import prod
 from libertem.udf import UDF
 
 
@@ -30,9 +31,9 @@ class PickUDF(UDF):
         if self.meta.roi is not None:
             navsize = np.count_nonzero(self.meta.roi)
         else:
-            navsize = np.prod(self.meta.dataset_shape.nav, dtype=np.int64)
+            navsize = prod(self.meta.dataset_shape.nav)
         warn_limit = 2**28
-        loaded_size = np.prod(sigshape, dtype=np.int64) * navsize * np.dtype(dtype).itemsize
+        loaded_size = prod(sigshape) * navsize * np.dtype(dtype).itemsize
         if loaded_size > warn_limit:
             log.warning("PickUDF is loading %s bytes, exceeding warning limit %s. "
                 "Consider using or implementing an UDF to process data on the worker "

--- a/src/libertem/utils/generate.py
+++ b/src/libertem/utils/generate.py
@@ -1,5 +1,7 @@
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter
+
+from libertem.common.math import prod
 from libertem.utils import make_cartesian, make_polar, frame_peaks
 import libertem.masks as m
 
@@ -118,7 +120,7 @@ def hologram_frame(amp, phi,
 
 def gradient_data(nav_dims, sig_dims):
     data = np.linspace(
-        start=5, stop=30, num=np.prod(nav_dims) * np.prod(sig_dims), dtype=np.float32
+        start=5, stop=30, num=prod(nav_dims) * prod(sig_dims), dtype=np.float32
     )
     return data.reshape(nav_dims + sig_dims)
 

--- a/tests/common/test_math.py
+++ b/tests/common/test_math.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from libertem.common.math import prod
+from libertem.common.shape import Shape
+
+
+@pytest.mark.parametrize(
+    ('sequence', 'ref', 'typ'), [
+        ([], 1, int),
+        (np.array([]), 1, int),
+        ((1, 2, 3), 6, int),
+        ((-11, 2, 3), -66, int),
+        ((1., 2, False), 0, ValueError),
+        (np.array((1., 1+2j, 1), dtype=np.complex128), 1, ValueError),
+        ((2**32, 2**32, 2**32), 2**96, int),
+        (np.array((2**62, 2**62, 2**62), dtype=np.int64), 2**(3*62), int),
+        (Shape((1, 2, 3), sig_dims=1).nav, 2, int)
+    ]
+)
+def test_prod(sequence, ref, typ):
+    if typ is int:
+        res = prod(sequence)
+        assert res == ref
+        assert isinstance(res, typ)
+    else:
+        with pytest.raises(typ):
+            res = prod(sequence)


### PR DESCRIPTION
Avoids integer overflows in size calculations

Closes #846, see there for more detail

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
