### PR TITLE
Delete continuous releases using the list endpoint

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -318,12 +318,17 @@ def upload_to_github(verbose, files, token, release):
             "draft": False,
             "prerelease": True,
         })
-        # first, delete existing continuous tag and release:
+        # first, delete existing continuous tag and release(s):
         try:
-            cont_release = repo.get_release("continuous")
-            cont_release.delete_release()
-            if verbose:
-                print("deleted existing continuous release")
+            continuous_releases = [
+                r
+                for r in repo.get_releases()
+                if r.tag_name == "continuous"
+            ]
+            for cont_release in continuous_releases:
+                cont_release.delete_release()
+                if verbose:
+                    print("deleted existing continuous release")
         except UnknownObjectException:
             pass
         try:


### PR DESCRIPTION
Probably fixes #414

For some reason, `repo.get_release("continuous")` does not return a release object, which is probably the reason we had leftover releases. List and filter instead.

Scheduled for 0.11 as I don't want to touch the release script shortly before 0.10.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
