### PR TITLE
`Context.make_with` number of workers interface

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,8 @@ The Python API is a concise API for using LiberTEM from Python code. It is suita
 for interactive scripting, for example from Jupyter notebooks, and for usage
 from within a Python application or script.
 
+For a full API reference, please see :ref:`reference`.
+
 .. _`context`:
 
 Context
@@ -15,47 +17,56 @@ Context
 The :class:`libertem.api.Context` object is the entry-point for most interaction
 and processing with LiberTEM. It is used to load datasets, specify and run analyses.
 The following snippet initializes a :class:`~libertem.api.Context` ready-for-use
-with default parameters and backing.
+with default parameters and backed by a parallel processing engine.
 
 .. code-block:: python
 
     import libertem.api as lt
 
-    ctx = lt.Context()
+    with lt.Context() as ctx:
+        ...
 
 See the :class:`API documentation <libertem.api.Context>` for the full capabilities
 exposed by the :class:`~libertem.api.Context`.
 
+.. note::
+    The use of a :code:`with` block in the above code ensures the :class:`~libertem.api.Context`
+    will correctly release any resources it holds on to when it goes out of scope,
+    but it is also possible to use the object as a normal variable, i.e. :code:`ctx = lt.Context()`
 
 Basic example
 -------------
 
 This is a basic example to load the API, create a local cluster, load a file and
-run an analysis. For complete examples on how to use the Python API, please see the
-Jupyter notebooks in `the example directory
-<https://github.com/LiberTEM/LiberTEM/tree/master/examples>`_.
-
-For more details, please see :ref:`loading data`, :ref:`dataset api` and
-:ref:`format-specific reference<formats>`. See :ref:`sample data` for publicly available datasets.
+run an analysis.
 
 .. include:: /../../examples/basic.py
     :code:
+
+For complete examples on how to use the Python API, please see the
+Jupyter notebooks in `the example directory
+<https://github.com/LiberTEM/LiberTEM/tree/master/examples>`_.
+
+For more details on the data formats that LiberTEM supports, please see
+:ref:`loading data`, :ref:`dataset api` and :ref:`format-specific reference<formats>`.
+See :ref:`sample data` for publicly available datasets.
 
 Custom processing routines
 --------------------------
 
 To go beyond the included capabilities of LiberTEM, you can implement your own
-using :ref:`user-defined functions`.
-
-Reference
----------
-
-For a full reference, please see :ref:`reference`.
+analyses using :ref:`user-defined functions`. UDFs are dataset-agnostic
+and benefit from the same parallelisation as the built-ins tools.
 
 .. _`executors`:
 
 Executors
 ---------
+
+An Executor is the internal engine which the :class:`~libertem.api.Context` uses to
+compute user-defined functions or run other tasks. Executors can be serial or parallel,
+and can differ substantially in their implementation, but all adhere to a
+common interface which the :class:`~libertem.api.Context` understands.
 
 .. versionadded:: 0.9.0
     The executor API is internal. Since choice and parameters of executors
@@ -104,75 +115,6 @@ For special applications, the
 is experimental, see :ref:`dask` for more details. It might use threading as
 well, depending on the Dask scheduler that is used by :code:`compute()`.
 
-
-Common executor choices
-.......................
-
-.. versionadded:: 0.9.0
-
-:meth:`libertem.api.Context.make_with` provides a convenient shortcut to start a
-:class:`~libertem.api.Context` with common executor choices. See the
-:meth:`API documentation <libertem.api.Context.make_with>`
-for available options!
-
-Connect to a cluster
-....................
-
-See :ref:`cluster` on how to start a scheduler and workers.
-
-.. Not run with docs-check since it doesn't play well with launching a multiprocessing
-   cluster
-
-.. code-block:: python
-
-    from libertem import api
-    from libertem.executor.dask import DaskJobExecutor
-
-    # Connect to a Dask.Distributed scheduler at 'tcp://localhost:8786'
-    with DaskJobExecutor.connect('tcp://localhost:8786') as executor:
-        ctx = api.Context(executor=executor)
-        ...
-
-.. _`cluster spec`:
-
-Customize CPUs and CUDA devices
-...............................
-
-To control how many CPUs and which CUDA devices are used, you can specify them as follows:
-
-.. Not run with docs-check since it doesn't play well with launching a multiprocessing
-   cluster
-
-.. code-block:: python
-
-    from libertem import api
-    from libertem.executor.dask import DaskJobExecutor, cluster_spec
-    from libertem.utils.devices import detect
-
-    # Find out what would be used, if you like
-    # returns dictionary with keys "cpus" and "cudas", each with a list of device ids
-    devices = detect()
-
-    # Example: Deactivate CUDA devices by removing them from the device dictionary
-    devices['cudas'] = []
-
-    # Example: Deactivate CuPy integration
-    devices['has_cupy'] = False
-
-    # Example: Use 3 CPUs. The IDs are ignored at the moment, i.e. no CPU pinning
-    devices['cpus'] = range(3)
-
-    # Generate a spec for a Dask.distributed SpecCluster
-    # Relevant kwargs match the dictionary entries
-    spec = cluster_spec(**devices)
-    # Start a local cluster with the custom spec
-    with DaskJobExecutor.make_local(spec=spec) as executor:
-        ctx = api.Context(executor=executor)
-        ...
-
-Please see :ref:`dask executor` for a reference of the Dask-based executor.
-
-
 .. _`pipelined`:
 
 Pipelined executor
@@ -188,26 +130,65 @@ fashion to worker processes. This is important to support processing that cannot
 up with the detector speed on a single CPU core. This executor also works for offline
 data sets in principle, but is not optimized for that use case.
 
-Similar to the Dask-based executor, it is possible to customize the devices
-used for computation:
-
-.. code-block:: python
-
-    from libertem import api
-    from libertem.executor.pipelined import PipelinedExecutor
-    from libertem.utils.devices import detect
-
-    spec = PipelinedExecutor.make_spec(cpus=[0, 1, 2], cudas=[])
-    executor = PipelinedExecutor(
-        spec=spec,
-        pin_workers=False,  # set to True to keep worker processes pinned to specific CPU cores or CPUs
-    )
-    ...
-    executor.close()
-
-    # you can also use the `detect` function as above:
-    spec2 = PipelinedExecutor.make_spec(**detect())
-
 Please see :ref:`pipelined executor` for a reference of the pipelined executor,
 and `the LiberTEM-live documentation <https://libertem.github.io/LiberTEM-live/>`_
 for details on live processing.
+
+
+.. _`cluster spec`:
+
+Specifying executor type, CPU and GPU workers
+.............................................
+
+.. versionadded:: 0.9.0
+
+:meth:`libertem.api.Context.make_with` provides a convenient shortcut to start a
+:class:`~libertem.api.Context` with specific executor and customise the number of
+workers it uses.
+
+.. code-block:: python
+
+    import libertem.api as lt
+
+    # Create a Dask-based Context with 4 cpu workers and 2 gpu workers
+    with lt.Context.make_with('dask', cpus=4, gpus=2) as ctx:
+        ...
+
+The default behaviour is to create a Dask-based Context, but the same
+method can be used to create any executor, as described in the documentation
+of the method. A useful shortcut is :code:`lt.Context.make_with('inline')`
+to quickly create a synchronous executor for debugging.
+
+.. note::
+    Not all executor types allow specifying number of workers, and
+    not all executor types are GPU-capable. In these cases the :code:`make_with`
+    method will raise an :class:`~libertem.exceptions.ExecutorSpecException`.
+
+See the :meth:`API documentation <libertem.api.Context.make_with>`
+for more information.
+
+
+Connect to an existing cluster
+..............................
+
+The :class:`~libertem.executor.dask.DaskJobExecutor` is capable of connecting
+to an existing :code:`dask.distributed` scheduler, which may be a centrally managed
+installation on a physical cluster, or a local, single-machine scheduler started for
+some other purpose (by LiberTEM or directly through Dask). Cluster re-use can
+reduce startup times as there is no requirement to spawn new workers each time
+a script or Notebook is executed.
+
+See :ref:`cluster` for more on how to start a scheduler and workers.
+
+.. Not run with docs-check since it doesn't play well with
+   launching a multiprocessing cluster
+
+.. code-block:: python
+
+    import libertem.api as lt
+    from libertem.executor.dask import DaskJobExecutor
+
+    # Connect to a Dask.Distributed scheduler at 'tcp://localhost:8786'
+    with DaskJobExecutor.connect('tcp://localhost:8786') as executor:
+        ctx = lt.Context(executor=executor)
+        ...

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -142,6 +142,11 @@ Specifying executor type, CPU and GPU workers
 
 .. versionadded:: 0.9.0
 
+.. versionchanged:: 0.12.0
+    Added the :code:`cpus` and :code:`gpus` keyword arguments, as well as the
+    explicit :code:`plot_class` keyword argument passed to the Context
+    initializer (replaced the prior :code:`*args, **kwargs` form).
+
 :meth:`libertem.api.Context.make_with` provides a convenient shortcut to start a
 :class:`~libertem.api.Context` with specific executor and customise the number of
 workers it uses.

--- a/docs/source/changelog/misc/make_with_workers.rst
+++ b/docs/source/changelog/misc/make_with_workers.rst
@@ -1,7 +1,7 @@
 [Misc] Context.make_with can specify workers
 ============================================
 
-* The :method:`Context.make_with` constructor method has been improved
-to allow simple specification of the number CPU and GPU workers to use,
-as well as the type of executor to create, where such a specification is
-supported (:pr:`1443`).
+* The :code:`Context.make_with` constructor method has been improved
+  to allow simple specification of the number CPU and GPU workers to use,
+  as well as the type of executor to create, where such a specification is
+  supported (:pr:`1443`).

--- a/docs/source/changelog/misc/make_with_workers.rst
+++ b/docs/source/changelog/misc/make_with_workers.rst
@@ -1,0 +1,7 @@
+[Misc] Context.make_with can specify workers
+============================================
+
+* The :method:`Context.make_with` constructor method has been improved
+to allow simple specification of the number CPU and GPU workers to use,
+as well as the type of executor to create, where such a specification is
+supported (:pr:`1443`).

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -233,7 +233,12 @@ class Context:
         if executor_spec in ('synchronous', 'inline'):
             executor = InlineJobExecutor()
         elif executor_spec == 'threads':
-            executor = ConcurrentJobExecutor.make_local()
+            n_threads = cpus
+            try:
+                n_threads = len(n_threads)
+            except TypeError:
+                pass
+            executor = ConcurrentJobExecutor.make_local(n_threads=n_threads)
         elif executor_spec == 'dask':
             executor = DaskJobExecutor.make_local(spec=spec)
         elif executor_spec == 'dask-integration':

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -219,7 +219,7 @@ class Context:
                                       'specifying GPU workers at this time')
         # Delay import here to avoid cupy import overhead
         if executor_spec in ('dask', 'dask-make-default', 'pipelined'):
-            from libertem.utils.devices import _cupy
+            from libertem.utils.devices import cupy as _cupy
             has_cupy = _cupy is not None
         if cpus is not None and gpus is None:
             gpus = 0

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -153,7 +153,7 @@ class Context:
         Parameters
         ----------
 
-        executor_spec:
+        executor_spec : ExecutorSpecType, optional, by default "dask"
             A string identifier for executor variants:
 
             "synchronous", "inline":

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -267,7 +267,7 @@ class Context:
         else:
             raise ValueError(
                 f'Argument `executor_spec` is {executor_spec}. Allowed are '
-                f'synchronous", "inline", "threads", "dask", "dask-integration",'
+                f'"synchronous", "inline", "threads", "dask", "dask-integration",'
                 f'"dask-make-default" "delayed" or "pipelined".'
             )
         return cls(executor=executor, plot_class=plot_class)

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -148,7 +148,7 @@ class Context:
             and passed them to the initializer of :class:`Context`. Given that the
             Context accepts only the :code:`plot_class` keyword-argument this was
             hard-coded into this function for backwards-compatibility, enabling
-            the  addition of the :code:`cpus` and :code:`gpus` parameters.
+            the addition of the :code:`cpus` and :code:`gpus` parameters.
 
         Parameters
         ----------

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -143,7 +143,7 @@ class Context:
 
         See :ref:`executors` for general information on executors.
 
-        .. note::
+        .. versionchanged:: 0.12.0
 
             Prior to version 0.12.0, this function accepted :code:`*args, **kwargs`
             and passed them to the initializer of :class:`Context`. Given that the

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -227,7 +227,7 @@ class Context:
             cpus = 0
         spec = None
         if cpus is not None and executor_spec in ('dask', 'dask-make-default'):
-            spec = cluster_spec(cpus=cpus, cuda=gpus, has_cupy=has_cupy)
+            spec = cluster_spec(cpus=cpus, cudas=gpus, has_cupy=has_cupy)
 
         executor: JobExecutor
         if executor_spec in ('synchronous', 'inline'):
@@ -247,7 +247,7 @@ class Context:
             executor = DelayedJobExecutor()
         elif executor_spec == 'pipelined':
             if cpus is not None:  # implies gpus is also not None
-                spec = PipelinedExecutor.make_spec(cpus=cpus, cuda=gpus, has_cupy=has_cupy)
+                spec = PipelinedExecutor.make_spec(cpus=cpus, cudas=gpus, has_cupy=has_cupy)
                 executor = PipelinedExecutor(spec=spec)
             else:
                 executor = PipelinedExecutor.make_local()

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -193,12 +193,15 @@ class Context:
             enable cpu-pinning where the exector and the system support it, but most
             use cases will only require an integer argument. Executors where this
             parameter does not make sense will raise an error if provided.
+            When unspecified the default executor behaviour is retained.
         gpus : int | Iterable[int], optional
             Similar to :code:`cpus`, specifies the number of GPU workers to create
             where the executor chosen supports it, else raise an error. The integer
-            form of the argument assigns workers round-robin to available GPUs on
-            the system, while the iterable form allows specifiying the number of
-            workers per GPU by repeating the id of any given GPU in the argument.
+            form of the argument specifies the total number of workers to create,
+            assigned according to the implementation of each executor, while
+            the iterable form allows assigment of multiple workers to specific GPUs
+            by repeating the id of any given GPU in the argument.
+            When unspecified the default executor behaviour is retained.
         plot_class : libertem.viz.base.Live2DPlot, optional
             Plot class for live plotting, passed to :class:`Context`.
 

--- a/src/libertem/exceptions.py
+++ b/src/libertem/exceptions.py
@@ -3,3 +3,11 @@ class UDFException(Exception):
     Raised when the UDF interface is somehow misused
     """
     pass
+
+
+class ExecutorSpecException(Exception):
+    """
+    Raised when there is an error specifying an
+    Executor or its resources / workers
+    """
+    pass

--- a/src/libertem/executor/concurrent.py
+++ b/src/libertem/executor/concurrent.py
@@ -1,6 +1,7 @@
 import contextlib
 import functools
 import logging
+from typing import Optional
 import concurrent.futures
 from typing import Iterable, Any, Dict
 
@@ -179,7 +180,7 @@ class ConcurrentJobExecutor(BaseJobExecutor):
             self.client.shutdown(wait=False)
 
     @classmethod
-    def make_local(cls):
+    def make_local(cls, n_threads: Optional[int] = None):
         """
         Create a local ConcurrentJobExecutor backed by
         a :class:`python:concurrent.futures.ThreadPoolExecutor`
@@ -190,7 +191,8 @@ class ConcurrentJobExecutor(BaseJobExecutor):
             the connected JobExecutor
         """
         devices = detect()
-        n_threads = len(devices['cpus'])
+        if n_threads is None:
+            n_threads = len(devices['cpus'])
         client = TracedThreadPoolExecutor(tracer, max_workers=n_threads)
         return cls(client=client, is_local=True)
 

--- a/src/libertem/executor/concurrent.py
+++ b/src/libertem/executor/concurrent.py
@@ -185,13 +185,21 @@ class ConcurrentJobExecutor(BaseJobExecutor):
         Create a local ConcurrentJobExecutor backed by
         a :class:`python:concurrent.futures.ThreadPoolExecutor`
 
+        Parameters
+        ----------
+
+        n_threads : Optional[int]
+            The number of threads to spawn in the executor,
+            by default None in which case as many threads as there
+            are CPU cores will be spawned.
+
         Returns
         -------
         ConcurrentJobExecutor
             the connected JobExecutor
         """
-        devices = detect()
         if n_threads is None:
+            devices = detect()
             n_threads = len(devices['cpus'])
         client = TracedThreadPoolExecutor(tracer, max_workers=n_threads)
         return cls(client=client, is_local=True)

--- a/tests/executor/test_functional.py
+++ b/tests/executor/test_functional.py
@@ -26,6 +26,7 @@ from utils import get_testdata_path
 
 d = detect()
 has_cupy = d['cudas'] and d['has_cupy']
+has_gpus = len(d['cudas']) > 0
 
 
 @pytest.fixture(
@@ -385,3 +386,9 @@ def test_executor_run_each_host(ctx: Context):
     for k, v in res.items():
         assert k in workers.hosts()
         assert v == 43
+
+
+@pytest.mark.skipif(has_gpus, reason='Test to check error on no-GPU avail')
+def test_make_with_no_gpu():
+    with pytest.raises(ValueError):
+        Context.make_with('dask', gpus=2)

--- a/tests/executor/test_functional.py
+++ b/tests/executor/test_functional.py
@@ -17,6 +17,7 @@ from libertem.executor.inline import InlineJobExecutor
 from libertem.api import Context
 from libertem.udf.stddev import StdDevUDF
 from libertem.udf.masks import ApplyMasksUDF
+from libertem.exceptions import ExecutorSpecException
 from sparseconverter import (
     BACKENDS, CUPY, CUPY_BACKENDS, CUPY_SCIPY_CSR, NUMPY, SCIPY_COO, SPARSE_COO
 )
@@ -390,7 +391,7 @@ def test_executor_run_each_host(ctx: Context):
 
 @pytest.mark.skipif(has_gpus, reason='Test to check error on no-GPU avail')
 def test_make_with_no_gpu():
-    with pytest.raises(ValueError):
+    with pytest.raises(ExecutorSpecException):
         Context.make_with('dask', gpus=2)
 
 
@@ -416,7 +417,7 @@ def test_make_with_scenarios():
         with Context.make_with('dask', gpus=2) as ctx:
             assert len(ctx.executor.get_available_workers().has_cpu()) > 0
             assert len(ctx.executor.get_available_workers().has_cuda()) == 2
-    except ValueError:
+    except ExecutorSpecException:
         assert not has_gpus, "should only happen if we have no GPUs available"
 
     # 2. GPU defaults are OK/not applicable, but I need to optimize my CPU worker setup.
@@ -430,7 +431,7 @@ def test_make_with_scenarios():
         with Context.make_with('dask', cpus=2, gpus=2) as ctx:
             assert len(ctx.executor.get_available_workers().has_cpu()) > 0
             assert len(ctx.executor.get_available_workers().has_cuda()) == 2
-    except ValueError:
+    except ExecutorSpecException:
         assert not has_gpus, "should only happen if we have no GPUs available"
 
     # 4.1 Disable all CPU* or GPU workers.

--- a/tests/executor/test_functional.py
+++ b/tests/executor/test_functional.py
@@ -438,7 +438,7 @@ def test_make_with_scenarios():
         assert len(ctx.executor.get_available_workers().has_cpu()) == 0
         if has_gpus:
             assert len(ctx.executor.get_available_workers().has_cuda()) > 0
-        else
+        else:
             # FIXME: this should raise, as we don't have any non-service
             # workers, correct?
             pass

--- a/tests/executor/test_functional.py
+++ b/tests/executor/test_functional.py
@@ -448,4 +448,3 @@ def test_make_with_scenarios():
     with Context.make_with('dask', gpus=0) as ctx:
         assert len(ctx.executor.get_available_workers().has_cpu()) > 0
         assert len(ctx.executor.get_available_workers().has_cuda()) == 0
-

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -276,9 +276,22 @@ def test_make_with_inline(inline_executor):
     assert isinstance(ctx.executor, inline_executor.__class__)
 
 
-def test_make_with_threads(concurrent_executor):
-    ctx = Context.make_with('threads')
+def test_make_with_inline_raises():
+    with pytest.raises(NotImplementedError):
+        Context.make_with('inline', cpus=4)
+
+
+@pytest.mark.parametrize('n_threads', (None, 4))
+def test_make_with_threads(concurrent_executor, n_threads):
+    ctx = Context.make_with('threads', cpus=n_threads)
     assert isinstance(ctx.executor, concurrent_executor.__class__)
+    # No way to check number of workers in a concurrent.futures.Executor!
+
+
+@pytest.mark.parametrize('exec_spec', ('threads', 'inline', 'delayed'))
+def test_make_with_raises_gpus_no_support(exec_spec):
+    with pytest.raises(NotImplementedError):
+        Context.make_with(exec_spec, gpus=4)
 
 
 def test_make_with_unrecognized():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -281,7 +281,7 @@ def test_make_with_inline_raises():
         Context.make_with('inline', cpus=4)
 
 
-@pytest.mark.parametrize('n_threads', (None, 4))
+@pytest.mark.parametrize('n_threads', (None, 4, (2, 3)))
 def test_make_with_threads(concurrent_executor, n_threads):
     ctx = Context.make_with('threads', cpus=n_threads)
     assert isinstance(ctx.executor, concurrent_executor.__class__)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -12,6 +12,7 @@ from libertem.udf.sum import SumUDF
 from libertem.udf.sumsigudf import SumSigUDF
 from libertem.udf.base import NoOpUDF
 from libertem.api import Context
+from libertem.exceptions import ExecutorSpecException
 
 
 def test_ctx_load(lt_ctx, default_raw):
@@ -277,7 +278,7 @@ def test_make_with_inline(inline_executor):
 
 
 def test_make_with_inline_raises():
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ExecutorSpecException):
         Context.make_with('inline', cpus=4)
 
 
@@ -290,10 +291,10 @@ def test_make_with_threads(concurrent_executor, n_threads):
 
 @pytest.mark.parametrize('exec_spec', ('threads', 'inline', 'delayed'))
 def test_make_with_raises_gpus_no_support(exec_spec):
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ExecutorSpecException):
         Context.make_with(exec_spec, gpus=4)
 
 
 def test_make_with_unrecognized():
-    with pytest.raises(ValueError):
+    with pytest.raises(ExecutorSpecException):
         Context.make_with('not_an_executor')


### PR DESCRIPTION
Adds the interface described here: https://github.com/LiberTEM/LiberTEM/pull/1353#issuecomment-1476394109 to `lt.Context.make_with(..)`.

Some of the added code would be temporary until all the executors accept something resembling a `ResourceSpec` created by `make_with`. This only implements the user-facing part and has some glue code to handle the different cases, the idea being it might be useful to have a working prototype!

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code