### PR TITLE
Fix: re-add missing `pip install tox`

### DIFF
--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -222,6 +222,9 @@ stages:
 #          path: $(tox_dir)
 #        displayName: 'cache tox environment'
 
+      - bash: pip install -U tox
+        displayName: 'install requirements'
+
       - ${{ if eq(parameters.recreate_tox, true) }}:
         - bash: tox -r
           displayName: 'Run tox tests $(TOXENV) $(Agent.OS) (recreating)'


### PR DESCRIPTION
This was inadvertendly removed in 4d62c2ad, but as the CI env doesn't
start from zero (for performance reasons), it didn't cause a problem
until now.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
