### PR TITLE
Generate notebooks from tox command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ data
 junit.xml
 .vscode-server
 *.sif
+examples/generated/

--- a/tox.ini
+++ b/tox.ini
@@ -206,7 +206,7 @@ extras=
     hdbscan
     bqplot
 commands=
-    jupyter nbconvert --allow-errors --to notebook --output-dir "{toxinidir}/examples/generated/" --execute "{toxinidir}/examples/hyperspy-integration.ipynb"
+    jupyter nbconvert --allow-errors --to notebook --output-dir "{toxinidir}/examples/generated/" --execute "{toxinidir}/examples/*.ipynb"
 passenv=
     TESTDATA_BASE_PATH
     # HyperSpy expects this on Windows

--- a/tox.ini
+++ b/tox.ini
@@ -191,3 +191,27 @@ whitelist_externals=
     cat
 passenv=
     HOME
+
+[testenv:notebooks_gen]
+deps=
+    -rtest_requirements.txt
+    libertem-blobfinder
+    hyperspy
+    pyxem
+    scikit-image
+    # for hyperspy-integration.ipynb
+    graphviz
+    pyopencl
+extras=
+    hdbscan
+    bqplot
+commands=
+    jupyter nbconvert --allow-errors --to notebook --output-dir "{toxinidir}/examples/generated/" --execute "{toxinidir}/examples/hyperspy-integration.ipynb"
+passenv=
+    TESTDATA_BASE_PATH
+    # HyperSpy expects this on Windows
+    PROGRAMFILES
+setenv=
+    PYTHONWARNINGS=ignore
+    DASK_LOGGING__DISTRIBUTED=60
+    KMP_WARNINGS=0


### PR DESCRIPTION
Adds a command `tox -e notebooks_gen` which regenerates the example notebooks into a folder `examples/generated/`. This is fine for all notebooks except `live-plotting.ipynb` which requires us to use an interactive matplotlib backend (currently `nbagg`). For now I can't think of an easy way to auto-generate this particular notebook. The new notebooks go in `generated/` so that the command can be run multiple times before a 'final' copy + commit of the updated notebooks is made in `examples/`.

The tox config essentially copies `tox -e notebooks` but also installs `pyopencl` and `graphviz` to support `hyperspy-integration.ipynb`. This won't be robust to graphviz install issues (but does work on the server where we have access to the example data).

I also set 
```
    PYTHONWARNINGS=ignore
    DASK_LOGGING__DISTRIBUTED=60
    KMP_WARNINGS=0
```
to suppress a lot of INFO prints from dask and numba. So far this isn't a problem when running the notebook tests but could be in the future.

This was used to generate the notebooks in #1341 .

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code
