### PR TITLE
Correct shape of buffer views for tile depth 1

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -105,6 +105,9 @@ Bugfixes
   and curl if they are defined (:issue:`1138`, :pr:`1139`).
 * :code:`make_dask_array` now works correctly when a :code:`roi` is specified
   (:issue:`933`).
+* Correct shape of buffer views in :meth:`~libertem.udf.base.UDFTileMixin.process_tile`
+  when the tile has depth 1 (:pr:`1215`).
+
 
 Documentation
 -------------

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -492,11 +492,7 @@ class BufferWrapper:
             # optimized builds for performance
             assert result_start < len(self._data)
             assert result_stop <= len(self._data)
-            # shape: (1,) + self._extra_shape
-            if len(self._extra_shape) + tile_slice.shape[0] > 1:
-                return self._data[result_start:result_stop]
-            else:
-                return self._data[result_start:result_stop, np.newaxis]
+            return self._data[result_start:result_stop]
         elif self._kind == "single":
             return self._data
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py{36,37,38,39}, py{36,37,38,39}-data, benchmark, benchmark-cuda{101,102,110}, mypy
+envlist = flake8, py{36,37,38,39}, py{36,37,38,39}-data, benchmark, benchmark-cuda{101,102,110,114}, mypy
 
 [testenv]
 commands=
@@ -13,6 +13,7 @@ deps=
     cuda101: cupy-cuda101
     cuda102: cupy-cuda102
     cuda110: cupy-cuda110
+    cuda114: cupy-cuda114
 extras=
     hdbscan
     bqplot
@@ -35,6 +36,8 @@ passenv=
     DASK_SCHEDULER_ADDRESS
     TESTDATA_BASE_PATH
     NUMBA_*
+    # HyperSpy expects this on Windows
+    PROGRAMFILES
 
 [testenv:numba_coverage]
 commands=
@@ -88,6 +91,8 @@ commands=
     pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml --nbval --sanitize-with nbval_sanitize.cfg -p no:python --current-env {posargs:examples/}
 passenv=
     TESTDATA_BASE_PATH
+    # HyperSpy expects this on Windows
+    PROGRAMFILES
 
 [testenv:benchmark]
 changedir={toxinidir}
@@ -95,7 +100,7 @@ commands=
     pytest --benchmark-enable --benchmark-warmup=on --benchmark-autosave --benchmark-storage "{toxinidir}/benchmark_results" -m "not compilation" {posargs:benchmarks/}
     pytest --benchmark-enable --benchmark-warmup=off --benchmark-autosave --benchmark-storage "{toxinidir}/benchmark_results" -m "compilation" {posargs:benchmarks/}
 
-[testenv:benchmark-cuda{101,102}]
+[testenv:benchmark-cuda{101,102,110,114}]
 changedir={toxinidir}
 commands=
     {[testenv:benchmark]commands}


### PR DESCRIPTION
Closes #1203

I'm not sure what the reason for the special treatment was, but it seems that removing it fixes this bug, and tests still pass.

The special treatment was part of the original implementation of tiled processing in 992fdb621

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
