### PR TITLE
WIP: `zeros_aligned` can be expensive, if the buffers aren't re-used

### DIFF
--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -387,11 +387,7 @@ class BufferWrapper:
             raise RuntimeError("cannot allocate: no shape set")
         if self._data is not None:
             raise RuntimeError("cannot allocate: data is already set")
-        if self._where == 'device' and lib is not None:
-            _z = lib.zeros
-        else:
-            _z = zeros_aligned
-        self._data = _z(self._shape, dtype=self._dtype)
+        self._data = lib.zeros(self._shape, dtype=self._dtype)
 
     def has_data(self):
         return self._data is not None

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -387,6 +387,8 @@ class BufferWrapper:
             raise RuntimeError("cannot allocate: no shape set")
         if self._data is not None:
             raise RuntimeError("cannot allocate: data is already set")
+        if lib is None:
+            lib = np
         self._data = lib.zeros(self._shape, dtype=self._dtype)
 
     def has_data(self):

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -12,7 +12,6 @@ from numba.typed import List
 from ncempy.io import dm
 
 from libertem.common.math import prod, make_2D_square, flat_nonzero
-from libertem.common.buffers import zeros_aligned
 from libertem.common import Shape
 from libertem.common.messageconverter import MessageConverter
 from .base import (
@@ -651,7 +650,7 @@ class DataBlock:
     def pixel_data(self):
         if not self.is_valid:
             raise ValueError("invalid block: %r" % self)
-        arr = zeros_aligned((930 * 16), dtype="uint16")
+        arr = np.zeros((930 * 16), dtype="uint16")
         self.readinto(arr)
         return arr.reshape(930, 16)
 


### PR DESCRIPTION
For example, for result buffers for small/many partitions, or many UDF runs, like in our tests.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
