### PR TITLE
Make sure coordinates are available in `get_task_data`

### DIFF
--- a/docs/source/changelog/features/coords-task-data.rst
+++ b/docs/source/changelog/features/coords-task-data.rst
@@ -1,0 +1,8 @@
+[Feature] Make `self.meta.coordinates` available in `UDF.get_task_data`
+=======================================================================
+
+* This is needed, for example, if you want to pre-allocate a buffer that is
+  partition-like-shaped, but you don't want this buffer to be part of the
+  result. A concrete example appears when working in a compressed space, where
+  you might want to batch the actual computation for the whole compressed
+  partition (:pr:`1397`).

--- a/docs/source/changelog/features/coords-task-data.rst
+++ b/docs/source/changelog/features/coords-task-data.rst
@@ -1,8 +1,4 @@
 [Feature] Make `self.meta.coordinates` available in `UDF.get_task_data`
 =======================================================================
 
-* This is needed, for example, if you want to pre-allocate a buffer that is
-  partition-like-shaped, but you don't want this buffer to be part of the
-  result. A concrete example appears when working in a compressed space, where
-  you might want to batch the actual computation for the whole compressed
-  partition (:pr:`1397`).
+* Make `self.meta.coordinates` available in `UDF.get_task_data` (:pr:`1397`).

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2022,8 +2022,9 @@ class UDFPartRunner:
     ) -> "nt.DTypeLike":
         dtype = _get_dtype(self._udfs, partition.dtype, corrections, execution_plan.keys())
         for backend, udfs in execution_plan.items():
+            pslice_for_roi = partition.slice.adjust_for_roi(roi)
             meta = UDFMeta(
-                partition_slice=partition.slice.adjust_for_roi(roi),
+                partition_slice=pslice_for_roi,
                 dataset_shape=partition.meta.shape,
                 roi=roi,
                 dataset_dtype=partition.dtype,
@@ -2038,6 +2039,7 @@ class UDFPartRunner:
                 udf.set_backend(backend)
                 udf.get_method()  # validate that one of the `process_*` methods is implemented
                 udf.set_meta(meta)
+                udf.set_slice(pslice_for_roi)
                 udf.init_result_buffers()
                 udf.allocate_for_part(partition, roi)
                 udf.init_task_data()


### PR DESCRIPTION
As an alternative to #1210, this keeps the option open to have different partition slicing schemes in the future, that cannot be modeled by a simple `Slice` object. For most applications, it should be sufficient to have the coordinate list available for the partition.

This does not yet add support for accessing coordinates in `preprocess`, as that is also called per-dataset, and the coordinate code would need substantial changes to support this.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
