### PR TITLE
Move to Mac OS X 10.15 for Python 3.6 tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -236,7 +236,7 @@ stages:
           Python36:
             python.version: '3.6'
             TOXENV: 'py36'
-            imageName: 'macos-10.14'
+            imageName: 'macos-10.15'
           Python37:
             python.version: '3.7'
             TOXENV: 'py37'


### PR DESCRIPTION
See announcement here:

https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/

Mac OS X 10.14 will soon be dropped from Azure Pipelines, and 10.15
seems to be the last image that supports Python 3.6

See toolset definitions here:

https://github.com/actions/virtual-environments/tree/main/images/macos/toolsets

I guess once Python 3.6 is dropped completely, we could either drop
support on Mac OS, or install via miniconda (probably slow...)

## Contributor Checklist:

* [N/A] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
