### PR TITLE
sync_to_async: shield async code from `StopIteration`

### DIFF
--- a/src/libertem/utils/async_utils.py
+++ b/src/libertem/utils/async_utils.py
@@ -2,7 +2,6 @@ import sys
 import queue
 import asyncio
 import threading
-import functools
 from typing import AsyncGenerator, Callable, Generator, Optional, TypeVar
 from concurrent.futures import ThreadPoolExecutor
 
@@ -10,11 +9,30 @@ from concurrent.futures import ThreadPoolExecutor
 T = TypeVar('T')
 
 
+class MyStopIteration(Exception):
+    """
+    TypeError: StopIteration interacts badly with generators
+    and cannot be raised into a Future
+    """
+    pass
+
+
+def _wrap_f(f, args, kwargs):
+    def _wrapped():
+        try:
+            return f(*args, **kwargs)
+        except StopIteration as e:
+            raise MyStopIteration() from e
+    return _wrapped
+
+
 async def sync_to_async(
     fn: Callable[..., T], pool: Optional[ThreadPoolExecutor] = None, *args, **kwargs
 ) -> T:
     """
     Run blocking function with `*args`, `**kwargs` in a thread pool.
+
+    Raises `MyStopIteration` in case `fn` raises a `StopIteration`.
 
     Parameters
     ----------
@@ -28,7 +46,11 @@ async def sync_to_async(
         Passed on to `fn`
     """
     loop = asyncio.get_event_loop()
-    fn = functools.partial(fn, *args, **kwargs)
+    # As `fn` may throw a `StopIteration` for whatever reason, which doesn't
+    # work inside of futures, we have to wrap it in a custom exception type.
+    # Without this, it's possible that things hang instead of propagating
+    # errors properly:
+    fn = _wrap_f(fn, args, kwargs)
     return await loop.run_in_executor(pool, fn)
 
 
@@ -231,14 +253,6 @@ async def async_generator_eager(gen, pool=None):
         # in case our thread raises an exception, we may need to stop the `SyncGenToQueueThread`:
         t.stop()
         t.join()
-
-
-class MyStopIteration(Exception):
-    """
-    TypeError: StopIteration interacts badly with generators
-    and cannot be raised into a Future
-    """
-    pass
 
 
 def adjust_event_loop_policy():

--- a/tests/utils/test_async_utils.py
+++ b/tests/utils/test_async_utils.py
@@ -1,0 +1,15 @@
+import pytest
+
+from libertem.utils.async_utils import sync_to_async, MyStopIteration
+
+
+def _f():
+    print("stuff while")
+    next(iter([]))
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_stopiteration():
+    print("stuff before")
+    with pytest.raises(MyStopIteration):
+        await sync_to_async(_f)


### PR DESCRIPTION
`StopIteration` seems to be used in the guts of async generators, from PEP-525:

    The protocol requires two special methods to be implemented:

    An __aiter__ method returning an asynchronous iterator.
    An __anext__ method returning an awaitable object, which uses StopIteration exception to "yield" values, and StopAsyncIteration exception to signal the end of the iteration.

This apparently means raising `StopIteration` anywhere in async code just generates an error, which also can't really be caught by user code... *sigh*

This is a partial fix for #1200 for defense in depth, the K2IS-specific parts will follow in a separate PR.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
