### PR TITLE
Add DataSet implementation for groups of raw files

### DIFF
--- a/src/libertem/io/dataset/base/backend_buffered.py
+++ b/src/libertem/io/dataset/base/backend_buffered.py
@@ -183,7 +183,7 @@ class DirectBufferedFile(BufferedFile):
             # Make sure to keep a reference, otherwise
             # it will be closed
             self._fh = win32file.CreateFile(
-                self.path,  # fileName
+                str(self.path),  # fileName
                 win32file.GENERIC_READ,  # desiredAccess
                 win32file.FILE_SHARE_READ
                 | win32file.FILE_SHARE_WRITE

--- a/src/libertem/io/dataset/raw_group.py
+++ b/src/libertem/io/dataset/raw_group.py
@@ -79,14 +79,15 @@ class RawFileGroupDataSet(RawFileDataSet):
                          nav_shape=nav_shape, sig_shape=sig_shape,
                          **kwargs)
         self._path = None
-        self._paths = paths
+        self._paths: List[Union[str, pathlib.Path]] = paths
 
         self._file_header = file_header
         self._frame_header = frame_header
         self._frame_footer = frame_footer
 
     def initialize(self, executor) -> 'RawFileGroupDataSet':
-        _filesizes = executor.run_function(self._get_filesizes)
+        _filesizes_list: List[int] = executor.map(self._get_filesize, self._paths)
+        _filesizes = {p: f for p, f in zip(self._paths, _filesizes_list)}
         self._filesize = sum(_filesizes.values())
         self._image_counts = tuple(self._frames_per_file(path, filesize=filesize)
                                    for path, filesize in _filesizes.items())

--- a/src/libertem/io/dataset/raw_group.py
+++ b/src/libertem/io/dataset/raw_group.py
@@ -94,7 +94,8 @@ class RawFileGroupDataSet(RawFileDataSet):
         chunked_paths = [self._paths[start:start + chunk_size]
                          for start in range(0, len(self._paths), chunk_size)]
         _filesizes_list = executor.map(self._get_filesizes, chunked_paths)
-        _filesizes: Dict[Union[str, pathlib.Path], int] = dict(*_filesizes_list)
+        _filesizes = dict(itertools.chain.from_iterable(d.items() for d in _filesizes_list))
+        _filesizes: Dict[Union[str, pathlib.Path], int]
         self._filesize = sum(_filesizes.values())
         self._image_counts = tuple(self._frames_per_file(path, filesize=filesize)
                                    for path, filesize in _filesizes.items())

--- a/src/libertem/io/dataset/raw_group.py
+++ b/src/libertem/io/dataset/raw_group.py
@@ -1,0 +1,85 @@
+import os
+import itertools
+import numpy as np
+
+from libertem.common.math import prod
+from libertem.common import Shape
+from .base import DataSetMeta, DataSetException
+from libertem.io.dataset.raw import RawFileDataSet, RawFileSet, RawFile
+from libertem.io.dataset.base import MMapBackend
+
+
+class RawFileGroupDataSet(RawFileDataSet):
+    def __init__(self, paths, *args, file_header=0, frame_header=0, frame_footer=0, **kwargs):
+        super().__init__(paths[0], *args, **kwargs)
+        self._path = None
+        self._paths = paths
+
+        self._file_header = file_header
+        self._frame_header = frame_header
+        self._frame_footer = frame_footer
+
+    def initialize(self, executor):
+        self._filesize = executor.run_function(self._get_total_filesize)
+        self._image_counts = executor.run_function(self._get_image_counts)
+        self._image_count = sum(self._image_counts)
+        self._nav_shape_product = int(prod(self._nav_shape))
+        self._sync_offset_info = self.get_sync_offset_info()
+        shape = Shape(self._nav_shape + self._sig_shape, sig_dims=self._sig_dims)
+        self._meta = DataSetMeta(
+                                 shape=shape,
+                                 raw_dtype=np.dtype(self._dtype),
+                                 sync_offset=self._sync_offset,
+                                 image_count=self._image_count,
+        )
+
+        if ((self._frame_header % self.dtype.itemsize or self._frame_footer % self.dtype.itemsize)
+                and isinstance(self.get_io_backend(), MMapBackend)):
+            raise DataSetException('Cannot have frame header/footer which are '
+                                   'not multiples of bytesize of raw_dtype when '
+                                   'using MMapBackend. Specifiy another IOBackend '
+                                   'or use file_header if single frame-per-file.')
+
+        return self
+
+    def _get_fileset(self):
+        end_idxs = tuple(itertools.accumulate(self._image_counts))
+        start_idxs = (0,) + end_idxs[:-1]
+        return RawFileSet([RawFile(path=p,
+                                   start_idx=s,
+                                   end_idx=e,
+                                   sig_shape=self.shape.sig,
+                                   native_dtype=self._meta.raw_dtype,
+                                   frame_footer=self._frame_footer,
+                                   frame_header=self._frame_header,
+                                   file_header=self._file_header)
+                           for p, s, e in zip(self._paths, start_idxs, end_idxs)],
+                        frame_header_bytes=self._frame_header,
+                        frame_footer_bytes=self._frame_footer)
+
+    def _get_filesize(self, path):
+        return os.stat(path).st_size
+
+    def _get_total_filesize(self):
+        return sum(self._get_filesize(p) for p in self._paths)
+
+    def _frames_per_file(self, path):
+        frame_size = (self._frame_header
+                      + np.dtype(self._dtype).itemsize * prod(self._sig_shape)
+                      + self._frame_footer)
+        nframes = (self._get_filesize(path) - self._file_header) / frame_size
+        if nframes % 1 != 0:
+            raise DataSetException(f"File {path} has size inconsistent with supplied parameters")
+        return int(nframes)
+
+    def _get_image_counts(self):
+        return tuple(self._frames_per_file(p) for p in self._paths)
+
+    def check_valid(self):
+        try:
+            fileset = self._get_fileset()
+            backend = self.get_io_backend().get_impl()
+            with backend.open_files(fileset):
+                return True
+        except (OSError, ValueError) as e:
+            raise DataSetException("invalid dataset: %s" % e)

--- a/src/libertem/io/dataset/raw_group.py
+++ b/src/libertem/io/dataset/raw_group.py
@@ -35,6 +35,8 @@ class RawFileGroupSet(RawFileSet):
 class RawFileGroupDataSet(RawFileDataSet):
     # Maximum number of files to open at one time
     # or to allow in a single partition
+    # This is a conservative value, seems like Windows it is around
+    # 512, and I've seen Linux referenced at 1024
     MAX_OPEN_FILES = 256
 
     def __init__(self,

--- a/src/libertem/io/dataset/raw_group.py
+++ b/src/libertem/io/dataset/raw_group.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import logging
 import itertools
 import numpy as np
 from typing import Union, TYPE_CHECKING, Tuple, List, Optional
@@ -10,6 +11,8 @@ from .base import DataSetMeta, DataSetException
 from libertem.io.dataset.raw import RawFileDataSet, RawFileSet, RawFile
 from libertem.io.dataset.base import MMapBackend
 from libertem.io.dataset.base.partition import BasePartition
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import numpy.typing as nt
@@ -91,6 +94,8 @@ class RawFileGroupDataSet(RawFileDataSet):
         self._frame_footer = frame_footer
 
     def initialize(self, executor) -> 'RawFileGroupDataSet':
+        if len(set(self._paths)) != len(self._paths):
+            log.warning(f'Paths passed to {self.__class__.__name__} contains duplicates')
         # Stat files in groups up to size chunk_size
         # If we are running in a threaded/distributed executor each chunk of stat
         # calls will be hopefully be parallelised, should not be different from

--- a/src/libertem/io/dataset/raw_group.py
+++ b/src/libertem/io/dataset/raw_group.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import itertools
 import numpy as np
-from typing import Union, TYPE_CHECKING, Tuple, List, Dict, Optional
+from typing import Union, TYPE_CHECKING, Tuple, List, Optional
 
 from libertem.common.math import prod
 from libertem.common import Shape
@@ -134,18 +134,6 @@ class RawFileGroupDataSet(RawFileDataSet):
         Get the file size of a single file
         """
         return os.stat(path).st_size
-
-    def _get_filesizes(self) -> Dict[Union[str, pathlib.Path], int]:
-        """
-        Compute the filesize of each file in self._paths
-
-        This should be the only time os.stat is called on each path
-        during initialization
-
-        In a network filesystem context this can be quite slow, might be
-        with running this method in a threaded or async way
-        """
-        return {p: self._get_filesize(p) for p in self._paths}
 
     def _frames_per_file(self,
                          path: Union[str, pathlib.Path],

--- a/src/libertem/io/dataset/raw_group.py
+++ b/src/libertem/io/dataset/raw_group.py
@@ -1,12 +1,17 @@
 import os
+import pathlib
 import itertools
 import numpy as np
+from typing import Union, TYPE_CHECKING, Tuple, List
 
 from libertem.common.math import prod
 from libertem.common import Shape
 from .base import DataSetMeta, DataSetException
 from libertem.io.dataset.raw import RawFileDataSet, RawFileSet, RawFile
 from libertem.io.dataset.base import MMapBackend
+
+if TYPE_CHECKING:
+    import numpy.typing as nt
 
 
 class RawFileGroupSet(RawFileSet):
@@ -24,8 +29,55 @@ class RawFileGroupSet(RawFileSet):
 
 
 class RawFileGroupDataSet(RawFileDataSet):
-    def __init__(self, paths, *args, file_header=0, frame_header=0, frame_footer=0, **kwargs):
-        super().__init__(paths[0], *args, **kwargs)
+    def __init__(self,
+                 paths: List[Union[str, pathlib.Path]],
+                 *,
+                 dtype: "nt.DTypeLike",
+                 nav_shape: Tuple[int, ...] = None,
+                 sig_shape: Tuple[int, ...] = None,
+                 file_header: int = 0,
+                 frame_header: int = 0,
+                 frame_footer: int = 0,
+                 **kwargs):
+        """
+        Wrapper around RawFileDataSet providing capability to read sets of raw
+        files as a single dataset, and adds support for file/frame headers and frame footers.
+
+        No decoding of headers or footers is performed.
+
+        Files in the set can each contain one-or-more frames (and indeed a variable)
+        number of frames per file, as long as file_header, frame_header and frame_footer
+        are all constant throughout.
+
+        It is the user's responsibility to ensure that the supplied paths are
+        sorted according to a flat navigation dimension in C-ordering.
+
+        See :class:`~libertem.io.dataset.raw.RawFileDataSet` for the majority of
+        the signature, only crucial arguments and those specific to this class
+        are specified below.
+
+        Parameters
+        ----------
+        paths : list[Union[str, pathlib.Path]]
+            List of file paths to interpret as the dataset.
+        dtype : nt.DTypeLike
+            The dtype of the data as stored on disk
+        nav_shape : tuple[int, ...]
+            The shape of the navigation dimensions
+        sig_shape : tuple[int, ...]
+            The shape of the signal dimensions
+        file_header : int, optional
+            Bytes to skip at beginning of each file, by default 0
+        frame_header : int, optional
+            Bytes to skip at beginning of each frame, by default 0
+        frame_footer : int, optional
+            Bytes to skip at end of each frame, by default 0
+        """
+        if isinstance(paths, (str, pathlib.Path)):
+            paths = [paths]
+        super().__init__(paths[0], dtype=dtype,
+                         nav_shape=nav_shape, sig_shape=sig_shape,
+                         **kwargs)
         self._path = None
         self._paths = paths
 
@@ -57,6 +109,9 @@ class RawFileGroupDataSet(RawFileDataSet):
         return self
 
     def _get_fileset(self):
+        """
+        Return RawFile descriptors for each file in self._paths
+        """
         end_idxs = tuple(itertools.accumulate(self._image_counts))
         start_idxs = (0,) + end_idxs[:-1]
         return RawFileGroupSet([RawFile(path=p,
@@ -72,12 +127,23 @@ class RawFileGroupDataSet(RawFileDataSet):
                         frame_footer_bytes=self._frame_footer)
 
     def _get_filesize(self, path):
+        """
+        Get the file size of a single file
+        """
         return os.stat(path).st_size
 
     def _get_total_filesize(self):
+        """
+        Get the sum of all filesizes in supplied paths
+        """
         return sum(self._get_filesize(p) for p in self._paths)
 
     def _frames_per_file(self, path):
+        """
+        Calculate the number of frames in each file based on its filesize
+
+        Raises if the file size and header/footer parameters are incompatible
+        """
         frame_size = (self._frame_header
                       + np.dtype(self._dtype).itemsize * prod(self._sig_shape)
                       + self._frame_footer)
@@ -87,9 +153,20 @@ class RawFileGroupDataSet(RawFileDataSet):
         return int(nframes)
 
     def _get_image_counts(self):
+        """
+        Get the number of frames in each file in self._paths
+        """
         return tuple(self._frames_per_file(p) for p in self._paths)
 
     def check_valid(self):
+        """
+        Check the fileset for validity in groups of MAX_OPEN files
+
+        Necessary to avoid a 'too many open files' error when
+        opening very large datasets
+
+        :meta private:
+        """
         MAX_OPEN = 1000
         try:
             backend = self.get_io_backend().get_impl()

--- a/tests/io/datasets/test_raw_group.py
+++ b/tests/io/datasets/test_raw_group.py
@@ -1,0 +1,208 @@
+import math
+import itertools
+import pathlib
+import contextlib
+import numpy as np
+import pytest
+
+from libertem.common.shape import Shape
+from libertem.udf.raw import PickUDF
+from libertem.udf.sum import SumUDF
+from libertem.io.dataset.raw_group import RawFileGroupDataSet
+from libertem.io.dataset.base import BufferedBackend, MMapBackend, DirectBackend
+from libertem.io.dataset.base import Negotiator, DataSetException
+
+from utils import _mk_random
+
+
+def random_bytes(n):
+    return np.random.randint(0, 255, size=(n,)).astype(np.uint8).tobytes()
+
+
+def group_frames(frame_iterator, n, file_header, frame_header, frame_footer):
+    frames = []
+    for _ in range(n):
+        try:
+            frame = (random_bytes(frame_header)
+                    + next(frame_iterator).tobytes()
+                    + random_bytes(frame_footer))
+            frames.append(frame)
+        except StopIteration:
+            pass
+    return len(frames), random_bytes(file_header) + b''.join(frames)
+
+
+def raw_group_ds(tmpdir_factory,
+                 frames_per_file, file_header,
+                 frame_header, frame_footer,
+                 nav_shape=(16, 16),
+                 sig_shape=(64, 64),
+                 dtype=np.float32):
+    if isinstance(frames_per_file, int):
+        if frames_per_file == -1:
+            frames_per_file = math.prod(nav_shape)
+        frames_per_file = (frames_per_file,)
+    frames_per_file = itertools.cycle(frames_per_file)
+
+    datadir = pathlib.Path(tmpdir_factory.mktemp('data'))
+    raw_data = _mk_random(size=(math.prod(nav_shape),) + sig_shape, dtype=dtype)
+
+    paths = []
+    frame_iterator = iter(raw_data)
+
+    frames = 0
+    while frames < raw_data.shape[0]:
+        _frames, fbytes = group_frames(frame_iterator,
+                                       next(frames_per_file),
+                                       file_header,
+                                       frame_header,
+                                       frame_footer)
+        frames += _frames
+        filename = datadir / f'{len(paths):>04d}.raw'
+        with filename.open('wb') as fp:
+            fp.write(fbytes)
+        paths.append(filename)
+
+    return raw_data.reshape(nav_shape + sig_shape), paths
+
+
+@contextlib.contextmanager
+def get_dataset(tmpdir_factory, lt_ctx,
+                frames_per_file=-1,
+                file_header=0,
+                frame_header=0,
+                frame_footer=0,
+                nav_shape=(16, 16),
+                sig_shape=(64, 64),
+                dtype=np.float32,
+                backend=None):
+    # Files per frame -1 corresponds to one raw file containing all frames
+    raw_data, paths = raw_group_ds(tmpdir_factory,
+                                   frames_per_file=frames_per_file,
+                                   file_header=file_header,
+                                   frame_header=frame_header,
+                                   frame_footer=frame_footer,
+                                   dtype=dtype,
+                                   nav_shape=nav_shape,
+                                   sig_shape=sig_shape)
+    shape = Shape(raw_data.shape, 2)
+    ds = RawFileGroupDataSet(paths=paths,
+                             nav_shape=shape.nav,
+                             sig_shape=shape.sig,
+                             dtype=raw_data.dtype,
+                             file_header=file_header,
+                             frame_header=frame_header,
+                             frame_footer=frame_footer,
+                             io_backend=backend)
+    ds.initialize(lt_ctx.executor)
+    yield ds, raw_data
+    _ = [f.unlink() for f in paths]
+
+
+@pytest.mark.parametrize("file_header", (0, 4))
+@pytest.mark.parametrize("frame_header", (0, 4))
+@pytest.mark.parametrize("frame_footer", (0, 4))
+@pytest.mark.parametrize("frames_per_file", (-1, 1, 3))
+@pytest.mark.parametrize("dtype", (np.float32, np.int16))
+@pytest.mark.parametrize("backend_cls", (BufferedBackend, MMapBackend, DirectBackend))
+def test_w_copy(tmpdir_factory, lt_ctx,
+                file_header, frame_header, frame_footer,
+                frames_per_file, backend_cls, dtype):
+    with get_dataset(tmpdir_factory, lt_ctx,
+                     frames_per_file=frames_per_file,
+                     file_header=file_header,
+                     frame_header=frame_header,
+                     frame_footer=frame_footer,
+                     backend=backend_cls(),
+                     dtype=dtype) as (ds, raw_data):
+        udf = PickUDF()
+        # Using an ROI forces copy-based reading
+        mask = np.zeros(ds.meta.shape.nav, dtype=bool)
+        h, w = mask.shape
+        x = np.random.randint(0, w)
+        y = np.random.randint(0, h)
+        mask[y, x] = True
+
+        result = lt_ctx.run_udf(dataset=ds, udf=udf, roi=mask)
+        frame = result['intensity'].data.squeeze(axis=0)
+        assert np.allclose(frame, raw_data[y, x])
+
+
+@pytest.mark.parametrize("file_header", (0, 4))
+@pytest.mark.parametrize("frame_header", (0, 4))
+@pytest.mark.parametrize("frame_footer", (0, 4))
+@pytest.mark.parametrize("nav_shape", ((16, 16),))
+@pytest.mark.parametrize("frames_per_file", (16,))
+@pytest.mark.parametrize("backend_cls", (MMapBackend,))
+def test_straight(tmpdir_factory, lt_ctx,
+                  file_header, frame_header, frame_footer,
+                  frames_per_file, nav_shape, backend_cls):
+    with get_dataset(tmpdir_factory, lt_ctx,
+                     frames_per_file=frames_per_file,
+                     file_header=file_header,
+                     frame_header=frame_header,
+                     frame_footer=frame_footer,
+                     nav_shape=nav_shape,
+                     backend=backend_cls()) as (ds, raw_data):
+        # Must hack num_partitions to force straight reading
+        # due to default tileshape.depth > frames_per_file
+        ds.get_num_partitions = lambda: ds.meta.shape.nav[0]
+        udf = SumUDF()
+        # Check we will actually read straight on the first partition!!
+        read_dtype = np.result_type(udf.get_preferred_input_dtype(), ds.dtype)
+        partition = next(ds.get_partitions())
+        tiling_scheme = Negotiator().get_scheme(
+            udfs=[udf],
+            approx_partition_shape=partition.shape,
+            dataset=ds,
+            read_dtype=read_dtype,
+        )
+        need_copy = ds.get_io_backend().get_impl().need_copy(
+            decoder=ds.get_decoder(),
+            roi=None,
+            native_dtype=ds.meta.raw_dtype,
+            read_dtype=read_dtype,
+            sync_offset=ds._sync_offset,
+            tiling_scheme=tiling_scheme,
+            fileset=ds._get_fileset(),
+        )
+        assert not need_copy
+        result = lt_ctx.run_udf(dataset=ds, udf=udf)
+        sum_frame = result['intensity'].data
+        assert np.allclose(sum_frame, raw_data.sum(axis=(0, 1)))
+
+
+@pytest.mark.parametrize("frame_header_footer", ((4, 7), (7, 4)))
+@pytest.mark.parametrize("backend_cls", (MMapBackend,))
+@pytest.mark.parametrize("dtype", (np.float32, np.int16))
+def test_mmap_nonitemsize_failure(tmpdir_factory, lt_ctx,
+                                  frame_header_footer,
+                                  dtype, backend_cls):
+    # Tests that we raise if using MMapBackend with a frame_header
+    # or footer which is not a multiple of dtype.itemsize
+    with pytest.raises(DataSetException):
+        with get_dataset(tmpdir_factory, lt_ctx,
+                         frames_per_file=3,
+                         frame_header=frame_header_footer[0],
+                         frame_footer=frame_header_footer[1],
+                         backend=backend_cls(),
+                         dtype=dtype) as _:
+            pass
+
+
+@pytest.mark.parametrize("frame_header", (7,))
+@pytest.mark.parametrize("backend_cls", (BufferedBackend,))
+@pytest.mark.parametrize("dtype", (np.float32, np.int16))
+def test_buffered_nonitemsize(tmpdir_factory, lt_ctx,
+                              frame_header, backend_cls, dtype):
+    # Shows that BufferedBackend does support frame_header
+    # which is not a multiple of dtype.itemsize
+    with get_dataset(tmpdir_factory, lt_ctx,
+                     frames_per_file=3,
+                     frame_header=frame_header,
+                     backend=backend_cls(),
+                     dtype=dtype) as (ds, raw_data):
+        udf = SumUDF()
+        result = lt_ctx.run_udf(dataset=ds, udf=udf)
+        sum_frame = result['intensity'].data
+        assert np.allclose(sum_frame, raw_data.sum(axis=(0, 1)))

--- a/tests/io/datasets/test_raw_group.py
+++ b/tests/io/datasets/test_raw_group.py
@@ -1,4 +1,3 @@
-import math
 import itertools
 import pathlib
 import contextlib
@@ -6,6 +5,7 @@ import numpy as np
 import pytest
 
 from libertem.common.shape import Shape
+from libertem.common.math import prod
 from libertem.udf.raw import PickUDF
 from libertem.udf.sum import SumUDF
 from libertem.io.dataset.raw_group import RawFileGroupDataSet, RawFile, RawFileGroupSet
@@ -40,12 +40,12 @@ def raw_group_ds(tmpdir_factory,
                  dtype=np.float32):
     if isinstance(frames_per_file, int):
         if frames_per_file == -1:
-            frames_per_file = math.prod(nav_shape)
+            frames_per_file = prod(nav_shape)
         frames_per_file = (frames_per_file,)
     frames_per_file = itertools.cycle(frames_per_file)
 
     datadir = pathlib.Path(tmpdir_factory.mktemp('data'))
-    raw_data = _mk_random(size=(math.prod(nav_shape),) + sig_shape, dtype=dtype)
+    raw_data = _mk_random(size=(prod(nav_shape),) + sig_shape, dtype=dtype)
 
     paths = []
     frame_iterator = iter(raw_data)

--- a/tests/io/datasets/test_raw_group.py
+++ b/tests/io/datasets/test_raw_group.py
@@ -1,3 +1,4 @@
+import sys
 import itertools
 import pathlib
 import contextlib
@@ -108,6 +109,8 @@ def get_dataset(tmpdir_factory, lt_ctx,
 def test_w_copy(tmpdir_factory, lt_ctx,
                 file_header, frame_header, frame_footer,
                 frames_per_file, backend_cls, dtype):
+    if sys.platform.startswith('darwin') and backend_cls.__name__ == 'DirectBackend':
+        pytest.skip('No DirectBackend on MacOSX')
     with get_dataset(tmpdir_factory, lt_ctx,
                      frames_per_file=frames_per_file,
                      file_header=file_header,

--- a/tests/io/datasets/test_raw_group.py
+++ b/tests/io/datasets/test_raw_group.py
@@ -225,3 +225,15 @@ def test_fileset(tmpdir_factory, lt_ctx, frames_per_file,
         assert len(subset) == ds_slice.stop - ds_slice.start
         assert subset._frame_footer_bytes == frame_footer
         assert subset._frame_header_bytes == frame_header
+
+
+@pytest.mark.parametrize("frame_header", (4,))
+@pytest.mark.parametrize("frame_footer", (8,))
+@pytest.mark.parametrize("frames_per_file", (1,))
+def test_check_valid(tmpdir_factory, lt_ctx, frames_per_file,
+                     frame_header, frame_footer):
+    with get_dataset(tmpdir_factory, lt_ctx,
+                     frames_per_file=frames_per_file,
+                     frame_header=frame_header,
+                     frame_footer=frame_footer) as (ds, _):
+        assert ds.check_valid()


### PR DESCRIPTION
Adds an extension of `RawDataSet` which can handle groups of files and files with frame headers/footers. Responds to #1204 .

Currently the implementation is not merged into `RawDataSet` or the usual LiberTEM `ctx.load` or web GUI endpoints. In a future release it would be possible to design a single class which handles both single-file and multi-file reading (in fact the implementation in this PR already handles single files), but it would entail a change to the RawDataSet API/interface (specifically the `path` argument which might change to plural). For now this class should be considered undocumented / testing-only until the interface is stabilized.

One limitation of the system is that when using `MMapBackend` it is impossible to have a frame header or footer which is not a multiple of `dtype.itemsize`. In this case the dataset raises a `DataSetException` and tells the user to change the backend.

This implementation also contains one or two optimizations specific to handling groups of files which might be useful elsewhere. Specifically:

- The method `check_valid` has been modified to only check 256 files at a time, this prevents an OSError due to too many open files
- The mechanism to infer the size of each file has been written to take advantage of parallel processing if this is provided by the executor (using `executor.map` on chunks of files). This prevents a big slowdown encountered when the class calls `os.stat` on thousands of files, particularly over a network filesystem.
- The number of partitions is adjusted to ensure fewer than 256 files-per-partition, to help avoid the OSError

Closes #206 (Dieter)

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
