### PR TITLE
Preload known HDF5 plugins automatically.

### DIFF
--- a/docs/source/changelog/misc/preload.rst
+++ b/docs/source/changelog/misc/preload.rst
@@ -1,0 +1,7 @@
+[Misc] Preloading
+=================
+
+* Start using :mod:`libertem.preload` again and import :code:`hdf5plugin` if
+  present so that users don't have to specify this common selection of HDF5
+  filters as preload themselves. (:pr:`1160`)
+  

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,7 @@ setup(
         'hdbscan': 'hdbscan',
         'cupy': 'cupy',
         'bqplot': ['bqplot', 'bqplot-image-gl', 'ipython'],
+        'hdf5plugin': 'hdf5plugin'
     },
     package_dir={"": "src"},
     packages=find_packages(where='src'),

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -79,17 +79,21 @@ def cluster_spec(
         cpu_spec['options']['preload'] = preload + (
             'from libertem.executor.dask import worker_setup; '
             + f'worker_setup(resource="CPU", device={cpu})',
+            'libertem.preload'
         )
         workers_spec[f'{name}-cpu-{cpu}'] = cpu_spec
 
     for service in range(num_service):
-        workers_spec[f'{name}-service-{service}'] = deepcopy(service_base_spec)
+        service_spec = deepcopy(service_base_spec)
+        service_spec['options']['preload'] = preload + ('libertem.preload',)
+        workers_spec[f'{name}-service-{service}'] = service_spec
 
     for cuda in cudas:
         cuda_spec = deepcopy(cuda_base_spec)
         cuda_spec['options']['preload'] = preload + (
             'from libertem.executor.dask import worker_setup; '
             + f'worker_setup(resource="CUDA", device={cuda})',
+            'libertem.preload'
         )
         workers_spec[f'{name}-cuda-{cuda}'] = cuda_spec
 

--- a/src/libertem/executor/inline.py
+++ b/src/libertem/executor/inline.py
@@ -22,6 +22,8 @@ class InlineJobExecutor(JobExecutor):
         allow one thread per CPU core
     """
     def __init__(self, debug=False, inline_threads=None, *args, **kwargs):
+        # Only import if actually instantiated, i.e. will likely be used
+        import libertem.preload  # noqa: 401
         self._debug = debug
         self._inline_threads = inline_threads
 

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -192,21 +192,32 @@ class H5DataSet(DataSet):
     Note
     ----
     If the HDF5 file to be loaded contains compressed data
-    using a custom compression filter (other than GZIP, LZF or SZIP)
-    the user must import the associated HDF5 filter library before
-    importing LiberTEM in their main script, for example the library
-    `hdf5plugin <https://github.com/silx-kit/hdf5plugin>`_.
+    using a custom compression filter (other than GZIP, LZF or SZIP),
+    the associated HDF5 filter library must be imported on the workers
+    before accessing the file. See the `h5py documentation
+    on filter pipelines
+    <https://docs.h5py.org/en/stable/high/dataset.html#filter-pipeline>`_
+    for more information.
 
-    For the web GUI or for running LiberTEM in a cluster with existing workers (e.g. by running
-    :code:`libertem-worker` or :code:`dask-worker` on nodes), it is recommended to add the
-    necessary imports as :code:`--preload` arguments to the launch command,
+    The the library `hdf5plugin <https://github.com/silx-kit/hdf5plugin>`_
+    is preloaded automatically if it is installed. Other filter libraries
+    may have to be specified for preloading by the user.
+
+    Preloads for a local :class:`~libertem.executor.dask.DaskJobExecutor` can be
+    specified through the :code:`preload` argument of either
+    :meth:`~libertem.executor.dask.DaskJobExecutor.make_local` or
+    :func:`libertem.executor.dask.cluster_spec`. For the
+    :class:`libertem.executor.inline.InlineJobExecutor`, the plugins
+    can simply be imported in the main script.
+
+    For the web GUI or for running LiberTEM in a cluster with existing workers
+    (e.g. by running
+    :code:`libertem-worker` or :code:`dask-worker` on nodes),
+    necessary imports can be specified as :code:`--preload` arguments to
+    the launch command,
     for example with :code:`libertem-server --preload hdf5plugin` resp.
     :code:`libertem-worker --preload hdf5plugin tcp://scheduler_ip:port`.
     :code:`--preload` can be specified multiple times.
-
-    See the `h5py documentation on filter pipelines
-    <https://docs.h5py.org/en/stable/high/dataset.html#filter-pipeline>`_ for
-    more information.
     """
     def __init__(self, path, ds_path=None, tileshape=None,
                  target_size=None, min_num_partitions=None, sig_dims=2, io_backend=None):

--- a/src/libertem/io/dataset/hdf5.py
+++ b/src/libertem/io/dataset/hdf5.py
@@ -199,7 +199,7 @@ class H5DataSet(DataSet):
     <https://docs.h5py.org/en/stable/high/dataset.html#filter-pipeline>`_
     for more information.
 
-    The the library `hdf5plugin <https://github.com/silx-kit/hdf5plugin>`_
+    The library `hdf5plugin <https://github.com/silx-kit/hdf5plugin>`_
     is preloaded automatically if it is installed. Other filter libraries
     may have to be specified for preloading by the user.
 

--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -198,7 +198,7 @@ def xml_binned_map_maker(xy_map_sizes):
 
 def xml_map_index_selector(used_y):
     """
-    returns the the bad pixel maps  index with the largest column count
+    returns the bad pixel maps  index with the largest column count
 
     Parameters
     ----------

--- a/src/libertem/preload.py
+++ b/src/libertem/preload.py
@@ -17,3 +17,8 @@ except ImportError:
     pass
 
 import libertem
+
+try:
+    import hdf5plugin
+except ImportError:
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps=
 extras=
     hdbscan
     bqplot
+    hdf5plugin
 setenv=
     # Using pytest in combination with tox on files that are part of the installed package
     # leads to collisions between the local source tree and the installed package when running tests.


### PR DESCRIPTION
Actually use libertem.preload, it got lost when libertem-worker
was established.
List of modules to try importing to be expanded!

Parts of this should also be ported to #1158

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
