### PR TITLE
Split `UDFPartRunner` off `UDFRunner`

### DIFF
--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -3,8 +3,7 @@ import pickle
 import numpy as np
 import pytest
 
-from libertem.udf.base import UDF, UDFRunner, UDFParams
-from libertem.udf.base import UDFMeta
+from libertem.udf.base import UDF, UDFPartRunner, UDFParams, UDFMeta
 from libertem.common.executor import Environment
 from libertem.io.dataset.memory import MemoryDataSet
 from libertem.io.dataset.base import TilingScheme, DataTile
@@ -567,7 +566,7 @@ def test_noncontiguous_tiles(lt_ctx, backend):
             corrections=None,
             tiling_scheme=tiling_scheme,
         )
-        UDFRunner([p_udf], debug=True).run_for_partition(
+        UDFPartRunner([p_udf], debug=True).run_for_partition(
             partition=partition,
             params=params,
             env=Environment(threads_per_worker=1, threaded_executor=False),


### PR DESCRIPTION
Refactoring to allow more specialized `UDFRunner` subclasses.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
