### PR TITLE
ApplyMasksUDF: re-use Slice objects from TilingScheme

### DIFF
--- a/src/libertem/io/dataset/base/dataset.py
+++ b/src/libertem/io/dataset/base/dataset.py
@@ -255,7 +255,9 @@ class DataSet:
     def get_base_shape(self, roi: Optional[np.ndarray]) -> Tuple[int, ...]:
         return (1,) + (1,) * (self.shape.sig.dims - 1) + (self.shape.sig[-1],)
 
-    def adjust_tileshape(self, tileshape: Tuple[int, ...], roi: Optional[np.ndarray]):
+    def adjust_tileshape(
+        self, tileshape: Tuple[int, ...], roi: Optional[np.ndarray]
+    ) -> Tuple[int, ...]:
         """
         Final veto of the DataSet in the tileshape negotiation process,
         make sure that corrections are taken into account!

--- a/src/libertem/io/dataset/base/tiling_scheme.py
+++ b/src/libertem/io/dataset/base/tiling_scheme.py
@@ -276,7 +276,7 @@ class Negotiator:
         # above, and we need to be careful not to break corrections with this,
         # and also fulfill requests of per-frame reading
         log.debug("tileshape before adjustment: %r", (tileshape,))
-        tileshape = dataset.adjust_tileshape(tileshape, roi=roi)
+        tileshape = tuple(dataset.adjust_tileshape(tileshape, roi=roi))
         log.debug("tileshape after adjustment: %r", (tileshape,))
 
         # if the veto generated a tileshape that is smaller than the full base shape,

--- a/src/libertem/io/dataset/memory.py
+++ b/src/libertem/io/dataset/memory.py
@@ -295,7 +295,7 @@ class MemoryDataSet(DataSet):
        if self.tileshape is not None:
            return tuple(self.tileshape)
        return super().adjust_tileshape(tileshape, roi)
- 
+
     def need_decode(self, read_dtype, roi, corrections):
         if self._force_need_decode:
             return True

--- a/src/libertem/io/dataset/memory.py
+++ b/src/libertem/io/dataset/memory.py
@@ -292,9 +292,9 @@ class MemoryDataSet(DataSet):
     def adjust_tileshape(
         self, tileshape: Tuple[int, ...], roi: Optional[np.ndarray],
     ) -> Tuple[int, ...]:
-       if self.tileshape is not None:
-           return tuple(self.tileshape)
-       return super().adjust_tileshape(tileshape, roi)
+        if self.tileshape is not None:
+            return tuple(self.tileshape)
+        return super().adjust_tileshape(tileshape, roi)
 
     def need_decode(self, read_dtype, roi, corrections):
         if self._force_need_decode:

--- a/src/libertem/io/dataset/memory.py
+++ b/src/libertem/io/dataset/memory.py
@@ -1,5 +1,6 @@
 import time
 import logging
+from typing import Optional, Tuple
 
 import psutil
 import numpy as np
@@ -282,10 +283,19 @@ class MemoryDataSet(DataSet):
         return self.num_partitions
 
     def get_base_shape(self, roi):
+        if self.tileshape is not None:
+            return self.tileshape
         if self._base_shape is not None:
             return self._base_shape
         return super().get_base_shape(roi)
 
+    def adjust_tileshape(
+        self, tileshape: Tuple[int, ...], roi: Optional[np.ndarray],
+    ) -> Tuple[int, ...]:
+       if self.tileshape is not None:
+           return tuple(self.tileshape)
+       return super().adjust_tileshape(tileshape, roi)
+ 
     def need_decode(self, read_dtype, roi, corrections):
         if self._force_need_decode:
             return True

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -175,7 +175,9 @@ class ApplyMasksUDF(UDF):
         flat_data = tile.reshape((tile.shape[0], -1))
         if self.task_data.use_torch:
             import torch
-            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=True)
+            masks = self.task_data.masks.get_for_idx(
+                self.meta.tiling_scheme, tile.scheme_idx, transpose=True
+            )
             # CuPy back-end disables torch in get_task_data
             # FIXME use GPU torch with CuPy array?
             result = torch.mm(
@@ -184,16 +186,22 @@ class ApplyMasksUDF(UDF):
             ).numpy()
         # Required due to https://github.com/cupy/cupy/issues/4072
         elif self.backend == 'cupy' and self.task_data.masks.use_sparse:
-            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=False)
+            masks = self.task_data.masks.get_for_idx(
+                self.meta.tiling_scheme, tile.scheme_idx, transpose=False
+            )
             result = masks.dot(flat_data.T).T
         # Required due to https://github.com/scipy/scipy/issues/13211
         elif (self.backend == 'numpy'
               and self.task_data.masks.use_sparse
               and 'scipy.sparse' in self.task_data.masks.use_sparse):
-            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=True)
+            masks = self.task_data.masks.get_for_idx(
+                self.meta.tiling_scheme, tile.scheme_idx, transpose=True
+            )
             result = rmatmul(flat_data, masks)
         else:
-            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=True)
+            masks = self.task_data.masks.get_for_idx(
+                self.meta.tiling_scheme, tile.scheme_idx, transpose=True
+            )
             result = flat_data @ masks
         # '+' is the correct merge for dot product
         self.results.intensity[:] += result

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -175,7 +175,7 @@ class ApplyMasksUDF(UDF):
         flat_data = tile.reshape((tile.shape[0], -1))
         if self.task_data.use_torch:
             import torch
-            masks = self.task_data.masks.get(self.meta.slice, transpose=True)
+            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=True)
             # CuPy back-end disables torch in get_task_data
             # FIXME use GPU torch with CuPy array?
             result = torch.mm(
@@ -184,16 +184,16 @@ class ApplyMasksUDF(UDF):
             ).numpy()
         # Required due to https://github.com/cupy/cupy/issues/4072
         elif self.backend == 'cupy' and self.task_data.masks.use_sparse:
-            masks = self.task_data.masks.get(self.meta.slice, transpose=False)
+            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=False)
             result = masks.dot(flat_data.T).T
         # Required due to https://github.com/scipy/scipy/issues/13211
         elif (self.backend == 'numpy'
               and self.task_data.masks.use_sparse
               and 'scipy.sparse' in self.task_data.masks.use_sparse):
-            masks = self.task_data.masks.get(self.meta.slice, transpose=True)
+            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=True)
             result = rmatmul(flat_data, masks)
         else:
-            masks = self.task_data.masks.get(self.meta.slice, transpose=True)
+            masks = self.task_data.masks.get_for_idx(self.meta.tiling_scheme, tile.scheme_idx, transpose=True)
             result = flat_data @ masks
         # '+' is the correct merge for dot product
         self.results.intensity[:] += result


### PR DESCRIPTION
Micro-optimization in the `ApplyMasksUDF`: directly re-use `Slice` objects from the `TilingScheme` instead of re-creating them using `discard_nav`. I noticed this when profiling something for #1159.

When using our usual test data, it is a bit hard to measure; even with the inline executor and multiple rounds, the numbers are not stable; I could cherry-pick a run that is faster by 500ms, or one that is exactly as fast as before - we still have some work to do here...

When running a test script on a large (~200GiB) test file, it can be measured more easily:

Before (sum/mean/min/max):

```
total: [75.06046856753528, 15.012093713507056, 14.906086668372154, 15.101721707731485]
```

After (sum/mean/min/max):

```
total: [73.61619642749429, 14.723239285498858, 14.58340313937515, 14.796591619960964]
```

And the small benchmark script I used:

<details>

```python
import time
import logging

import numpy as np

from libertem.api import Context
from libertem.udf.masks import ApplyMasksUDF


def main():
    logging.basicConfig(level=logging.INFO)
    ctx = Context()
    # ds = ctx.load("mib", path="/home/alex/source/upstream-libertem/benchmarks/io/data/some_prefix/MIB/20200518 165148/default.hdr")
    ds = ctx.load("k2is", path="/cachedata/alex/03_25V_.gtg")

    sig_shape = ds.shape.sig

    def mask():
        return np.ones(sig_shape, dtype=bool)

    udf = ApplyMasksUDF(mask_factories=[mask], backends=('numpy',))

    # warmup
    ctx.run_udf(udf=udf, dataset=ds)

    deltas = []

    for i in range(5):
        t0 = time.perf_counter()
        ctx.run_udf(udf=udf, dataset=ds)
        t1 = time.perf_counter()
        delta = t1 - t0
        print(f"run {i}: {delta}")
        deltas.append(delta)

    stats = [
        np.sum(deltas),
        np.mean(deltas),
        np.min(deltas),
        np.max(deltas),
    ]

    print(f"total: {stats}")


if __name__ == "__main__":
    main()
```
</details>

This also includes fixes for the memory dataset, which didn't properly communicate its tile shape, when one was forced by the user. Now, the `TilingScheme` should properly represent the slices of the tiles returned by `get_tiles`.

## Contributor Checklist:

* [N/A] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
