### PR TITLE
Don't freeze when missing in-flight tasks

### DIFF
--- a/docs/source/changelog/bugfix/pipelined-timeout.rst
+++ b/docs/source/changelog/bugfix/pipelined-timeout.rst
@@ -1,0 +1,4 @@
+[Bugfix] Avoid deadlock on missing tasks
+========================================
+
+* Don't wait infinitely for missing in-flight tasks to avoid deadlocks.

--- a/docs/source/changelog/bugfix/pipelined-timeout.rst
+++ b/docs/source/changelog/bugfix/pipelined-timeout.rst
@@ -1,4 +1,4 @@
 [Bugfix] Avoid deadlock on missing tasks
 ========================================
 
-* Don't wait infinitely for missing in-flight tasks to avoid deadlocks.
+* Don't wait infinitely for missing in-flight tasks to avoid deadlocks (:pr:`1311`).


### PR DESCRIPTION
Tested in the DECTRIS live acquisition with a missing frame that
causes an assertion error.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
