### PR TITLE
`make_slices` obeys `num_partitions` (avoids hanging frames)

### DIFF
--- a/examples/Introduction to UDFs.ipynb
+++ b/examples/Introduction to UDFs.ipynb
@@ -85,7 +85,7 @@
        " {'name': 'Data kind', 'value': 'u'},\n",
        " {'name': 'Layout', 'value': '(1, 1)'},\n",
        " {'name': 'Partition shape', 'value': '(2075, 256, 256)'},\n",
-       " {'name': 'Number of partitions', 'value': '33'},\n",
+       " {'name': 'Number of partitions', 'value': '32'},\n",
        " {'name': 'Number of frames skipped at the beginning', 'value': 0},\n",
        " {'name': 'Number of frames ignored at the end', 'value': 0},\n",
        " {'name': 'Number of blank frames inserted at the beginning', 'value': 0},\n",

--- a/nbval_sanitize.cfg
+++ b/nbval_sanitize.cfg
@@ -17,3 +17,7 @@ replace: DEFAULT_REPR
 [figure_size]
 regex: Figure size [0-9]+x[0-9]+
 replace: FIGURE
+
+[num_partitions]
+regex: 'name': 'Number of partitions', 'value': '[0-9]+'
+replace: NUM_PART

--- a/src/libertem/io/dataset/base/partition.py
+++ b/src/libertem/io/dataset/base/partition.py
@@ -74,15 +74,17 @@ class Partition:
                 RuntimeWarning
             )
             num_partitions = 1
-        boundaries = tuple(
-            np.linspace(
-                0,
-                num_frames,
-                num=max(2, num_partitions + 1),
-                endpoint=True,
-                dtype=int,
-            )
+        boundaries = np.linspace(
+            0,
+            num_frames,
+            num=max(2, num_partitions + 1),
+            endpoint=True,
+            dtype=int,
         )
+
+        # Cast explicitly to tuple[int, ...] to avoid pickle/JSON errors
+        boundaries = tuple(map(int, boundaries))
+
         for (start, stop) in zip(boundaries[:-1], boundaries[1:]):
             part_slice = Slice(
                 origin=(start,) + tuple([0] * shape.sig.dims),

--- a/src/libertem/io/dataset/base/partition.py
+++ b/src/libertem/io/dataset/base/partition.py
@@ -67,13 +67,13 @@ class Partition:
         indices for each partition.
         """
         num_frames = shape.nav.size
-        if num_partitions <= num_frames:
+        if num_partitions > num_frames:
             warnings.warn(
                 "dataset contains fewer frames than partitions, "
-                "setting equal to allow processing (use fewer workers?)",
+                "setting num_part to 1 to allow processing (use fewer workers?)",
                 RuntimeWarning
             )
-            num_partitions = num_frames
+            num_partitions = 1
         boundaries = tuple(
             np.linspace(
                 0,

--- a/src/libertem/io/dataset/memory.py
+++ b/src/libertem/io/dataset/memory.py
@@ -355,7 +355,7 @@ class MemPartition(BasePartition):
         return mt
 
     def get_tiles(self, *args, **kwargs):
-        if args and isinstance(args, TilingScheme):
+        if args and isinstance(args[0], TilingScheme):
             tiling_scheme = args[0]
             args = args[1:]
             intent = tiling_scheme.intent

--- a/src/libertem/io/dataset/memory.py
+++ b/src/libertem/io/dataset/memory.py
@@ -354,15 +354,15 @@ class MemPartition(BasePartition):
         self._force_tileshape = True
         return mt
 
-    def get_tiles(self, *args, **kwargs):
+    def get_tiles(self, tiling_scheme: TilingScheme, dest_dtype="float32", roi=None):
         # force our own tiling_scheme, if a tileshape is given:
         if self._tileshape is not None and self._force_tileshape:
             tiling_scheme = TilingScheme.make_for_shape(
                 tileshape=self._tileshape,
                 dataset_shape=self.meta.shape,
+                intent=tiling_scheme.intent,
             )
-            kwargs.update({"tiling_scheme": tiling_scheme})
-        tiles = super().get_tiles(*args, **kwargs)
+        tiles = super().get_tiles(tiling_scheme, dest_dtype=dest_dtype, roi=roi)
         if self._tiledelay:
             log.debug("delayed get_tiles, tiledelay=%.3f" % self._tiledelay)
             for tile in tiles:

--- a/tests/io/datasets/test_dm.py
+++ b/tests/io/datasets/test_dm.py
@@ -321,10 +321,10 @@ def test_missing_frames(lt_ctx, io_backend):
         for t in p.get_tiles(tiling_scheme=tiling_scheme):
             pass
 
-    assert p._start_frame == 12
-    assert p._num_frames == 3
-    assert p.slice.origin == (12, 0, 0)
-    assert p.slice.shape[0] == 3
+    assert p._start_frame == 11
+    assert p._num_frames == 4
+    assert p.slice.origin == (11, 0, 0)
+    assert p.slice.shape[0] == 4
     assert t.tile_slice.origin == (9, 0, 0)
     assert t.tile_slice.shape[0] == 1
 

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -285,10 +285,10 @@ def test_missing_frames(lt_ctx):
         for t in p.get_tiles(tiling_scheme=tiling_scheme):
             pass
 
-    assert p._start_frame == 348
-    assert p._num_frames == 2
-    assert p.slice.origin == (348, 0, 0)
-    assert p.slice.shape[0] == 2
+    assert p._start_frame == 262
+    assert p._num_frames == 88
+    assert p.slice.origin == (262, 0, 0)
+    assert p.slice.shape[0] == 88
     assert t.tile_slice.origin == (279, 0, 0)
     assert t.tile_slice.shape[0] == 1
 

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -41,6 +41,22 @@ def test_num_part_larger_than_num_frames():
         next(slice_iter)
 
 
+@pytest.mark.parametrize(
+    'repeat', range(30)
+)
+def test_make_slices(repeat):
+    num_part = np.random.randint(1, 41)
+    num_frames = np.random.randint(num_part, 333)
+    shape = Shape((num_frames,), 0)
+    slices = tuple(Partition.make_slices(shape=shape, num_partitions=num_part))
+    assert len(slices) == num_part
+    assert slices[0][0].origin[0] == 0
+    assert slices[-1][0].origin[0] + slices[-1][0].shape[0] == num_frames
+    assert slices[0][1] == 0
+    assert slices[-1][-1] == num_frames
+    assert all(s0[-1] == s1[1] for s0, s1 in zip(slices[:-1], slices[1:]))
+
+
 def test_roi_to_nd_indices():
     roi = np.full((5, 5), False)
     roi[1, 2] = True

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -45,15 +45,18 @@ def test_num_part_larger_than_num_frames():
     'repeat', range(30)
 )
 def test_make_slices(repeat):
+    sync_offset = np.random.randint(-5, 5)
     num_part = np.random.randint(1, 41)
     num_frames = np.random.randint(num_part, 333)
     shape = Shape((num_frames,), 0)
-    slices = tuple(Partition.make_slices(shape=shape, num_partitions=num_part))
+    slices = tuple(Partition.make_slices(shape=shape,
+                                         num_partitions=num_part,
+                                         sync_offset=sync_offset))
     assert len(slices) == num_part
     assert slices[0][0].origin[0] == 0
     assert slices[-1][0].origin[0] + slices[-1][0].shape[0] == num_frames
-    assert slices[0][1] == 0
-    assert slices[-1][-1] == num_frames
+    assert slices[0][1] == 0 + sync_offset
+    assert slices[-1][-1] == num_frames + sync_offset
     assert all(s0[-1] == s1[1] for s0, s1 in zip(slices[:-1], slices[1:]))
 
 

--- a/tests/udf/test_by_partition.py
+++ b/tests/udf/test_by_partition.py
@@ -55,7 +55,7 @@ class TouchUDF(UDF):
     'use_roi', (False, True)
 )
 @pytest.mark.parametrize(
-    'tileshape', (None, (7, 16, 16), (8*16, 16, 16))
+    'tileshape', (None, (7, 16, 16), (8 * 16, 16, 16))
 )
 def test_partition_roi(lt_ctx, use_roi, tileshape):
     data = _mk_random(size=(16, 16, 16, 16), dtype="float32")
@@ -65,11 +65,6 @@ def test_partition_roi(lt_ctx, use_roi, tileshape):
     else:
         roi = None
     udf = TouchUDF()
-    success = (tileshape is None) or (tileshape == (8*16, 16, 16))
-    if success:
-        res = lt_ctx.run_udf(dataset=dataset, udf=udf, roi=roi)
-        print(data.shape, res['touched'].data.shape)
-        assert np.all(res['touched'].raw_data == 1)
-    else:
-        with pytest.raises(Exception):
-            lt_ctx.run_udf(dataset=dataset, udf=udf, roi=roi)
+    res = lt_ctx.run_udf(dataset=dataset, udf=udf, roi=roi)
+    print(data.shape, res['touched'].data.shape)
+    assert np.all(res['touched'].raw_data == 1)

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -696,7 +696,7 @@ class CheckSigSliceFrame(UDF):
     'udf_class,tileshape,success', [
         (CheckSigSliceFrame, (3, 3, 5), False),
         (CheckSigSliceFrame, (3, 3, 7), True),
-        (CheckSigSlicePartition, (3, 3, 7), False),
+        (CheckSigSlicePartition, (3, 3, 7), True),
         (CheckSigSlicePartition, (15, 3, 7), True),
         (CheckSigSlice, (3, 2, 2), True),
     ],


### PR DESCRIPTION
Closes #1335 . Uses the implementation with `np.linspace`.

This required making a change to `MemoryPartition.get_tiles()` to propagate `tiling_intent` where available, which I think was actually a bug/oversight.

I also had to modify a number of test cases (including core tests in `tests/udf`) because they had been coded both for the old implementation of `make_slices` and the old implementation of `MemoryPartition.get_tiles()`. It seems like there were a few cases which previously were expected to raise with `pytest.raises` but now actually pass as with the other parametrizations of those tests. These changes should be thoroughly reviewed!

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code