### PR TITLE
Split get_search_order in `io.dataset.__init__`

### DIFF
--- a/src/libertem/io/dataset/__init__.py
+++ b/src/libertem/io/dataset/__init__.py
@@ -185,10 +185,10 @@ def get_dataset_cls(filetype: str) -> typing.Type[DataSet]:
     return cls
 
 
-def detect(path: Union[str, np.ndarray], executor) -> Dict[str, Any]:
+def get_search_order(path: Union[str, np.ndarray]) -> List[str]:
     """
-    Returns dataset's detected type, parameters and
-    additional info.
+    Return the keys from filetypes in an order which
+    is perhaps optimal for dataset auto-detection
     """
     extension_map = build_extension_map()
     search_order = list(filetypes.keys())
@@ -217,6 +217,15 @@ def detect(path: Union[str, np.ndarray], executor) -> Dict[str, Any]:
     except AttributeError:
         # Cannot interpret as a memory dataset
         pass
+    return search_order
+
+
+def detect(path: Union[str, np.ndarray], executor) -> Dict[str, Any]:
+    """
+    Returns dataset's detected type, parameters and
+    additional info.
+    """
+    search_order = get_search_order(path)
     for filetype in search_order:
         try:
             cls = get_dataset_cls(filetype)


### PR DESCRIPTION
Small change to split the util function for choosing the dataset search order from the `detect()` function. Useful if we want to access this order from another location.

For me doesn't need a changelog entry?

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code
