### PR TITLE
Replace docker hub link with a public one

### DIFF
--- a/docs/source/changelog/misc/docker.rst
+++ b/docs/source/changelog/misc/docker.rst
@@ -2,5 +2,5 @@
 =============================
 
 * A `Docker image with a LiberTEM installation
-  <https://hub.docker.com/repository/docker/libertem/libertem>`_
+  <https://hub.docker.com/r/libertem/libertem/tags>`_
   is available on DockerHub now (:pr:`1144`, :issue:`484`).

--- a/docs/source/deployment/clustercontainer.rst
+++ b/docs/source/deployment/clustercontainer.rst
@@ -3,7 +3,7 @@ Containers and clusters
 
 .. versionadded:: 0.9.0
     `LiberTEM repository on Docker Hub
-    <https://hub.docker.com/repository/docker/libertem/libertem>`_ with images
+    <https://hub.docker.com/r/libertem/libertem/tags>`_ with images
     for public use.
 
 .. note::
@@ -33,7 +33,7 @@ Containers
 ----------
 
 Docker images can be found in `the LiberTEM repository on Docker Hub
-<https://hub.docker.com/repository/docker/libertem/libertem>`_. LiberTEM is
+<https://hub.docker.com/r/libertem/libertem/tags>`_. LiberTEM is
 installed in a virtual environment in :code:`/venv/` in the Docker image. The
 executables :code:`libertem-server`, :code:`dask-scheduler` and
 :code:`libertem-worker` can be found in :code:`/venv/bin/`, consequently. The
@@ -60,7 +60,7 @@ Available versions
 The tag "latest" (default) points to the stable release with the highest version
 number, and "continuous" points to the current master. Version tags for all
 stable releases are available as well. See `the LiberTEM repository on Docker
-Hub <https://hub.docker.com/repository/docker/libertem/libertem>`_ for details.
+Hub <https://hub.docker.com/r/libertem/libertem/tags>`_ for details.
 
 Updating
 ........

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -222,7 +222,7 @@ Docker and Singularity
 .. versionadded:: 0.9.0
 
 A `Docker image with a LiberTEM installation
-<https://hub.docker.com/repository/docker/libertem/libertem>`_ is available on
+<https://hub.docker.com/r/libertem/libertem/tags>`_ is available on
 Docker hub. See :ref:`containers` for more details.
 
 Troubleshooting


### PR DESCRIPTION
The old one requires a login and might only work for members of the LiberTEM org on Docker Hub...

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
