### PR TITLE
Allow adjust_tileshape() to upgrade to full frames

### DIFF
--- a/src/libertem/io/dataset/base/tiling_scheme.py
+++ b/src/libertem/io/dataset/base/tiling_scheme.py
@@ -187,7 +187,6 @@ class Negotiator:
         corrections: Optional[CorrectionSet],
     ):
         sig_shape = shape[1:]
-
         # we need some wiggle room with the size, because there may be a harder
         # lower size value for some cases (for example HDF5, which overrides
         # some of the sizing negotiation we are doing here)
@@ -209,10 +208,10 @@ class Negotiator:
             else:
                 raise ValueError(message)
         for dim in range(len(base_shape)):
-            if shape[dim] % base_shape[dim] != 0:
+            if shape[dim] % base_shape[dim] != 0 and shape[dim] != ds_sig_shape[dim]:
                 raise ValueError(
                     f"The tileshape {shape} is incompatible with base "
-                    f"shape {base_shape} in dimension {dim}."
+                    f"shape {base_shape} and dataset shape {ds_sig_shape} in dimension {dim}."
                 )
 
     def get_scheme(


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code
