### PR TITLE
Fix `assert_allclose` usage

### DIFF
--- a/tests/io/datasets/test_raw_csr.py
+++ b/tests/io/datasets/test_raw_csr.py
@@ -406,15 +406,21 @@ def test_reshape_sync_offset(
 
     assert_allclose(
         ref_result[0]['intensity'].raw_data,
-        result[0]['intensity'].raw_data
+        result[0]['intensity'].raw_data,
+        rtol=1e-5,
+        atol=1e-8,
     )
     assert_allclose(
         ref_result[1]['std'].raw_data,
-        result[1]['std'].raw_data
+        result[1]['std'].raw_data,
+        rtol=1e-5,
+        atol=1e-8,
     )
     assert_allclose(
         ref_result[1]['num_frames'].raw_data,
-        result[1]['num_frames'].raw_data
+        result[1]['num_frames'].raw_data,
+        rtol=1e-5,
+        atol=1e-8,
     )
 
 


### PR DESCRIPTION
By default, it is too strict, setting `atol=0` - this is too strict for these tests. Use the default tolerances from `np.allclose` instead.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
