### PR TITLE
Flaky progress bar test fix

### DIFF
--- a/tests/common/test_progress.py
+++ b/tests/common/test_progress.py
@@ -46,7 +46,6 @@ class FastTime:
 
     def __call__(self):
         self._now += self._increment
-        print(self._now)
         return self._now
 
 
@@ -93,29 +92,8 @@ def test_progress_inline_fasttime(lt_ctx, monkeypatch):
     assert reporter._bar.n == reporter._bar.total
 
     states = reporter._history
-    # Check we received some specific messages
     start_progress = ProgressState(0., 16, 0, 0, 2)
     assert start_progress in states
-    # part0_start_progress = ProgressState(0., 16, 0, 1, 2)
-    # NOTE Sometimes missing ? Maybe a warmup / busy problem
-    # Can only reproduce this sometimes when running the full
-    # test suite. In the end it's not critical that we don't
-    # get every message because the update methods are robust
-    # to missing messages so the bar should always complete correctly
-    # assert part0_start_progress in states
-    part0_end_progress = ProgressState(8., 16, 1, 0, 2)
-    assert part0_end_progress in states
-    part1_start_progress = ProgressState(8., 16, 1, 1, 2)
-    assert part1_start_progress in states
-    part1_end_progress = ProgressState(16., 16, 2, 0, 2)
-    assert part1_end_progress in states
-
-    # Becase every tile is 'slow' we can expect
-    # to recieve some mid-partition updates
-    part0_mid_progress = ProgressState(4., 16, 0, 1, 2)
-    assert part0_mid_progress in states
-    part1_mid_progress = ProgressState(12., 16, 1, 1, 2)
-    assert part1_mid_progress in states
 
     # Check for errant values
     assert {s.num_part_in_progress for s in states} == {0, 1}


### PR DESCRIPTION
Responds to [ db48c49 ](https://github.com/LiberTEM/LiberTEM/commit/db48c497353af9debf2b3f2dbe77ec71ba34d3f6)

This is still a draft as I need to come up with a better test case, but putting this up to explain why the original test was flaky.

After looking at this in detail, I think the issue is twofold:

1. Partition Start + Tile Completion messages go via the Queue and are processed in the background thread, while Partition End messages are fully synchronous and are processed immediately after we get results from the task. (This is the fallback which means all partitions will be accounted for even if for some reason the comms break down). The test case does no real work, so occasionally a partition will complete in the main thread before we receive all of its start + intermediate messages in the background.

2. The test is written in a way which doesn't account for point 1, as it is checking that at a given point in time we had a precise number of partitions in flight and frames processed. If a partition was marked as complete before we get its intermediate messages => the intermediate messages are dropped and the sequence of states is different. I don't think any messages were ever 'lost' in this test, rather they were received and dropped or received later than a partition end message causing the state sequence to be different.

I will re-think the test to actually check the messages we received rather than the states after each message.


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code