### PR TITLE
Fix for `UDFData.get()` on missing key

### DIFF
--- a/docs/source/changelog/bugfix/params_get.rst
+++ b/docs/source/changelog/bugfix/params_get.rst
@@ -1,0 +1,6 @@
+[Bugfix] Fix UDFData.get(key, default)
+======================================
+
+* Fix for the method :code:`UDFData.get(key, default)` which previously
+  could not return the default parameter due to catching the wrong
+  error. (:issue:`1284`).

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -356,7 +356,7 @@ class UDFData:
     ) -> Optional[Union[T, np.ndarray, BufferWrapper]]:
         try:
             return self.__getattr__(k)
-        except KeyError:
+        except (KeyError, AttributeError):
             return default
 
     def __setattr__(self, k: str, v: "nt.ArrayLike") -> None:

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -691,6 +691,7 @@ class ParamsCheckUDF(UDF):
         assert isinstance(self.params.int_param, int)
         assert self.params.get('is_222', default=None) == 222
         assert self.params.get('is_missing', default=333) == 333
+        assert self.params.get('is_missing') is None
 
 
 def test_params_check(lt_ctx):


### PR DESCRIPTION
Closes #1284 , catches both the existing `KeyError` and now also `AttributeError`.

Also added a test case for the method for coverage.

Note that there is a change in behaviour here: before, calling `.get` on a missing key would raise, now it will silently return None. This is consistent with the behaviour of `dict.get()` but is a (very small) API change for LiberTEM.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code