### PR TITLE
Fix coverage for multiprocessing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,6 @@ exclude = .git,__pycache__,.tox,build,dist,node_modules,TOXENV
 [coverage:run]
 branch = True
 include = src/
-concurrency =
-    thread
-    multiprocessing
 
 [coverage:report]
 # Regexes for lines to exclude from consideration

--- a/tests/io/datasets/test_npy.py
+++ b/tests/io/datasets/test_npy.py
@@ -220,7 +220,7 @@ def test_auto_sig_dims(lt_ctx):
     assert ds._sig_dims == 3
 
 
-def test_shape_arg_smallernav(default_npy_filepath, default_raw_data, lt_ctx):
+def test_shape_arg_smallernav(default_npy, default_npy_filepath, default_raw_data, lt_ctx):
     nav_shape, sig_shape = default_raw_data.shape[:2], default_raw_data.shape[2:]
     smaller_nav_shape = tuple(n - 1 for n in nav_shape)
     ds = lt_ctx.load(
@@ -236,7 +236,7 @@ def test_shape_arg_smallernav(default_npy_filepath, default_raw_data, lt_ctx):
     assert result.data.shape == smaller_nav_shape
 
 
-def test_shape_arg_flatnav(default_npy_filepath, default_raw_data, lt_ctx):
+def test_shape_arg_flatnav(default_npy, default_npy_filepath, default_raw_data, lt_ctx):
     nav_shape, sig_shape = default_raw_data.shape[:2], default_raw_data.shape[2:]
     flat_nav_shape = (prod(nav_shape),)
     ds = lt_ctx.load(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = flake8, py{36,37,38,39,310}, py{36,37,38,39,310}-data, benchmark, benc
 
 [testenv]
 commands=
-    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/}
+    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg --junitxml=junit.xml {posargs:tests/}
     # win_tweaks.py depends on modules that are only available on Windows
     pytest --doctest-modules --ignore=src/libertem/common/win_tweaks.py src/libertem/
 deps=
@@ -41,7 +41,7 @@ passenv=
 
 [testenv:numba_coverage]
 commands=
-    pytest --durations=5 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml -m with_numba --junitxml=junit.xml {posargs:tests/}
+    pytest --durations=5 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg -m with_numba --junitxml=junit.xml {posargs:tests/}
 setenv=
     NUMBA_DISABLE_JIT=1
 
@@ -58,7 +58,7 @@ deps=
     scikit-image<0.19
 
 commands=
-    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
+    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
 
 [testenv:py310-data]
 deps=
@@ -72,7 +72,7 @@ deps=
     scikit-image
 
 commands=
-    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
+    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
 
 [testenv:py{36,37,38}-data]
 deps=
@@ -85,7 +85,7 @@ deps=
     scikit-image<0.19
 
 commands=
-    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
+    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg --junitxml=junit.xml {posargs:tests/io/datasets tests/executor/test_functional.py}
 
 [testenv:notebooks]
 deps=
@@ -100,7 +100,7 @@ extras=
     hdbscan
     bqplot
 commands=
-    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --junitxml=junit.xml --nbval --sanitize-with nbval_sanitize.cfg -p no:python --current-env {posargs:examples/}
+    pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg --junitxml=junit.xml --nbval --sanitize-with nbval_sanitize.cfg -p no:python --current-env {posargs:examples/}
 passenv=
     TESTDATA_BASE_PATH
     # HyperSpy expects this on Windows


### PR DESCRIPTION
Fixes #545 

These days, `pytest-cov` "just works" with threading and multiprocessing, but only if there is no additional direct configuration of `coverage`. This should improve coverage reporting from our integration tests, and is also a good preparation for #1267 

Snuck in a fix for npy tests not working well with `pytest-xdist`.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
