### PR TITLE
No longer install hdbscan from git for docs

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,5 +1,4 @@
-# need current hdbscan master to work around compatibility issues w/ building against the wrong numpy version:
-git+https://github.com/scikit-learn-contrib/hdbscan@b0e0bd5ffd0262b16c7860c38bef582bf973682a#egg=hdbscan
+hdbscan>=0.8.28
 sphinx>=3.5.1
 sphinx-autobuild
 sphinxcontrib-bibtex>=2


### PR DESCRIPTION
A new release containing the relevant fixes has been pushed.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
