### PR TITLE
Fix scipy deprecation warnings

### DIFF
--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -9,7 +9,7 @@ from libertem.utils import make_polar
 # Import here for backwards compatibility, refs #1031
 from libertem.common.sparse import to_dense, to_sparse, is_sparse  # NOQA: F401
 
-MaskArrayType = Union[np.ndarray, sp.coo.coo_matrix, sp.dok.dok_matrix]
+MaskArrayType = Union[np.ndarray, sp.coo_matrix, sp.dok_matrix]
 MaskFactoriesType = Union[Callable[[], MaskArrayType], Iterable[Callable[[], MaskArrayType]]]
 
 

--- a/src/libertem/utils/generate.py
+++ b/src/libertem/utils/generate.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 from libertem.common.math import prod
 from libertem.utils import make_cartesian, make_polar, frame_peaks

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 import libertem.utils as ut
 from libertem.utils.generate import hologram_frame
 


### PR DESCRIPTION
See https://github.com/scipy/scipy/releases/tag/v1.8.0 - "Clear split
between public and private API"

    2022-07-23T09:36:06.8980821Z .tox/py310/lib/python3.10/site-packages/libertem/masks.py:12
    2022-07-23T09:36:06.8981593Z   /azp/agent/_work/1/s/.tox/py310/lib/python3.10/site-packages/libertem/masks.py:12: DeprecationWarning: Please use `coo_matrix` from the `scipy.sparse` namespace, the `scipy.sparse.coo` namespace is deprecated.
    2022-07-23T09:36:06.8982174Z     MaskArrayType = Union[np.ndarray, sp.coo.coo_matrix, sp.dok.dok_matrix]
    2022-07-23T09:36:06.8982378Z
    2022-07-23T09:36:06.8982821Z .tox/py310/lib/python3.10/site-packages/libertem/masks.py:12
    2022-07-23T09:36:06.8983586Z   /azp/agent/_work/1/s/.tox/py310/lib/python3.10/site-packages/libertem/masks.py:12: DeprecationWarning: Please use `dok_matrix` from the `scipy.sparse` namespace, the `scipy.sparse.dok` namespace is deprecated.
    2022-07-23T09:36:06.8984163Z     MaskArrayType = Union[np.ndarray, sp.coo.coo_matrix, sp.dok.dok_matrix]
    2022-07-23T09:36:06.8984351Z
    2022-07-23T09:36:06.8984729Z .tox/py310/lib/python3.10/site-packages/libertem/utils/generate.py:2
    2022-07-23T09:36:06.8985566Z   /azp/agent/_work/1/s/.tox/py310/lib/python3.10/site-packages/libertem/utils/generate.py:2: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
    2022-07-23T09:36:06.8986139Z     from scipy.ndimage.filters import gaussian_filter
    2022-07-23T09:36:06.8986314Z
    2022-07-23T09:36:06.8986511Z tests/test_utils.py:3
    2022-07-23T09:36:06.8986973Z   /azp/agent/_work/1/s/tests/test_utils.py:3: DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
    2022-07-23T09:36:06.8987471Z     from scipy.ndimage.filters import gaussian_filter

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
