### PR TITLE
`PipelinedExecutor`: handle alow startup more gracefully

### DIFF
--- a/docs/source/changelog/bugfix/pipelined-startup-err.rst
+++ b/docs/source/changelog/bugfix/pipelined-startup-err.rst
@@ -1,4 +1,5 @@
 [Bugfix] Gracefully handle startup timeout
 ==========================================
 
-* In the pipelined executor, increase default timeout and emit a more user-friendly error message in case of hitting the timeout (:pr:`1342`).
+* In the pipelined executor, increase default timeout and emit a more
+  user-friendly error message in case of hitting the timeout (:pr:`1342`).

--- a/docs/source/changelog/bugfix/pipelined-startup-err.rst
+++ b/docs/source/changelog/bugfix/pipelined-startup-err.rst
@@ -1,0 +1,4 @@
+[Bugfix] Gracefully handle startup timeout
+==========================================
+
+* In the pipelined executor, increase default timeout and emit a more user-friendly error message in case of hitting the timeout (:pr:`1342`).

--- a/tests/executor/test_pipelined.py
+++ b/tests/executor/test_pipelined.py
@@ -246,10 +246,8 @@ def test_early_startup_error():
             executor = PipelinedExecutor(
                 spec=PipelinedExecutor.make_spec(cpus=range(2), cudas=[]),
                 pin_workers=False,
-                startup_timeout=0.4,
             )
-        # FIXME: can we differentiate between early errors and timeouts? probably not?
-        assert e.match("Timeout while starting workers")
+        assert e.match("One or more workers failed to start")
     finally:
         libertem.executor.pipelined.pipelined_worker = original_pipelined_worker
         if executor is not None:


### PR DESCRIPTION
Fixes #1340 

Increase `startup_timeout` and throw a user-friendly exception:

```
Traceback (most recent call last):
  File "/tmp/work/t.py", line 4, in <module>
    executor = PipelinedExecutor.make_local(startup_timeout=0)
  File "/home/alex/source/LiberTEM/src/libertem/executor/pipelined.py", line 711, in make_local
    return cls(spec=spec, **kwargs)
  File "/home/alex/source/LiberTEM/src/libertem/executor/pipelined.py", line 654, in __init__
    self._pool = self._start_pool()
  File "/home/alex/source/LiberTEM/src/libertem/executor/pipelined.py", line 681, in _start_pool
    raise RuntimeError(
RuntimeError: Timeout while starting workers, might need to increase `startup_timeout` (is 0s)
```

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
