### PR TITLE
Add explicit cleanup for potentially large temp test data

### DIFF
--- a/tests/io/datasets/test_frms6.py
+++ b/tests/io/datasets/test_frms6.py
@@ -116,7 +116,14 @@ def default_frms6_raw(tmpdir_factory):
             block = _read_block(f, raw_shape, start, stop)
             view[offset + start:offset + stop] = _unfold_block(block)
         offset += frame_count
-    return data
+
+    yield data
+
+    # Might be needed for windows, so we don't keep any views, mmaps or open
+    # file handles around:
+    del view
+    del data
+    os.unlink(fn)
 
 
 @pytest.fixture(scope='module')

--- a/tests/io/datasets/test_hdf5.py
+++ b/tests/io/datasets/test_hdf5.py
@@ -510,6 +510,8 @@ def test_chunked_weird(lt_ctx, tmpdir_factory, chunks, udf, shared_random_data):
         np.sum(data, axis=(2, 3))
     )
 
+    os.unlink(filename)
+
 
 @pytest.mark.parametrize('in_dtype', [
     np.float32,


### PR DESCRIPTION
Fixes #1349. Explicit cleanup for both FRMS6 (~8G) and HDF5 (~3G) tests.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
