### PR TITLE
Add guard against too-large files in RawCSRDataSet detect_params

### DIFF
--- a/docs/source/changelog/bugfix/raw_csr_detection.rst
+++ b/docs/source/changelog/bugfix/raw_csr_detection.rst
@@ -1,0 +1,7 @@
+[Bugfix] RawCSR dataset no longer tries to load large files
+===========================================================
+
+* The :code:`RawCSRDataSet.detect_params` function will
+no longer try to load any file as binary and parse it to TOML,
+which could previously lead to large files being loaded during
+:code:`ctx.load('auto', path)`. (:pr:`1404`).

--- a/src/libertem/io/dataset/raw_csr.py
+++ b/src/libertem/io/dataset/raw_csr.py
@@ -232,7 +232,7 @@ class RawCSRDataSet(DataSet):
         try:
             _, extension = os.path.splitext(path)
             has_extension = extension.lstrip('.') in cls.get_supported_extensions()
-            under_size_lim = os.stat(path).st_size < 2**20  # 1 MB
+            under_size_lim = executor.run_function(os.stat, path).st_size < 2**20  # 1 MB
             if not (has_extension or under_size_lim):
                 return False
             conf = executor.run_function(load_toml, path)

--- a/src/libertem/io/dataset/raw_csr.py
+++ b/src/libertem/io/dataset/raw_csr.py
@@ -230,6 +230,11 @@ class RawCSRDataSet(DataSet):
     @classmethod
     def detect_params(cls, path: str, executor: "JobExecutor"):
         try:
+            _, extension = os.path.splitext(path)
+            has_extension = extension.lstrip('.') in cls.get_supported_extensions()
+            under_size_lim = os.stat(path).st_size < 2**20  # 1 MB
+            if not (has_extension or under_size_lim):
+                return False
             conf = executor.run_function(load_toml, path)
             if "params" not in conf:
                 return False


### PR DESCRIPTION
Closes #1403 

Guards against by accepting either files with a supported extension, or files less than 1 MB in size with any extension.

~~Need to add a regression test case.~~

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [NA] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [NA] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code