### PR TITLE
Add `UDFMeta.sig_slice` and `UDFMeta.tiling_scheme_idx`

### DIFF
--- a/docs/source/changelog/features/new-udfmeta-attrs.rst
+++ b/docs/source/changelog/features/new-udfmeta-attrs.rst
@@ -1,0 +1,5 @@
+Add :code:`UDFMeta.sig_slice` and :code:`UDFMeta.tiling_scheme_idx`
+===================================================================
+
+* These attributes can be used for performant access to the current signal
+  slice - mostly important for throughput-limited analysis (:pr:`1167`, :issue:`1166`).

--- a/src/libertem/common/container.py
+++ b/src/libertem/common/container.py
@@ -130,6 +130,12 @@ class MaskContainer:
         slice_ = scheme[idx]
         return self._get(slice_, *args, **kwargs)
 
+    def get_for_sig_slice(self, sig_slice: Slice, *args, **kwargs):
+        """
+        Same as `get`, but without calling `discard_nav()` on the slice
+        """
+        return self._get(sig_slice, *args, **kwargs)
+
     def get(self, key: Slice, dtype=None, sparse_backend=None, transpose=True, backend=None):
         if not isinstance(key, Slice):
             raise TypeError(

--- a/src/libertem/io/dataset/base/tiling_scheme.py
+++ b/src/libertem/io/dataset/base/tiling_scheme.py
@@ -66,7 +66,7 @@ class TilingScheme:
             debug=debug,
         )
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx) -> Slice:
         return self._slices[idx]
 
     def __len__(self):

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -175,8 +175,8 @@ class ApplyMasksUDF(UDF):
         flat_data = tile.reshape((tile.shape[0], -1))
         if self.task_data.use_torch:
             import torch
-            masks = self.task_data.masks.get_for_idx(
-                self.meta.tiling_scheme, tile.scheme_idx, transpose=True
+            masks = self.task_data.masks.get_for_sig_slice(
+                self.meta.sig_slice, transpose=True
             )
             # CuPy back-end disables torch in get_task_data
             # FIXME use GPU torch with CuPy array?
@@ -186,21 +186,21 @@ class ApplyMasksUDF(UDF):
             ).numpy()
         # Required due to https://github.com/cupy/cupy/issues/4072
         elif self.backend == 'cupy' and self.task_data.masks.use_sparse:
-            masks = self.task_data.masks.get_for_idx(
-                self.meta.tiling_scheme, tile.scheme_idx, transpose=False
+            masks = self.task_data.masks.get_for_sig_slice(
+                self.meta.sig_slice, transpose=False
             )
             result = masks.dot(flat_data.T).T
         # Required due to https://github.com/scipy/scipy/issues/13211
         elif (self.backend == 'numpy'
               and self.task_data.masks.use_sparse
               and 'scipy.sparse' in self.task_data.masks.use_sparse):
-            masks = self.task_data.masks.get_for_idx(
-                self.meta.tiling_scheme, tile.scheme_idx, transpose=True
+            masks = self.task_data.masks.get_for_sig_slice(
+                self.meta.sig_slice, transpose=True
             )
             result = rmatmul(flat_data, masks)
         else:
-            masks = self.task_data.masks.get_for_idx(
-                self.meta.tiling_scheme, tile.scheme_idx, transpose=True
+            masks = self.task_data.masks.get_for_sig_slice(
+                self.meta.sig_slice, transpose=True
             )
             result = flat_data @ masks
         # '+' is the correct merge for dot product


### PR DESCRIPTION
They are meant as a direct replacement of accessing the `DataTile` attributes directly, and serve as an official interface for this functionality, which also works with cupy.

In addition, removes a now-redundant `UDFMeta` recreation in the `UDFRunner`, which was needed before to set the tiling scheme.

Fixes #1166

## Contributor Checklist:

* [N/A] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
