### PR TITLE
Allow integer arguments for `cluster_spec`

### DIFF
--- a/docs/source/changelog/misc/int_cluster_spec.rst
+++ b/docs/source/changelog/misc/int_cluster_spec.rst
@@ -1,0 +1,8 @@
+[Misc] Specify workers using integer arguments
+==============================================
+
+* The methods :method:`PipelinedExecutor.make_spec` and
+  :function:`libertem.executor.dask.cluster_spec` both now
+  accept integers for their :code:`cpus` and :code:`cudas`
+  arguments, in addition to the existing iterable forms.
+  (:issue:`1294`).

--- a/src/libertem/executor/utils/__init__.py
+++ b/src/libertem/executor/utils/__init__.py
@@ -1,4 +1,4 @@
-from typing import Iterable, int, Union
+from typing import Iterable, Union
 import itertools
 import warnings
 

--- a/src/libertem/executor/utils/__init__.py
+++ b/src/libertem/executor/utils/__init__.py
@@ -1,0 +1,38 @@
+from typing import Iterable, int, Union
+import itertools
+import warnings
+
+
+def assign_cudas(cudas: Union[int, Iterable[int]]) -> Iterable[int]:
+    """
+    Takes the cudas argument to :code:`cluster_spec` and
+    converts it into a properly formatted iterable of CUDA
+    device ids
+
+    If cudas is an integer, assigns this many workers to
+    device ids in a round-robin fashion, where CUDA devices
+    can be detected. If the devices cannot be detected raise
+    a warning and assign device_ids in a sequential fashion.
+
+    Will also raise a warning if cudas is a non-empty iterable
+    on a system where the CUDA devices cannot be detected.
+    """
+    if isinstance(cudas, int) or len(cudas):
+        # Needed to know if we can assign CUDA workers
+        from libertem.utils.devices import detect
+        avail_cudas = detect()['cudas']
+        if not avail_cudas and cudas:  # needed in case cudas == 0
+            warnings.warn('Specifying CUDA workers on system with '
+                          'no visible CUDA devices',
+                          RuntimeWarning)
+            # If we are assigning from int, just use increasing
+            # device indices even if they are unavailable
+            avail_cudas = itertools.count()
+
+        if isinstance(cudas, int):
+            # Round-Robin-assign to available CUDA devices
+            # Can override by specifying cudas as an iterable
+            cudas_iter = itertools.cycle(avail_cudas)
+            cudas = tuple(next(cudas_iter) for _ in range(cudas))
+
+    return cudas

--- a/tests/executor/test_pipelined.py
+++ b/tests/executor/test_pipelined.py
@@ -367,6 +367,22 @@ def test_make_spec_multi_cuda():
     ]
 
 
+def test_make_spec_cpu_int():
+    int_spec = PipelinedExecutor.make_spec(cpus=4, cudas=tuple(), has_cupy=True)
+    range_spec = PipelinedExecutor.make_spec(cpus=range(4), cudas=tuple(), has_cupy=True)
+    assert range_spec == int_spec
+
+
+def test_make_spec_cuda_int():
+    spec_n = 2
+    cuda_spec = PipelinedExecutor.make_spec(cpus=[0], cudas=spec_n)
+    num_cudas = 0
+    for spec in cuda_spec:
+        if spec['device_kind'] == 'CUDA':
+            num_cudas += 1
+    assert num_cudas == spec_n
+
+
 def test_close_with_scatter():
     # make sure `.make_local` works:
     executor = None

--- a/tests/test_local_cluster.py
+++ b/tests/test_local_cluster.py
@@ -188,6 +188,21 @@ def test_start_local_cupyonly(hdf5_ds_1):
     assert np.allclose(udf_res['on_device'].data, data.sum(axis=(0, 1)))
 
 
+def test_cluster_spec_cpu_int():
+    int_spec = cluster_spec(cpus=4, cudas=tuple(), has_cupy=True)
+    range_spec = cluster_spec(cpus=range(4), cudas=tuple(), has_cupy=True)
+    assert range_spec == int_spec
+
+
+def test_cluster_spec_cudas_int():
+    spec_n = 4
+    cuda_spec = cluster_spec(cpus=tuple(), cudas=spec_n, has_cupy=True)
+    num_cudas = 0
+    for spec in cuda_spec.values():
+        num_cudas += spec.get('options', {}).get('resources', {}).get('CUDA', 0)
+    assert num_cudas == spec_n
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(not detect()['cudas'], reason="No CUDA devices")
 def test_start_local_cudaonly(hdf5_ds_1):


### PR DESCRIPTION
Closes #1294 . Covers `DaskJobExecutor` and `PipelinedExecutor`.

In order to round-robin assign CUDA ids we need to call `detect()` within the `make_spec` function (I delayed the import). I also added a warning when creating CUDA workers on a system with no detected CUDA devices.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code