### PR TITLE
Explicitly add content of client/ in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,12 @@
 graft src
-graft src/libertem/web/client/
+graft src/libertem/web/client
 include LICENSE
 include README.rst
-graft client
-prune client/node_modules
-prune client/build
-prune client/coverage
+graft client/src
+graft client/public
+graft client/types
+include client/*.*js*
+include client/README.md
 graft tests
 include conftest.py
 include pytest.ini


### PR DESCRIPTION
Avoids extremely long package build times (and pyroma evaluation time) by explicitly avoiding ever adding `node_modules` to the source dist.

Previously we had these two lines in MANIFEST.in:

```
graft client
prune client/node_modules
```

which during building would first add, then remove node_modules. On some systems this can take up to a minute, and is done even during `pyroma` which means it happens on every commit (with pre-commit enabled).

NOTE: on my system it seems like `package-lock.json` is included in the dist file, which can be quite large (> 1 MB). If we are building from a clean checkout this would not happen but it's something to be aware of (or we can exclude it explicitly).

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
