### PR TITLE
Add support for Python 3.10 in CI

### DIFF
--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -91,17 +91,19 @@ stages:
           Python36:
             python.version: '3.6'
             TOXENV: 'py36-data'
-          # 3.7: default in current Debian stable
           Python37:
             python.version: '3.7'
             TOXENV: 'py37-data'
           # Python38:
           #   python.version: '3.8'
           #   TOXENV: 'py38'
-          # Most recent supported version
+          # 3.9: default in current Debian stable
           Python39:
             python.version: '3.9'
             TOXENV: 'py39-data'
+          Python310:
+            python.version: '3.10'
+            TOXENV: 'py310-data'
       variables:
         TESTDATA_BASE_PATH: '/data/'
       steps:
@@ -161,6 +163,9 @@ stages:
           Python39:
             python.version: '3.9'
             TOXENV: 'py39'
+          Python310:
+            python.version: '3.10'
+            TOXENV: 'py310'
       variables:
         TOXENV: '$(TOXENV)'
       steps:

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -91,9 +91,6 @@ stages:
           Python36:
             python.version: '3.6'
             TOXENV: 'py36-data'
-          Python37:
-            python.version: '3.7'
-            TOXENV: 'py37-data'
           # Python38:
           #   python.version: '3.8'
           #   TOXENV: 'py38'
@@ -154,9 +151,6 @@ stages:
           Python36:
             python.version: '3.6'
             TOXENV: 'py36'
-          Python37:
-            python.version: '3.7'
-            TOXENV: 'py37'
           Python38:
             python.version: '3.8'
             TOXENV: 'py38'

--- a/docs/source/changelog/features/python-310.rst
+++ b/docs/source/changelog/features/python-310.rst
@@ -1,0 +1,3 @@
+[Feature] Support for Python 3.10
+=================================
+* Added Python 3.10 to our testing infrastructure (:issue:`1133`, :pr:`1258`).

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,7 +4,7 @@ Installation
 ============
 
 .. note::
-    LiberTEM can currently be used on Python 3.6, 3.7, 3.8 and >=3.9.3.
+    LiberTEM can currently be used on Python 3.6, 3.7, 3.8, >=3.9.3 and 3.10.
 
     If you would like to install the latest development version, please also
     see :ref:`installing from a git clone`.

--- a/setup.py
+++ b/setup.py
@@ -198,6 +198,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,21 @@ deps=
 commands=
     pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
 
-[testenv:py{36,37,38,39,310}-data]
+[testenv:py310-data]
+deps=
+    -rtest_requirements.txt
+    # Important fix for https://github.com/ercius/openNCEM/pull/40
+    git+https://github.com/ercius/openNCEM.git@123d1ca#egg=ncempy
+    hyperspy
+    stemtool
+    mrcfile
+    pims
+    scikit-image
+
+commands=
+    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
+
+[testenv:py{36,37,38}-data]
 deps=
     -rtest_requirements.txt
     hyperspy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py{36,37,38,39}, py{36,37,38,39}-data, benchmark, benchmark-cuda{101,102,110,114}, mypy
+envlist = flake8, py{36,37,38,39,310}, py{36,37,38,39,310}-data, benchmark, benchmark-cuda{101,102,110,114}, mypy
 
 [testenv]
 commands=
@@ -48,10 +48,6 @@ setenv=
 [testenv:py39-data]
 deps=
     -rtest_requirements.txt
-    # Include pyproject.toml to allow building for Python 3.9
-    # https://github.com/pyFFTW/pyFFTW/pull/226
-    # FIXME switch to release version as soon as included
-    git+https://github.com/pyFFTW/pyFFTW.git#egg=pyfftw
     # Important fix for https://github.com/ercius/openNCEM/pull/40
     git+https://github.com/ercius/openNCEM.git@123d1ca#egg=ncempy
     hyperspy
@@ -64,7 +60,7 @@ deps=
 commands=
     pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
 
-[testenv:py{36,37,38}-data]
+[testenv:py{36,37,38,39,310}-data]
 deps=
     -rtest_requirements.txt
     hyperspy


### PR DESCRIPTION
- Remove pyfftw special-case from tox.ini
- Add py310 tox env
- Fix comment: Python version in debian stable is 3.9
- Add azure devops jobs for Python 3.10 in the matrices for data_tests
  and linux_tests

Fixes #1133 

## TODO

- [x] fix `primesieve` ,which does compile but fails at runtime

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
