### PR TITLE
Fix for CoM r / ri inversion when switching mode

### DIFF
--- a/client/src/compoundAnalysis/components/CenterOfMassAnalysis.tsx
+++ b/client/src/compoundAnalysis/components/CenterOfMassAnalysis.tsx
@@ -317,6 +317,13 @@ const CenterOfMassAnalysis: React.FC<CompoundAnalysisProps> = ({ compoundAnalysi
                     <List.Item>
                         <List.Content>
                             <MaskShapeSelector selectedShape={maskShape} handleChange={(e, data) => {
+                                if (data.value === CoMMaskShapes.RING && ri >= r){
+                                    // Fixes r being set smaller than ri when the ri handle is hidden
+                                    // and the constraint is therefore no longer applied
+                                    // Only possible when switching to RING from DISK
+                                    // Otherwise maintains previous memory behaviour of r and ri
+                                    setRI(r * 0.5)
+                                }
                                 setMaskShape(data.value as CoMMaskShapes)
                             }} />
                         </List.Content>


### PR DESCRIPTION
Fixes #1191. This is a minimal solution to the problem, I simply check if `r > ri` when switching to Ring mode and otherwise arbitrarily set `ri = r * 0.5` (which matches how the values initialize).

An alternative solution I thought of would be to update `ri` even when in Disk mode as a secondary effect of changing the `r` handle. It wouldn't display, of course, and would maintain the ratio of `r` to `ri` at the expense of losing the 'memory' of `ri` that we currently have when changing from Ring to Disk and back again. (This solution is also a bit more difficult to implement and adds an extra callback / operation per 'move' of the r-handle, and this callback would need to be disabled when actually in Ring mode).

I haven't pushed the updated client yet as I wanted to get your input @sk1p 


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code