### PR TITLE
BufferWrapper: partitions w/ sig slicing

### DIFF
--- a/src/libertem/common/math.py
+++ b/src/libertem/common/math.py
@@ -14,7 +14,7 @@ ProdAccepted = Union[
 ]
 
 
-def prod(iterable: Iterable[ProdAccepted]):
+def prod(iterable_or_value: Union[Iterable[ProdAccepted], ProdAccepted]):
     '''
     Safe product for large integer size calculations.
 
@@ -24,7 +24,10 @@ def prod(iterable: Iterable[ProdAccepted]):
     '''
     result = 1
 
-    for item in iterable:
+    if not isinstance(iterable_or_value, Iterable):
+        return iterable_or_value
+
+    for item in iterable_or_value:
         if isinstance(item, _prod_accepted):
             result *= int(item)
         else:

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -1,12 +1,16 @@
 import logging
+import typing
 
 import numba
 from numba.typed import List as NumbaList
 import numpy as np
 
 from libertem.common.numba import numba_ravel_multi_index_single as _ravel_multi_index, cached_njit
+from libertem.common.slice import Slice
 from .roi import _roi_to_indices
 
+if typing.TYPE_CHECKING:
+    import numpy.typing as nt
 
 log = logging.getLogger(__name__)
 
@@ -264,7 +268,10 @@ default_get_read_ranges = make_get_read_ranges()
 
 
 class DataTile(np.ndarray):
-    def __new__(cls, input_array, tile_slice, scheme_idx):
+    tile_slice: Slice
+    scheme_idx: int
+
+    def __new__(cls, input_array: "nt.ArrayLike", tile_slice: Slice, scheme_idx: int):
         obj = np.asarray(input_array).view(cls)
         obj.tile_slice = tile_slice
         obj.scheme_idx = scheme_idx

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -197,3 +197,8 @@ class ApplyMasksUDF(UDF):
             result = flat_data @ masks
         # '+' is the correct merge for dot product
         self.results.intensity[:] += result
+
+    def merge(self, dest, src):
+        # if partitions are sliced in sig dimensions, we have to add the
+        # individual partition results instead of replacing them:
+        dest.intensity += src.intensity

--- a/src/libertem/udf/sumsigudf.py
+++ b/src/libertem/udf/sumsigudf.py
@@ -27,6 +27,9 @@ class SumSigUDF(UDF):
         ""
         self.results.intensity[:] += np.sum(tile, axis=tuple(range(1, len(tile.shape))))
 
+    def merge(self, dest, src):
+        dest.intensity += src.intensity
+
 
 def run_sumsig(ctx, dataset):
     udf = SumSigUDF()

--- a/tests/common/test_bufferwrapper.py
+++ b/tests/common/test_bufferwrapper.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 
+from libertem.io.dataset.base import Partition
 from libertem.io.dataset.memory import (
     MemPartition, MemoryDataSet, FileSet, MemoryFile
 )
@@ -9,6 +10,7 @@ from libertem.common.buffers import (
 )
 from libertem.common import Shape, Slice
 from libertem.udf.base import UDF
+from libertem.udf.base import UDFData
 
 from utils import _mk_random
 
@@ -28,7 +30,7 @@ def test_new_for_partition():
 
     for idx, partition in enumerate(dataset.get_partitions()):
         print("partition number", idx)
-        new_buf = buf.new_for_partition(partition, roi=roi)
+        new_buf = buf.new_for_partition(partition_slice=partition.slice, roi=roi)
         ps = partition.slice.get(nav_only=True)
         roi_part = roi.reshape(-1)[ps]
 
@@ -194,3 +196,300 @@ def test_buffer_slices(lt_ctx, tileshape, udf_cls):
     with pytest.raises(Exception) as exc_info:
         _ = lt_ctx.run_udf(dataset=bad_ds, udf=udf_cls())
     assert exc_info.errisinstance((AssertionError, IndexError))
+
+
+class PlaceholderPartition(Partition):
+    def __init__(
+        self, meta, partition_slice, tiles, start_frame: int, num_frames: int,
+    ):
+        self._tiles = tiles
+        self._start_frame = start_frame
+        self._num_frames = num_frames
+        super().__init__(
+            meta=meta,
+            partition_slice=partition_slice,
+            io_backend=None,
+            decoder=None,
+        )
+
+    def get_tiles(self, tiling_scheme, dest_dtype=np.float32, roi=None):
+        assert roi is None
+
+        # FIXME: stop after processing `num_frames`
+        yield from self._tiles
+
+    def get_base_shape(self, roi):
+        return (930, 16)
+
+    def set_corrections(self, corrections):
+        self._corrections = corrections
+
+
+def test_sig_slicing():
+    from libertem.common import Shape, Slice
+    from libertem.udf.sum import SumUDF
+    from libertem.io.dataset.base import DataTile, DataSetMeta
+    from libertem.udf.base import UDFMeta
+    from libertem.executor.base import Environment
+
+    partition_slice = Slice(
+        origin=(0, 0, 256),
+        shape=Shape((4000, 1860, 256), sig_dims=2),
+    )
+
+    dataset_shape = Shape(
+        (4000, 1860, 2048), sig_dims=2,
+    )
+
+    dsmeta = DataSetMeta(
+        shape=dataset_shape,
+        raw_dtype=np.uint16,
+        image_count=4000,
+    )
+
+    partition = PlaceholderPartition(
+        meta=dsmeta,
+        partition_slice=partition_slice,
+        start_frame=0,
+        num_frames=4000,
+        tiles=[],
+    )
+
+    roi = None
+    corrections = None  # FIXME?
+    device_class = 'cpu'
+    dtype = np.uint16
+    env = Environment(threads_per_worker=2)
+
+    tile_slice = Slice(
+        origin=(0, 0, 480),
+        shape=Shape((1, 930, 16), sig_dims=2),
+    )
+    data = np.zeros((1, 930, 16), dtype=np.uint16)
+    tile = DataTile(
+        data,
+        tile_slice=tile_slice,
+        scheme_idx=30,
+    )
+
+    udf = SumUDF()
+
+    meta = UDFMeta(
+        partition_slice=partition.slice.adjust_for_roi(roi),
+        dataset_shape=dataset_shape,
+        roi=roi,
+        dataset_dtype=partition.dtype,
+        input_dtype=dtype,
+        tiling_scheme=None,
+        corrections=corrections,
+        device_class=device_class,
+        threads_per_worker=env.threads_per_worker,
+    )
+
+    udf.set_meta(meta)
+    udf.init_result_buffers()
+    udf.allocate_for_part(partition_slice=partition.slice, roi=None)
+    udf.init_task_data()
+
+    udf.set_contiguous_views_for_tile(
+        partition_slice=partition.slice,
+        tile=tile,
+    )
+    udf.process_tile(tile)
+
+
+def test_sig_slicing_2():
+    from libertem.common import Shape, Slice
+    from libertem.io.dataset.base import DataTile, DataSetMeta
+
+    partition_slice = Slice(
+        origin=(0, 0, 256),
+        shape=Shape((4000, 1860, 256), sig_dims=2),
+    )
+
+    dataset_shape = Shape(
+        (4000, 1860, 2048), sig_dims=2,
+    )
+
+    dsmeta = DataSetMeta(
+        shape=dataset_shape,
+        raw_dtype=np.uint16,
+        image_count=4000,
+    )
+
+    partition = PlaceholderPartition(
+        meta=dsmeta,
+        partition_slice=partition_slice,
+        start_frame=0,
+        num_frames=4000,
+        tiles=[],
+    )
+
+    tile_slice = Slice(
+        origin=(0, 0, 480),
+        shape=Shape((1, 930, 16), sig_dims=2),
+    )
+    data = np.zeros((1, 930, 16), dtype=np.uint16)
+    tile = DataTile(
+        data,
+        tile_slice=tile_slice,
+        scheme_idx=30,
+    )
+    roi = None
+
+    buf = BufferWrapper(
+        kind='sig',
+        extra_shape=(),
+        dtype=np.uint16,
+        where=None,
+        use=None,
+    )
+    buf.set_shape_partition(partition.slice, roi)
+    buf.allocate(lib=None)
+    view = buf.get_contiguous_view_for_tile(partition.slice, tile)
+    assert view.size > 0
+
+
+def test_sig_slicing_views_for_partition():
+    from libertem.common import Shape, Slice
+    from libertem.io.dataset.base import DataSetMeta
+
+    partition_slice = Slice(
+        origin=(0, 0, 256),
+        shape=Shape((4000, 1860, 256), sig_dims=2),
+    )
+
+    dataset_shape = Shape(
+        (4000, 1860, 2048), sig_dims=2,
+    )
+
+    dsmeta = DataSetMeta(
+        shape=dataset_shape,
+        raw_dtype=np.uint16,
+        image_count=4000,
+    )
+
+    partition = PlaceholderPartition(
+        meta=dsmeta,
+        partition_slice=partition_slice,
+        start_frame=0,
+        num_frames=4000,
+        tiles=[],
+    )
+
+    roi = None
+
+    buf = BufferWrapper(
+        kind='sig',
+        extra_shape=(),
+        dtype=np.uint16,
+        where=None,
+        use=None,
+    )
+    buf.set_shape_ds(dataset_shape, roi)
+    buf.allocate(lib=None)
+    view_p = buf.get_view_for_partition(partition_slice=partition.slice)
+    view_p[:] = 1
+
+    # FIXME: this works for now, as the dataset parameter is not used yet. we
+    # may need to stub out the dataset, too, in the future
+    view_ds = buf.get_view_for_dataset(dataset=None)
+
+    assert np.allclose(view_ds[partition.slice.sig.get()], 1)
+
+    # the partition "left" of that is zero:
+    partition_slice_0 = Slice(
+        origin=(0, 0, 0),
+        shape=Shape((4000, 1860, 256), sig_dims=2),
+    )
+    assert np.allclose(view_ds[partition_slice_0.sig.get()], 0)
+
+    # actually, everything _but_ the give partition is 0:
+    view_roi = np.zeros(dataset_shape.sig, dtype=bool)
+    view_roi[partition.slice.sig.get()] = 1
+    assert np.allclose(view_ds[~view_roi], 0)
+
+
+def test_sig_slicing_views_for_partition_2():
+    from libertem.common import Shape, Slice
+    from libertem.io.dataset.base import DataSetMeta
+
+    partition_slice = Slice(
+        origin=(0, 0, 256),
+        shape=Shape((4000, 1860, 256), sig_dims=2),
+    )
+
+    dataset_shape = Shape(
+        (4000, 1860, 2048), sig_dims=2,
+    )
+
+    dsmeta = DataSetMeta(
+        shape=dataset_shape,
+        raw_dtype=np.uint16,
+        image_count=4000,
+    )
+
+    partition = PlaceholderPartition(
+        meta=dsmeta,
+        partition_slice=partition_slice,
+        start_frame=0,
+        num_frames=4000,
+        tiles=[],
+    )
+
+    roi = None
+
+    # we want to test merging of a partition into the dataset buffer, so we
+    # create two UDFData instances:
+    ud_ds = UDFData({
+        'buf': BufferWrapper(
+            kind='sig',
+            extra_shape=(),
+            dtype=np.uint16,
+            where=None,
+            use=None,
+        )
+    })
+    for k, buf in ud_ds._get_buffers():
+        buf.set_shape_ds(dataset_shape, roi)
+    for k, buf in ud_ds._get_buffers(filter_allocated=True):
+        buf.allocate()
+
+    # emulate what's happening in run_for_partition:
+    ud_p = UDFData({
+        'buf': BufferWrapper(
+            kind='sig',
+            extra_shape=(),
+            dtype=np.uint16,
+            where=None,
+            use=None,
+        )
+    })
+    for k, buf in ud_p._get_buffers():
+        buf.set_shape_partition(partition_slice=partition.slice, roi=roi)
+    for k, buf in ud_p._get_buffers(filter_allocated=True):
+        buf.allocate(lib=None)
+
+    # set the whole partition result to 1:
+    ud_p.buf[:] = 1
+
+    # and wrap up:
+    ud_p.clear_views()
+    ud_p.export()
+
+    # prepare ds result buffer:
+    ud_ds.set_view_for_partition(partition_slice=partition.slice)
+
+    # now, simulate a merge:
+    dest = ud_ds.get_proxy()
+    src = ud_p.get_proxy()
+    dest.buf[:] += src.buf
+
+    ud_p.clear_views()
+    ud_ds.clear_views()
+
+    # everything _but_ the give partition is 0:
+    view_roi = np.zeros(dataset_shape.sig, dtype=bool)
+    view_roi[partition.slice.sig.get()] = 1
+    assert np.allclose(ud_ds.buf[~view_roi], 0)
+    assert np.allclose(ud_ds.buf[view_roi], 1)

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -404,7 +404,7 @@ def test_udf_pickle(lt_ctx):
     pixelsum.set_backend("numpy")
     pixelsum.set_meta(meta)
     pixelsum.init_result_buffers()
-    pixelsum.allocate_for_part(partition, None)
+    pixelsum.allocate_for_part(partition.slice, None)
     pickle.loads(pickle.dumps(pixelsum))
 
 


### PR DESCRIPTION
Supersedes #1025.

Support partitions that don't contain whole signal elements / frames, but slice the signal dimension.

# TODO

- [ ] Tests for included UDFs with sig-slicing partitions
- [ ] Maybe updates for other included UDFs?
- [ ] Update UDF documentation

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
