### PR TITLE
Re-enable live plotting

### DIFF
--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -999,7 +999,7 @@ class Context:
                 progress=progress,
                 corrections=corrections,
                 backends=backends,
-                iterate=iterate
+                iterate=(iterate or enable_plotting)
             )
             for udf_results in result_iter:
                 yield udf_results


### PR DESCRIPTION
Don't skip intermediate results if they will be required
for plotting.

No changelog since this is a regression introduced after 0.8.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
