### PR TITLE
Release GIL in more Numba methods

### DIFF
--- a/src/libertem/common/numba/__init__.py
+++ b/src/libertem/common/numba/__init__.py
@@ -9,7 +9,7 @@ from .cache import prime_numba_cache, cached_njit  # NOQA: F401
 logger = logging.getLogger(__name__)
 
 
-@numba.njit(boundscheck=True)
+@numba.njit(boundscheck=True, nogil=True)
 def numba_ravel_multi_index_single(multi_index, dims):
     # only supports the "single index" case
     idxs = range(len(dims) - 1, -1, -1)
@@ -22,7 +22,7 @@ def numba_ravel_multi_index_single(multi_index, dims):
     return res
 
 
-@numba.njit(boundscheck=True)
+@numba.njit(boundscheck=True, nogil=True)
 def numba_ravel_multi_index_multi(multi_index, dims):
     # only supports the "multi index" case
     idxs = range(len(dims) - 1, -1, -1)
@@ -36,7 +36,7 @@ def numba_ravel_multi_index_multi(multi_index, dims):
     return res
 
 
-@numba.njit(boundscheck=True)
+@numba.njit(boundscheck=True, nogil=True)
 def numba_unravel_index_single(index, shape):
     sizes = np.zeros(len(shape), dtype=np.intp)
     result = np.zeros(len(shape), dtype=np.intp)
@@ -50,7 +50,7 @@ def numba_unravel_index_single(index, shape):
     return result
 
 
-@numba.njit(boundscheck=True)
+@numba.njit(boundscheck=True, nogil=True)
 def numba_unravel_index_multi(indices, shape):
     sizes = np.zeros(len(shape), dtype=np.intp)
     result = np.zeros((len(shape), len(indices)), dtype=np.intp)
@@ -127,7 +127,7 @@ def rmatmul(left_dense, right_sparse):
     return result_t.T.copy()
 
 
-@numba.njit(fastmath=True, cache=True)
+@numba.njit(fastmath=True, cache=True, nogil=True)
 def _rmatmul_csc(left_dense, right_data, right_indices, right_indptr, res_inout_t):
     left_rows = left_dense.shape[0]
     for right_column in range(len(right_indptr) - 1):
@@ -143,7 +143,7 @@ def _rmatmul_csc(left_dense, right_data, right_indices, right_indptr, res_inout_
                     res_inout_t[right_column, left_row] += tmp
 
 
-@numba.njit(fastmath=True, cache=True)
+@numba.njit(fastmath=True, cache=True, nogil=True)
 def _rmatmul_csr(left_dense, right_data, right_indices, right_indptr, res_inout_t):
     left_rows = left_dense.shape[0]
     rowbuf = np.empty(shape=(left_rows,), dtype=left_dense.dtype)

--- a/src/libertem/corrections/detector.py
+++ b/src/libertem/corrections/detector.py
@@ -9,7 +9,7 @@ from libertem.common.numba import (
 )
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=True, nogil=True)
 def _correct_numba_inplace(buffer, dark_image, gain_map, exclude_pixels, repair_environments,
         repair_counts):
     '''
@@ -102,7 +102,7 @@ def _correct_numba_inplace(buffer, dark_image, gain_map, exclude_pixels, repair_
     return buffer
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=True, nogil=True)
 def environments(excluded_pixels, sigshape):
     '''
     Calculate a hypercube surface around a pixel, excluding frame boundaries
@@ -151,7 +151,7 @@ class RepairValueError(ValueError):
     pass
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=True, nogil=True)
 def flatten_filter(excluded_pixels, repairs, repair_counts, sig_shape):
     '''
     Flatten excluded pixels and repair environments and filter for collisions

--- a/src/libertem/io/dataset/base/backend_buffered.py
+++ b/src/libertem/io/dataset/base/backend_buffered.py
@@ -22,7 +22,7 @@ def _make_buffered_reader_and_decoder(decode):
     """
     decode: from buffers, in bytes, possibly interpreted as native_dtype, to out_decoded.dtype
     """
-    @cached_njit(boundscheck=False)
+    @cached_njit(boundscheck=False, nogil=True)
     def _buffered_tilereader(outer_idx, buffers, sig_dims, tile_read_ranges,
                            out_decoded, native_dtype, do_zero,
                            origin, shape, ds_shape, offsets):
@@ -48,7 +48,7 @@ def _make_buffered_reader_and_decoder(decode):
     return _buffered_tilereader
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=True, nogil=True)
 def block_get_min_fill_factor(rrs):
     """
     Try to find out how sparse the given read ranges are, per file.

--- a/src/libertem/io/dataset/base/backend_mmap.py
+++ b/src/libertem/io/dataset/base/backend_mmap.py
@@ -24,7 +24,7 @@ def _make_mmap_reader_and_decoder(decode):
     """
     decode: from inp, in bytes, possibly interpreted as native_dtype, to out_decoded.dtype
     """
-    @cached_njit(boundscheck=False, cache=True)
+    @cached_njit(boundscheck=False, cache=True, nogil=True)
     def _mmap_tilereader_w_copy(outer_idx, mmaps, sig_dims, tile_read_ranges,
                            out_decoded, native_dtype, do_zero,
                            origin, shape, ds_shape):
@@ -52,7 +52,7 @@ def _make_mmap_reader_and_decoder(decode):
     return _mmap_tilereader_w_copy
 
 
-@numba.njit
+@numba.njit(nogil=True)
 def _get_prefetch_ranges(num_files, tile_ranges):
     res = np.zeros((num_files, 3), dtype=np.int64)
     for rr_idx in range(tile_ranges.shape[0]):

--- a/src/libertem/io/dataset/base/roi.py
+++ b/src/libertem/io/dataset/base/roi.py
@@ -4,7 +4,7 @@ import numpy as np
 from libertem.common import Slice
 
 
-@numba.njit
+@numba.njit(nogil=True)
 def _roi_to_indices(roi, start, stop, sync_offset=0):
     """
     Helper function to calculate indices from roi mask. Indices

--- a/src/libertem/io/dataset/base/tiling.py
+++ b/src/libertem/io/dataset/base/tiling.py
@@ -44,7 +44,7 @@ def _default_px_to_bytes(
     read_ranges.append((file_idx, start, stop))
 
 
-@numba.njit(boundscheck=True)
+@numba.njit(boundscheck=True, nogil=True)
 def _find_file_for_frame_idx(fileset_arr, frame_idx):
     """
     Find the file in `fileset_arr` that contains
@@ -166,7 +166,7 @@ def make_get_read_ranges(
         where the last dimension contains: file index, start_byte, stop_byte
     """
 
-    @cached_njit(boundscheck=True, cache=True)
+    @cached_njit(boundscheck=True, cache=True, nogil=True)
     def _get_read_ranges_inner(
         start_at_frame, stop_before_frame, roi, depth,
         slices_arr, fileset_arr, sig_shape,

--- a/src/libertem/udf/stddev.py
+++ b/src/libertem/udf/stddev.py
@@ -7,7 +7,7 @@ from libertem.udf import UDF
 from libertem.common.buffers import reshaped_view
 
 
-@numba.njit(fastmath=True, cache=True)
+@numba.njit(fastmath=True, cache=True, nogil=True)
 def merge_single(n, n_0, sum_0, varsum_0, n_1, sum_1, varsum_1, mean_1):
     '''
     Basic function to perform numerically stable merge.
@@ -55,7 +55,7 @@ def merge_single(n, n_0, sum_0, varsum_0, n_1, sum_1, varsum_1, mean_1):
     return sumsum, varsum
 
 
-@numba.njit
+@numba.njit(nogil=True)
 def merge(dest_n, dest_sum, dest_varsum, src_n, src_sum, src_varsum):
     """
     Given two sets of buffers, with sum of frames
@@ -101,7 +101,7 @@ def merge(dest_n, dest_sum, dest_varsum, src_n, src_sum, src_varsum):
     return n
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, nogil=True)
 def process_tile(tile, n_0, sum_inout, varsum_inout):
     '''
     Compute sum and variance of :code:`tile` along navigation axis


### PR DESCRIPTION
This commit was extracted from #1158 as it is independent but touches a number of files. The original commit message is:

It turns out that tiling slows down the threaded case. This
change releases the GIL for more parts of the LiberTEM internals.  The
float32 case uses a very large single tile for the partition and shows
the difference.

Rebased from @uellue commit d0037924

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)