### PR TITLE
Context.run_udf: explicitly check for empty UDF list

### DIFF
--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -1003,10 +1003,13 @@ class Context:
         enable_plotting = bool(plots)
 
         udf_is_list = isinstance(udf, Iterable)
-        if not isinstance(udf, Iterable):
+        if not udf_is_list:
             udfs = [udf]
         else:
             udfs = list(udf)
+
+        if len(udfs) == 0:
+            raise ValueError("empty list of UDFs - nothing to do!")
 
         if enable_plotting:
             with tracer.start_as_current_span("prepare_plots"):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -24,6 +24,19 @@ def test_ctx_load(lt_ctx, default_raw):
     )
 
 
+def test_run_empty_udf_list(lt_ctx, default_raw):
+    ds = lt_ctx.load(
+        "raw",
+        path=default_raw._path,
+        nav_shape=(16, 16),
+        dtype="float32",
+        sig_shape=(128, 128),
+    )
+    with pytest.raises(ValueError) as em:
+        lt_ctx.run_udf(dataset=ds, udf=[])
+    em.match("^empty list of UDFs - nothing to do!$")
+
+
 def test_run_udf_with_io_backend(lt_ctx, default_raw):
     io_backend = MMapBackend(enable_readahead_hints=True)
     lt_ctx.load(


### PR DESCRIPTION
With out it, we get an error from the innards of the `UDFRunner`

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
