### PR TITLE
Include tests, Remove pyc / nbc / nbi files in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 graft src
+graft src/libertem/web/client/
 include LICENSE
 include README.rst
 graft client
@@ -10,3 +11,4 @@ include conftest.py
 include pytest.ini
 include test_requirements.txt
 include tox.ini
+global-exclude *.pyc *.nbi *.nbc __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,8 @@ graft client
 prune client/node_modules
 prune client/build
 prune client/coverage
+graft tests
+include conftest.py
+include pytest.ini
+include test_requirements.txt
+include tox.ini

--- a/docs/source/changelog/misc/change_manifest.rst
+++ b/docs/source/changelog/misc/change_manifest.rst
@@ -1,0 +1,6 @@
+[Misc] Remove cache files when packaging, include tests
+=======================================================
+
+* Adjusted MANIFEST.in to remove cache files when packaging for
+  PyPi, and add test files to enable testing when building for
+  conda-forge.


### PR DESCRIPTION
In response to #1271 and #1275, adjusts `MANIFEST.in` to include:

- tests/
- pytest.ini
- conftest.py
- tox.ini
- test_requirements.txt

and excludes:

- *.pyc
- *.nbc
- *.nbi
- `__pycache__/`

Tested by installing from the .whl output of `python -m build` into fresh py39 and py310 environments. Confirmed that the source distribution does not contain any of the cache files.

Tested also that the web client files are correctly packaged.

Bundle size has dropped from 4.1 MB to 3.0 MB even when including 800 KB of test files !

This should allow running tests when packaging for conda-forge.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

Closes #1275 