### PR TITLE
Tweak nbval regex once again

### DIFF
--- a/nbval_sanitize.cfg
+++ b/nbval_sanitize.cfg
@@ -1,9 +1,9 @@
 [cpu_times]
-regex: CPU times: user (\d+min ?)?([\d\.e+]+ ?[nmµ]?s)?, sys: (\d+min )?([\d\.e+]+ ?[mnµ]?s)?, total: (\d+min )?([\d\.e+]+ ?[nmµ]?s)?
+regex: CPU times: user (\d+min ?)?([\d\.e+]+ ?[nmµ]?s)?, sys: (\d+min ?)?([\d\.e+]+ ?[mnµ]?s)?, total: (\d+min ?)?([\d\.e+]+ ?[nmµ]?s)?
 replace: CPU_TIMES
 
 [wall_time]
-regex: Wall time: (\d+min )?([\d\.e+]+ ?[nmµ]?s)?
+regex: Wall time: (\d+min ?)?([\d\.e+]+ ?[nmµ]?s)?
 replace: WALL_TIME
 
 [default_repr]


### PR DESCRIPTION
Should fix the following error:

2022-06-27T11:41:19.3546591Z [94mTraceback:[0m
2022-06-27T11:41:19.3547258Z [94m mismatch 'stdout'[91m
2022-06-27T11:41:19.3547473Z
2022-06-27T11:41:19.3547910Z  assert reference_output == test_output failed:
2022-06-27T11:41:19.3548106Z
2022-06-27T11:41:19.3548591Z   'CPU_TIMES\nWALL_TIME\n' == 'CPU_TIMES1mi...LL_TIME1min\n'
2022-06-27T11:41:19.3549050Z   - CPU_TIMES1min
2022-06-27T11:41:19.3549415Z   ?          ----
2022-06-27T11:41:19.3549709Z   + CPU_TIMES
2022-06-27T11:41:19.3550078Z   - WALL_TIME1min
2022-06-27T11:41:19.3550428Z   ?          ----
2022-06-27T11:41:19.3550858Z   + WALL_TIME

... and related errors for the CPU_TIMES output

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
