### PR TITLE
Add [dectris] option to LiberTEM-live test install

### DIFF
--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -323,7 +323,7 @@ stages:
       - bash: $(Agent.TempDirectory)/venv/bin/pip install $(Build.SourcesDirectory)/LiberTEM/
         displayName: install LiberTEM
 
-      - bash: $(Agent.TempDirectory)/venv/bin/pip install $(Build.SourcesDirectory)/LiberTEM-live/
+      - bash: $(Agent.TempDirectory)/venv/bin/pip install "$(Build.SourcesDirectory)/LiberTEM-live/[dectris]"
         displayName: install LiberTEM-live
 
       - bash: $(Agent.TempDirectory)/venv/bin/pip install -r $(Build.SourcesDirectory)/LiberTEM-live/test_requirements.txt


### PR DESCRIPTION
Updates the Azure pipelines definition for `test live_integration` to include the `libertem-live[dectris]` optional extra.

~~What I don't know is if running `/azp run libertem.libertem-data` here will use the updated file or the already-defined file?~~


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code