### PR TITLE
Update nodejs version in CI to current LTS

### DIFF
--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -290,7 +290,7 @@ stages:
       steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '12'
+          versionSpec: '16'
 
 #      - task: Cache@2
 #        inputs:
@@ -300,7 +300,7 @@ stages:
 #          path: $(npm_config_cache)
 #        displayName: Cache npm
 
-      - bash: (cd client && npm install)
+      - bash: (cd client && npm ci)
         displayName: 'install npm dependencies'
 
       - bash: (cd client && npm run build)


### PR DESCRIPTION
Update from old LTS version (12) to the current one (16). This is important to get a `npm` version that is recent enough for the new lockfile version.

Also updates the CI script to use `npm ci` instead of `npm install`, to always install the locked versions.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
