### PR TITLE
Ensure unique CUDA worker names

### DIFF
--- a/docs/source/changelog/misc/cuda_workers.rst
+++ b/docs/source/changelog/misc/cuda_workers.rst
@@ -1,0 +1,6 @@
+[Misc] Allow spawning multiple CUDA workers on same device
+==========================================================
+
+* :function:`~libertem.executor.dask.cluster_spec` now accepts the same
+  CUDA device ID multiple times to spawn multiple workers on the same GPU.
+  This can help increase GPU resource utilisation for some workloads.

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -58,7 +58,8 @@ def cluster_spec(
         number and identification of workers, not the CPU cores that are used.
     cudas
         IDs for CUDA device workers. LiberTEM will use the IDs specified here. This
-        has to match CUDA device IDs on the system.
+        has to match CUDA device IDs on the system. Specify the same ID multiple times
+        to spawn multiple workers on the same CUDA device.
     has_cupy
         Specify if the cluster should signal that it supports GPU-based array programming using
         CuPy
@@ -145,6 +146,9 @@ def cluster_spec(
 
     for cuda in cudas:
         worker_name = f'{name}-cuda-{cuda}'
+        if worker_name in workers_spec:
+            num_with_name = sum(n.startswith(worker_name) for n in workers_spec)
+            worker_name = f'{worker_name}-{num_with_name - 1}'
         cuda_spec = deepcopy(cuda_base_spec)
         cuda_spec['options']['preload'] = preload + (
             'from libertem.executor.dask import worker_setup; '

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -297,3 +297,8 @@ def test_use_plain_dask(hdf5_ds_1):
 
     assert np.all(udf_res['device_class'].data == 'cpu')
     assert np.allclose(udf_res['on_device'].data, data.sum(axis=(0, 1)))
+
+
+def test_multi_cuda_worker():
+    spec = cluster_spec(cpus=(), cudas=(0, 1, 0, 1), has_cupy=False, num_service=0)
+    assert len(spec) == 4


### PR DESCRIPTION
Fixes the case where a CUDA worker spec with the same name squashes the previous worker spec in the `workers_spec` dictionary. This enables spawning multiple CUDA workers on the same GPU via `cluster_spec`, which currently has to be done by manually by editing the returned dictionary (now more challenging due to tracing setup!!).

The first cuda worker created on each device has an unmodified name ('default-cuda-0'), subsequent workers on the same device are named ('default-cuda-0-0', 'default-cuda-0-1', 'default-cuda-0-2' etc).

Closes #1225 

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code
