### PR TITLE
Tweak gc in pipelined executor

### DIFF
--- a/src/libertem/executor/pipelined.py
+++ b/src/libertem/executor/pipelined.py
@@ -1,6 +1,5 @@
 import itertools
 import os
-import gc
 import sys
 import logging
 import functools
@@ -211,7 +210,6 @@ def worker_run_task(
                 "libertem.task_size_pickled": len(header["task"]),
                 "libertem.os.pid": os.getpid(),
             })
-            gc.disable()
             task: TaskProtocol = cloudpickle.loads(header["task"])
             params_handle = header["params_handle"]
             params = work_mem[params_handle]
@@ -236,9 +234,7 @@ def worker_run_task(
                 "uuid": header["uuid"],
             })
         finally:
-            gc.enable()
-            with tracer.start_as_current_span("gc"):
-                gc.collect()
+            pass
 
 
 def worker_run_function(header, queues, worker_idx):


### PR DESCRIPTION
Forcing gc after each partition is a bit too much, and not worth the stability you get while running the code for one partition. Remove forced/manual GC for now.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
