### PR TITLE
Fixes for the current pytest-asyncio

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -560,7 +560,8 @@ def event_loop():
     yield loop
     print("event loop teardown")
     loop.run_until_complete(loop.shutdown_asyncgens())
-    loop.run_until_complete(loop.shutdown_default_executor())
+    if hasattr(loop, 'shutdown_default_executor'):
+        loop.run_until_complete(loop.shutdown_default_executor())
     loop.close()
 
     # Work around: pytest-asyncio sets an empty event loop policy here,

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,4 @@ log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 env =
     D:NUMBA_NUM_THREADS = 4
+asyncio_mode = auto

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,6 @@
 pytest>=6,<7
 pytest-cov
-# See https://github.com/LiberTEM/LiberTEM/issues/1187
-pytest-asyncio>0.11,<0.17
+pytest-asyncio>0.11
 nest-asyncio
 pytest-xdist
 pytest-env

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest>=6,<7
+pytest>=6
 pytest-cov
 pytest-asyncio>0.11
 nest-asyncio

--- a/tests/template/test_com_template.py
+++ b/tests/template/test_com_template.py
@@ -29,7 +29,7 @@ def test_com_default(hdf5_ds_2, tmpdir_factory, lt_ctx, local_cluster_url):
     notebook = notebook_generator(conn, dataset, analysis, save=True)
     notebook = io.StringIO(notebook.getvalue())
     nb = nbformat.read(notebook, as_version=4)
-    ep = ExecutePreprocessor(timeout=600)
+    ep = ExecutePreprocessor(timeout=30)
     ep.preprocess(nb, {"metadata": {"path": datadir}})
     channels = [
         "field",


### PR DESCRIPTION
The changes here at least make `tests/server` run through; the ones in `tests/template` ~still hang indefinitely somewhere, after
the main test code times out. Possibly the hang is in the added code for event loop cleanup, like `loop.shutdown_asyncgens` and `loop.shutdown_default_executor`?~ Updating to current `pytest` and `pytest-asyncio` fixed the hang in there, too.

Fixes #1187

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
