### PR TITLE
bqp updates

### DIFF
--- a/src/libertem/viz/bqp.py
+++ b/src/libertem/viz/bqp.py
@@ -109,8 +109,12 @@ class BQLive2DPlot(Live2DPlot):
         dtype = np.result_type(self.data, np.int8)
         # Map on dtype that supports subtraction
         valid_data = self.data[damage].astype(dtype)
-        mmin = valid_data.min()
-        mmax = valid_data.max()
+        if valid_data.size > 0:
+            mmin = valid_data.min()
+            mmax = valid_data.max()
+        else:
+            mmin = 1
+            mmax = 1 + 1e-12
         delta = mmax - mmin
         if delta <= 0:
             delta = 1

--- a/src/libertem/viz/bqp.py
+++ b/src/libertem/viz/bqp.py
@@ -91,15 +91,18 @@ class BQLive2DPlot(Live2DPlot):
             title=self.title
         )
 
+        color_scale = ColorScale(min=0, max=1)
+
         scales_image = {'x': scale_x,
                         'y': scale_y,
-                        'image': ColorScale(min=0, max=1)}
+                        'image': color_scale}
 
         dtype = np.result_type(self.data, np.int8)
         image = ImageGL(image=self.data.astype(dtype), scales=scales_image)
         figure.marks = (image,)
         self.figure = figure
         self.image = image
+        self.color_scale = color_scale
 
     def display(self):
         from IPython.display import display

--- a/tests/viz/test_bqp.py
+++ b/tests/viz/test_bqp.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from unittest import mock
 
@@ -5,6 +6,7 @@ import IPython
 
 from libertem.viz.bqp import BQLive2DPlot
 from libertem.udf.sum import SumUDF
+from libertem.udf.sumsigudf import SumSigUDF
 
 
 def test_bqp_smoke(monkeypatch, lt_ctx, default_raw):
@@ -14,3 +16,17 @@ def test_bqp_smoke(monkeypatch, lt_ctx, default_raw):
     monkeypatch.setattr(lt_ctx, 'plot_class', BQLive2DPlot)
     lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=True)
     IPython.display.display.assert_called()
+
+
+def test_empty(monkeypatch, lt_ctx, default_raw):
+    pytest.importorskip("bqplot")
+    udf = SumSigUDF()
+    monkeypatch.setattr(IPython.display, 'display', mock.MagicMock())
+    monkeypatch.setattr(lt_ctx, 'plot_class', BQLive2DPlot)
+
+    def extract(udf_result, damage):
+        return udf_result['intensity'].data, np.zeros_like(damage)
+
+    plot = BQLive2DPlot(dataset=default_raw, udf=udf, channel=extract)
+
+    lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=[plot])

--- a/tests/viz/test_gms.py
+++ b/tests/viz/test_gms.py
@@ -26,7 +26,6 @@ def test_gms_nodisplay(monkeypatch, lt_ctx, default_raw):
 
 
 def test_empty(monkeypatch, lt_ctx, default_raw):
-    pytest.importorskip("bqplot")
     udf = SumSigUDF()
     monkeypatch.setitem(sys.modules, 'DigitalMicrograph', mock.MagicMock())
     monkeypatch.setattr(lt_ctx, 'plot_class', GMSLive2DPlot)

--- a/tests/viz/test_gms.py
+++ b/tests/viz/test_gms.py
@@ -1,10 +1,12 @@
 from unittest import mock
 import sys
 
+import numpy as np
 import pytest
 
 from libertem.viz.gms import GMSLive2DPlot
 from libertem.udf.sum import SumUDF
+from libertem.udf.sumsigudf import SumSigUDF
 
 
 def test_gms_smoke(monkeypatch, lt_ctx, default_raw):
@@ -21,3 +23,17 @@ def test_gms_nodisplay(monkeypatch, lt_ctx, default_raw):
     plots = [GMSLive2DPlot(dataset=default_raw, udf=udf)]
     with pytest.warns(UserWarning, match="Plot is not displayed, not plotting."):
         lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=plots)
+
+
+def test_empty(monkeypatch, lt_ctx, default_raw):
+    pytest.importorskip("bqplot")
+    udf = SumSigUDF()
+    monkeypatch.setitem(sys.modules, 'DigitalMicrograph', mock.MagicMock())
+    monkeypatch.setattr(lt_ctx, 'plot_class', GMSLive2DPlot)
+
+    def extract(udf_result, damage):
+        return udf_result['intensity'].data, np.zeros_like(damage)
+
+    plot = GMSLive2DPlot(dataset=default_raw, udf=udf, channel=extract)
+
+    lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=[plot])

--- a/tests/viz/test_mpl.py
+++ b/tests/viz/test_mpl.py
@@ -34,7 +34,6 @@ def test_mpl_nodisplay(monkeypatch, lt_ctx, default_raw):
 
 
 def test_empty(monkeypatch, lt_ctx, default_raw):
-    pytest.importorskip("bqplot")
     udf = SumSigUDF()
     monkeypatch.setattr(
         matplotlib.pyplot,

--- a/tests/viz/test_mpl.py
+++ b/tests/viz/test_mpl.py
@@ -1,10 +1,12 @@
 from unittest import mock
 
+import numpy as np
 import pytest
 import matplotlib.pyplot
 
 from libertem.viz.mpl import MPLLive2DPlot
 from libertem.udf.sum import SumUDF
+from libertem.udf.sumsigudf import SumSigUDF
 
 
 def test_mpl_smoke(monkeypatch, lt_ctx, default_raw):
@@ -29,3 +31,21 @@ def test_mpl_nodisplay(monkeypatch, lt_ctx, default_raw):
     plots = [MPLLive2DPlot(dataset=default_raw, udf=udf)]
     with pytest.warns(UserWarning, match="Plot is not displayed, not plotting."):
         lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=plots)
+
+
+def test_empty(monkeypatch, lt_ctx, default_raw):
+    pytest.importorskip("bqplot")
+    udf = SumSigUDF()
+    monkeypatch.setattr(
+        matplotlib.pyplot,
+        'subplots',
+        mock.MagicMock(return_value=(mock.MagicMock(), mock.MagicMock()))
+    )
+    monkeypatch.setattr(lt_ctx, 'plot_class', MPLLive2DPlot)
+
+    def extract(udf_result, damage):
+        return udf_result['intensity'].data, np.zeros_like(damage)
+
+    plot = MPLLive2DPlot(dataset=default_raw, udf=udf, channel=extract)
+
+    lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=[plot])


### PR DESCRIPTION
Extracted from #1025:

- Resilience against empty damage region in plotting
- Allow manipulation of color scales from outside

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
