### PR TITLE
(Partially) optimise Shape/Slice

### DIFF
--- a/docs/source/changelog/misc/slice_shape_optim.rst
+++ b/docs/source/changelog/misc/slice_shape_optim.rst
@@ -1,0 +1,6 @@
+[Misc] Optimise Slice/Shape behaviour for tiles
+===============================================
+
+* Reduces overhead of (re-)constructing :code:`Slice` and :code:`Shape`
+  objects when slicing tiles, in particular focused on the method
+  :code:`BufferWrapper.get_contiguous_view_for_tile()`. (:issue:`1313`)

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -557,12 +557,15 @@ class BufferWrapper:
         '''
         if self._kind == "sig":
             for key, view in self._contiguous_cache.items():
-                sl = key.get(sig_only=True)
+                sl, _ = self._slice_from_key(key, tuple())
+                _, _, sig_dims = key
+                sl = sl[-sig_dims:]
                 self._data[sl] = view
-                if debug and not disjoint(key, self._contiguous_cache.keys()):
-                    raise RuntimeError(
-                        "`key` %r should be disjoint with existing keys" % key
-                    )
+                # FIXME disjoint() for tuple keys
+                # if debug and not disjoint(key, self._contiguous_cache.keys()):
+                #     raise RuntimeError(
+                #         "`key` %r should be disjoint with existing keys" % key
+                #     )
             self._contiguous_cache = dict()
         else:
             if self._contiguous_cache:


### PR DESCRIPTION
Addresses #1313 at least for the method `BufferWrapper.get_contiguous_view_for_tile`.

I don't have an infallible way to prove the performance advantage yet, but comparing cProfiles for before/after this change, on the same data/tiling as in #1313 but as a dense `MemoryDataSet` + `InlineJobExecutor`:

Before:
![image](https://user-images.githubusercontent.com/78845903/189874120-cbafaf37-7afb-4524-983b-bb3579608ef7.png)

After:
![image](https://user-images.githubusercontent.com/78845903/189874246-888dae0b-18ad-42c7-860c-d8cc276197b5.png)

`get_contiguous_view_for_tile` doesn't show in the _After_ image, but the time spent in this function is:

![image](https://user-images.githubusercontent.com/78845903/189878078-b6ee5917-60da-4204-99b9-49bd57d7e699.png)

compared to 44% of `run_for_partition` time before these changes.

Summary of changes / rationale:

- Where possible avoid calling the `Shape` and `Slice` constructors, which happens a lot throughout the code and adds overhead everywhere.
 - Adds `NavOnlyShape` and `SigOnlyShape` with optimised constructors + methods, as sub-classes of `Shape`
- Don't construct `Slice` objects to use as keys in `BufferWrapper._contiguous_cache`, only to subsequently convert the `Slice` back to a tuple of `slice` objects for slicing the data. Instead the keys are now a native tuple `(origin_tuple, shape_tuple, sig_dims)` which can still be cached, and converted directly into `tuple(slice)` (could be converted to `namedtuple`)
- `lru_cache` the conversion from the `key` tuple to `tuple(slice)` as the slices we need are repeated in each partition

These optimisations are focused on `get_contiguous_view_for_tile` but I think similar changes could be made in lots of places in the codebase where we repeatedly access `shape.sig`, `shape.dims` etc. One thing to do in the future would be to use `functools.cached_property` where possible (currently only py3.8 but it can be backported) as I believe the assumed behaviour is that Shapes and Slices are effectively immutable? Another possibility is actually subclassing `tuple` to implement `Shape`, which I tried here but found it didn't help much in this case. We should also look into optimisation of `UDFData._get_buffers` which is the next lowest hanging fruit.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code