### PR TITLE
Pick random port for libertem-server if default/choice not available

### DIFF
--- a/docs/source/changelog/misc/pick_free_port.rst
+++ b/docs/source/changelog/misc/pick_free_port.rst
@@ -1,0 +1,6 @@
+[Misc] Server launcher picks free port if default/choice in use
+===============================================================
+
+* The function launching the `libertem-server` application will now
+  pick a free, random port if the default or chosen port is in use.
+  Closes #1184.

--- a/docs/source/changelog/misc/pick_free_port.rst
+++ b/docs/source/changelog/misc/pick_free_port.rst
@@ -1,6 +1,7 @@
-[Misc] Server launcher picks free port if default/choice in use
-===============================================================
+[Misc] Server launcher picks free port if default in use
+========================================================
 
 * The function launching the `libertem-server` application will now
-  pick a free, random port if the default or chosen port is in use.
-  Closes #1184.
+  pick a free, random port if the default port is in use. Choosing 
+  an explicit port will continue to raise an error.
+  Closes :issue:`1184`.

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -61,4 +61,4 @@ def main(port, local_directory, browser, log_level, insecure, host="localhost",
         numeric_level = getattr(logging, log_level.upper(), None)
         if not isinstance(numeric_level, int):
             raise click.UsageError(f'Invalid log level: {log_level}.\n{log_values}')
-        run(host, port, browser, local_directory, numeric_level, token, preload)
+        run(host, port, browser, local_directory, numeric_level, token, preload, is_custom_port)

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -48,7 +48,8 @@ def main(port, local_directory, browser, log_level, insecure, host="localhost",
     from libertem.common.threading import set_num_threads_env
     from libertem.common.tracing import maybe_setup_tracing
     token = get_token(token_path)
-    if token is None and host != 'localhost' and not insecure:
+    is_localhost = host in ['localhost', '127.0.0.1', '::1']
+    if token is None and not is_localhost and not insecure:
         raise click.UsageError(
             f'listening on non-localhost {host}:{port} currently requires token authentication '
             f'or --insecure'

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -22,9 +22,9 @@ def get_token(token_path):
 
 @click.command()
 @click.option('-h', '--host', help='host on which the server should listen on',
-              default="localhost", type=str)
-@click.option('-p', '--port', help='port on which the server should listen on',
-              default=9000, type=int)
+              default="localhost", type=str, show_default=True)
+@click.option('-p', '--port', help='port on which the server should listen on, [default: 9000]',
+              default=None, type=int)
 @click.option('-d', '--local-directory', help='local directory to manage dask-worker-space files',
               default='dask-worker-space', type=str)
 @click.option('-b/-n', '--browser/--no-browser',
@@ -41,6 +41,10 @@ def get_token(token_path):
               default=False, is_flag=True)
 def main(port, local_directory, browser, log_level, insecure, host="localhost",
         token_path=None, preload: Tuple[str] = ()):
+    is_custom_port = port is not None
+    if port is None:
+        port = 9000
+
     from libertem.common.threading import set_num_threads_env
     from libertem.common.tracing import maybe_setup_tracing
     token = get_token(token_path)

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -6,6 +6,7 @@ import signal
 import select
 import threading
 import webbrowser
+import ipaddress
 from functools import partial
 import hmac
 import hashlib
@@ -225,9 +226,15 @@ def run(host, port, browser, local_directory, numeric_level, token, preload, str
         port = _port
 
     main(bound_sockets, event_registry, shared_state, token)
-    log.info(f"listening on http://{host}:{port}")
+
+    try:
+        is_ipv6 = isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address)
+    except ValueError:
+        is_ipv6 = False
+    url = f'http://[{host}]:{port}' if is_ipv6 else f'http://{host}:{port}'
+    log.info(f"listening on {url}")
     if browser:
-        webbrowser.open(f'http://{host}:{port}')
+        webbrowser.open(url)
     loop = asyncio.get_event_loop()
     handle_signal(shared_state)
     # Strictly necessary only on Windows, but doesn't do harm in any case.


### PR DESCRIPTION
Closes #1184 

Change the way the server binds to a port `server.bind_socket()` rather than `server.listen()` so that we can explicitly create the socket ourselves and set/access its port. Sets a random port if the default/choice by using the alias port 0 when binding to the socket. Required returning the socket object from server.py:main() so that server.py:run() can launch the correct address in the browser tab.

Tested running/using the server on Windows and Linux. I think there is no direct testing of the server.py:main/run, though, I will  try to look into that.


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code