### PR TITLE
ValidationUDF tracks which data has been 'seen'

### DIFF
--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -26,7 +26,8 @@ def test_validation(lt_ctx):
 
     udf = ValidationUDF(reference=data.reshape((-1, 16, 16)))
     res = lt_ctx.run_udf(dataset=dataset, udf=udf)
-    assert res['nav_shape'].data.shape == (16, 16)
+    assert res['seen'].data.shape == (16, 16)
+    assert np.sum(res['seen'].data) == np.prod((16, 16))
 
     with pytest.raises(AssertionError):
         data2 = data.copy()

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -27,7 +27,6 @@ def test_validation(lt_ctx):
     udf = ValidationUDF(reference=data.reshape((-1, 16, 16)))
     res = lt_ctx.run_udf(dataset=dataset, udf=udf)
     assert res['seen'].data.shape == (16, 16)
-    assert np.sum(res['seen'].data) == np.prod((16, 16))
 
     with pytest.raises(AssertionError):
         data2 = data.copy()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -221,6 +221,9 @@ class ValidationUDF(UDF):
             if slices is None:
                 assert roi is not None and not roi[flat_idx]
                 continue
+            # Check that ROI=true frames match
+            if roi is not None:
+                assert roi[flat_idx]
             # This could be optimized with some slice combination
             # but using a bitmask is completely robust and not
             # actually that slow to run

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -176,6 +176,11 @@ class ValidationUDF(UDF):
             self.meta.slice.get(self.params.reference), tile
         )
 
+    def merge(self, dest, src):
+        # Need to sum results even for a nav merge to avoid
+        # missing double visits by overwriting with a slice
+        dest.seen[:] += src.seen
+
     def _do_get_results(self):
         results = super()._do_get_results()
         if self.meta.roi is None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -171,10 +171,30 @@ class ValidationUDF(UDF):
         }
 
     def process_tile(self, tile):
+        # This will increment self.results.seen for every tile
+        # i.e. multiple times per frame, the final value will
+        # correspond to the number of tiles each frame was split into
+        # If we can assume that the tiling scheme logic is robust
+        # then all the visited frames should share the same value
+        # and that all the pixels of a given frame were 'visited'
+        # the postprocess method is used to validate that all frames
+        # were visited the same number of time (or not at all)
         self.results.seen[:] += 1
         assert self.params.validation_function(
             self.meta.slice.get(self.params.reference), tile
         )
+
+    def postprocess(self):
+        """
+        checks if all frames were visited either:
+         - never (i.e. not in partition or masked by roi)
+         - the same number of times as all other visited frames in the partition
+        """
+        seen_values = np.unique(self.results.seen)
+        assert seen_values.size in (1, 2)
+        if seen_values.size == 2:
+            assert 0 in seen_values
+        self.results.seen[:] = np.where(self.results.seen, 1, 0)
 
     def merge(self, dest, src):
         # Need to sum results even for a nav merge to avoid

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -227,7 +227,7 @@ class ValidationUDF(UDF):
             for sl in slices:
                 frame_mask[sl] = True
             assert frame_mask.all()
-        assert flat_idx == self.meta.dataset_shape.nav.size
+        assert (flat_idx + 1) == self.meta.dataset_shape.nav.size
         return results
 
 


### PR DESCRIPTION
Addresses #1282.

Overrides `UDF._do_get_results(self)` on `ValidationUDF` to verify that every frame is fully tiled and visited during the processing, taking into account the ROI (if provided).

~~As tiled processing visits each frame potentially multiple times, the raw 'seen'/'visited' values can be >= 1, here I've made the assumption that the tiling code is robust/correct so I don't verify that each pixel of each frame was seen, only that each frame was split in to the same number of tiles (or never seen at all in the partition).~~

~~Needs test cases to verify this actually raises when a dataset is not visited completely, which will require some kind of deliberately broken over-ride implementation of `get_tiles`.~~


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code
