### PR TITLE
`PipelinedExecutor`: move `TaskCommHandler` cleanup to `finally`

### DIFF
--- a/src/libertem/executor/pipelined.py
+++ b/src/libertem/executor/pipelined.py
@@ -843,8 +843,6 @@ class PipelinedExecutor(BaseJobExecutor):
             # at the end, block to get the remaining results:
             while in_flight[0] > 0:
                 yield from yield_result_if_found(block=True, timeout=0.1)
-
-            task_comm_handler.done()
         except Exception as e:
             # In case of an exception, we need to drain the response queue,
             # so the next `run_tasks` call isn't polluted by old responses.
@@ -858,6 +856,8 @@ class PipelinedExecutor(BaseJobExecutor):
                 raise e2 from e
             # if from a worker, this is the first exception that got put into the queue
             raise
+        finally:
+            task_comm_handler.done()
 
     def _drain_response_queue(self, in_flight: int) -> None:
         """


### PR DESCRIPTION
Otherwise, in case of exceptions, it's possible that resources from the handler are not cleaned up properly, leading to leaks.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
