### PR TITLE
Don't use squeezed damage for plotting

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -246,6 +246,25 @@ def default_raw(tmpdir_factory, default_raw_data):
 
 
 @pytest.fixture(scope='session')
+def default_raw_asymm(tmpdir_factory, default_raw_data):
+    lt_ctx = lt.Context(executor=InlineJobExecutor())
+    datadir = tmpdir_factory.mktemp('data')
+    filename = datadir + '/raw-test-default'
+    default_raw_data.tofile(str(filename))
+    del default_raw_data
+    ds = lt_ctx.load(
+        "raw",
+        path=str(filename),
+        dtype="float32",
+        nav_shape=(14, 17),
+        sig_shape=(128, 128),
+        io_backend=MMapBackend(),
+    )
+    ds.set_num_cores(2)
+    yield ds
+
+
+@pytest.fixture(scope='session')
 def buffered_raw(tmpdir_factory, default_raw_data):
     lt_ctx = lt.Context(executor=InlineJobExecutor())
     datadir = tmpdir_factory.mktemp('data')

--- a/docs/source/changelog/bugfix/non-square-plots.rst
+++ b/docs/source/changelog/bugfix/non-square-plots.rst
@@ -1,0 +1,5 @@
+[Bugfix] Fix for non-square plots
+=================================
+
+* Don't use squeezed damage (:pr:`1255`).
+

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -1007,10 +1007,12 @@ class Context:
                 yield udf_results
                 if enable_plotting:
                     self._update_plots(
-                        plots, udfs, udf_results.buffers, udf_results.damage, force=False
+                        plots, udfs, udf_results.buffers, udf_results.damage.data, force=False
                     )
             if enable_plotting:
-                self._update_plots(plots, udfs, udf_results.buffers, udf_results.damage, force=True)
+                self._update_plots(
+                    plots, udfs, udf_results.buffers, udf_results.damage.data, force=True
+                )
 
         if iterate:
             return _run_sync_wrap()

--- a/tests/viz/test_bqp.py
+++ b/tests/viz/test_bqp.py
@@ -18,7 +18,17 @@ def test_bqp_smoke(monkeypatch, lt_ctx, default_raw):
     IPython.display.display.assert_called()
 
 
-def test_empty(monkeypatch, lt_ctx, default_raw):
+def test_bqp_asymm(monkeypatch, lt_ctx, default_raw_asymm):
+    pytest.importorskip("bqplot")
+    udfs = [SumSigUDF(), SumUDF()]
+    monkeypatch.setattr(IPython.display, 'display', mock.MagicMock())
+    monkeypatch.setattr(lt_ctx, 'plot_class', BQLive2DPlot)
+    lt_ctx.run_udf(dataset=default_raw_asymm, udf=udfs, plots=True)
+    IPython.display.display.assert_called()
+
+
+def test_empty(monkeypatch, lt_ctx, default_raw_asymm):
+    default_raw = default_raw_asymm
     pytest.importorskip("bqplot")
     udf = SumSigUDF()
     monkeypatch.setattr(IPython.display, 'display', mock.MagicMock())


### PR DESCRIPTION
Fixes issues with non-square plots

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
