### PR TITLE
Try to fix robustness of memleak test: use 2 rounds of warmup

### DIFF
--- a/tests/udf/test_memleak.py
+++ b/tests/udf/test_memleak.py
@@ -62,7 +62,7 @@ def worker_memory(client):
 def test_executor_memleak(local_cluster_ctx, lt_ctx_fast, default_raw, ctx_select):
     if ctx_select == 'dask':
         ctx = local_cluster_ctx
-        rounds = 3
+        rounds = 5
 
         def get_worker_mem(ctx):
             return worker_memory(ctx.executor.client)
@@ -91,8 +91,9 @@ def test_executor_memleak(local_cluster_ctx, lt_ctx_fast, default_raw, ctx_selec
     )
 
     # warm-up
-    for _ in ctx.run_udf_iter(dataset=default_raw, udf=udf):
-        pass
+    for _ in range(2):
+        for _ in ctx.run_udf_iter(dataset=default_raw, udf=udf):
+            pass
 
     cumulative_worker_delta = 0
     cumulative_executor_delta = 0


### PR DESCRIPTION
Locally, the first "real" round was still varying a lot in memory use, let's see if it's the same issue on Mac OS X

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
