### PR TITLE
Choose square `nav_shape` if detected `num_frames` is square (web-only)

### DIFF
--- a/docs/source/changelog/misc/square_nav_auto_web.rst
+++ b/docs/source/changelog/misc/square_nav_auto_web.rst
@@ -1,0 +1,7 @@
+[Misc] Guess a square nav_shape in the web UI if no other information
+=====================================================================
+
+* If a dataset does not declare its navigation shape then guess
+  a square nav_shape in the Web UI if the number of detected frames
+  is a square number. This can occur for the MIB, TVIPS, SEQ, MRC
+  and K2IS dataset formats. (:issue:`1309`)

--- a/src/libertem/common/math.py
+++ b/src/libertem/common/math.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Union
+from typing import Iterable, Union, Tuple
 
 import numpy as np
 
@@ -30,3 +30,33 @@ def prod(iterable: Iterable[ProdAccepted]):
         else:
             raise ValueError()
     return result
+
+
+def make_2D_square(shape: Tuple[int, ...]) -> Tuple[int, ...]:
+    """
+    Convert the 1D shape tuple into a square 2D shape tuple
+    if the size of shape is a square number
+
+    Non-square dim and len(shape) != 1 are passed directly through.
+    shape (1,) is considered square and returns (1, 1)
+
+    Parameters
+    ----------
+    shape : Tuple[int, ...]
+        1D shape tuple[int]
+
+    Returns
+    -------
+    Tuple[int, ...]
+        2D shape tuple[int, int] if shape is 1D and contains a square
+        number of elements, else the input shape is returned
+    """
+    if len(shape) != 1:
+        return shape
+    size = prod(shape)
+    if size < 1:
+        raise ValueError('Zero or negative shape.size')
+    dim, remainder = divmod(np.sqrt(size), 1)
+    if remainder == 0:
+        return (dim,) * 2
+    return shape

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -11,7 +11,7 @@ import numba
 from numba.typed import List
 from ncempy.io import dm
 
-from libertem.common.math import prod
+from libertem.common.math import prod, make_2D_square
 from libertem.common.buffers import zeros_aligned
 from libertem.common import Shape
 from libertem.common.messageconverter import MessageConverter
@@ -890,7 +890,7 @@ class K2ISDataSet(DataSet):
         sync_offset = num_frames - num_frames_w_shutter_active_flag_set
         nav_shape = executor.run_function(_get_nav_shape, path)
         if nav_shape is None:
-            nav_shape = (num_frames_w_shutter_active_flag_set,)
+            nav_shape = make_2D_square((num_frames_w_shutter_active_flag_set,))
         return {
             "parameters": {
                 "path": path,

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -10,7 +10,7 @@ from numba.typed import List as NumbaList
 import numba
 import numpy as np
 
-from libertem.common.math import prod
+from libertem.common.math import prod, make_2D_square
 from libertem.common import Shape
 from libertem.io.dataset.base.file import OffsetsSizes
 from libertem.common.messageconverter import MessageConverter
@@ -1121,7 +1121,7 @@ class MIBDataSet(DataSet):
         pathlow = path.lower()
         if pathlow.endswith(".mib"):
             image_count, sig_shape = executor.run_function(get_image_count_and_sig_shape, path)
-            nav_shape = tuple((image_count,))
+            nav_shape = make_2D_square((image_count,))
         elif pathlow.endswith(".hdr") and executor.run_function(is_valid_hdr, path):
             hdr = executor.run_function(read_hdr_file, path)
             image_count, sig_shape = executor.run_function(get_image_count_and_sig_shape, path)

--- a/src/libertem/io/dataset/mrc.py
+++ b/src/libertem/io/dataset/mrc.py
@@ -3,7 +3,7 @@ import logging
 
 from ncempy.io.mrc import fileMRC
 
-from libertem.common.math import prod
+from libertem.common.math import prod, make_2D_square
 from libertem.common import Shape
 from libertem.common.messageconverter import MessageConverter
 from .base import DataSet, FileSet, BasePartition, DataSetException, DataSetMeta, File
@@ -188,7 +188,7 @@ class MRCDataSet(DataSet):
             return {
                 "parameters": {
                     "path": path,
-                    "nav_shape": tuple((int(nav_shape),)),
+                    "nav_shape": make_2D_square((int(nav_shape),)),
                     "sig_shape": sig_shape,
                 },
                 "info": {

--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -36,7 +36,7 @@ import numpy as np
 import sparse
 from ncempy.io.mrc import mrcReader
 
-from libertem.common.math import prod
+from libertem.common.math import prod, make_2D_square
 from libertem.common import Shape
 from libertem.common.messageconverter import MessageConverter
 from libertem.io.dataset.base import (
@@ -610,7 +610,7 @@ class SEQDataSet(DataSet):
             return {
                 "parameters": {
                     "path": path,
-                    "nav_shape": tuple((image_count,)),
+                    "nav_shape": make_2D_square((image_count,)),
                     "sig_shape": sig_shape,
                 },
                 "info": {

--- a/src/libertem/io/dataset/tvips.py
+++ b/src/libertem/io/dataset/tvips.py
@@ -6,7 +6,7 @@ from typing import IO, TYPE_CHECKING, Dict, NamedTuple, List, Optional, Tuple
 import numpy as np
 from glob import glob, escape
 
-from libertem.common.math import prod
+from libertem.common.math import prod, make_2D_square
 from libertem.common import Shape
 from libertem.common.executor import JobExecutor
 from libertem.common.messageconverter import MessageConverter
@@ -447,7 +447,7 @@ class TVIPSDataSet(DataSet):
                 sync_offset, nav_shape = executor.run_function(detect_shape, path)
             except DetectionError:
                 sync_offset = 0
-                nav_shape = tuple((image_count,))
+                nav_shape = make_2D_square((image_count,))
         else:
             return False
         return {

--- a/tests/common/test_math.py
+++ b/tests/common/test_math.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from libertem.common.math import prod
+from libertem.common.math import prod, make_2D_square
 from libertem.common.shape import Shape
 
 
@@ -26,3 +26,24 @@ def test_prod(sequence, ref, typ):
     else:
         with pytest.raises(typ):
             res = prod(sequence)
+
+
+@pytest.mark.parametrize(
+    ('shape', 'result'), [
+        ((16,), (4, 4)),
+        ((100,), (10, 10)),
+        ((15,), (15,)),
+        ((1,), (1, 1)),
+        ((-20,), ValueError),
+        ((3, 7), (3, 7)),
+        (tuple(), tuple()),
+        ((0.4,), ValueError),
+    ]
+)
+def test_make_2D_square(shape, result):
+    if isinstance(result, tuple):
+        assert make_2D_square(shape) == result
+    elif issubclass(result, Exception):
+        with pytest.raises(result):
+            make_2D_square(shape)
+            return

--- a/tests/executor/test_pipelined.py
+++ b/tests/executor/test_pipelined.py
@@ -29,7 +29,7 @@ def pipelined_ex():
             # to prevent issues in already-pinned situations (i.e. containerized
             # environments), don't pin our worker processes in testing:
             pin_workers=False,
-            cleanup_timeout=0.5,
+            cleanup_timeout=5.,
         )
         yield executor
     finally:

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -116,7 +116,7 @@ def test_detect(lt_ctx):
     params = MIBDataSet.detect_params(MIB_TESTDATA_PATH, lt_ctx.executor)["parameters"]
     assert params == {
         "path": MIB_TESTDATA_PATH,
-        "nav_shape": (1024,),
+        "nav_shape": (32, 32),
         "sig_shape": (256, 256)
     }
 

--- a/tests/io/datasets/test_mrc.py
+++ b/tests/io/datasets/test_mrc.py
@@ -94,7 +94,7 @@ def test_detect_1(lt_ctx):
         executor=lt_ctx.executor,
     )["parameters"] == {
         'path': fpath,
-        'nav_shape': (4,),
+        'nav_shape': (2, 2),
         'sig_shape': (1024, 1024)
     }
 


### PR DESCRIPTION
Fixes #1309 

Required updating tests for MIB and MRC `detect_params`. Quite difficult to test this for the other datasets affected as we don't necessarily have data recorded on a square nav grid (apart from mocking the data).


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code