### PR TITLE
Properly expose UDF cancellation

### DIFF
--- a/docs/source/changelog/features/udf-cancellation.rst
+++ b/docs/source/changelog/features/udf-cancellation.rst
@@ -1,0 +1,7 @@
+[Feature] Gracefully handle UDF cancellation
+============================================
+
+* Allow the internals to raise
+  :class:`~libertem.common.executor.JobCancelledError`, which is translated to
+  a :class:`~libertem.exceptions.UDFRunCancelled` exception for the user
+  (:pr:`1448`).

--- a/docs/source/udf/basic.rst
+++ b/docs/source/udf/basic.rst
@@ -493,6 +493,32 @@ than making two passes over the whole :code:`DataSet`:
    # `res` and `res_sum`:
    res, res_sum = ctx.run_udf(udf=[udf, SumUDF()], dataset=dataset)
 
+.. _`udf cancellation`:
+
+Cancellation
+~~~~~~~~~~~~
+
+.. versionadded:: 0.12.0
+
+Especially when running UDFs on live data streams, it can happen that a UDF
+doesn't run to completion. An example scenario is when a continuously running
+preview scan is stopped, or scan parameters are changed while the scan is
+running.
+
+In this case, the exception
+:class:`~libertem.exceptions.UDFRunCancelled` is raised, which you can
+handle in an appropriate way for your application:
+
+.. testcode:: run
+
+   from libertem.exceptions import UDFRunCancelled
+
+   try:
+       res = ctx.run_udf(udf=udf, dataset=dataset)
+   except UDFRunCancelled:
+       # handle cancellation, for example, start the next UDF run
+       pass
+
 
 .. _`udf roi`:
 

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -781,6 +781,12 @@ class Context:
             Added the :code:`plots` and :code:`sync` parameters,
             and the ability to run multiple UDFs on the same data in a single pass.
 
+        Raises
+        ------
+        UDFRunCancelled
+            Either the run was cancelled using :meth:`AsyncJobExecutor.cancel`,
+            or the underlying data source was interrupted.
+
         Parameters
         ----------
         dataset

--- a/src/libertem/common/executor.py
+++ b/src/libertem/common/executor.py
@@ -150,7 +150,13 @@ class JobExecutor:
         task_comm_handler: "TaskCommHandler",
     ):
         """
-        Run the tasks with the given parameters
+        Run the tasks with the given parameters.
+
+        Raises
+        ------
+        JobCancelledError
+            Either the job was cancelled using :meth:`AsyncJobExecutor.cancel`,
+            or the underlying data source was interrupted.
 
         Parameters
         ----------

--- a/src/libertem/common/executor.py
+++ b/src/libertem/common/executor.py
@@ -554,6 +554,9 @@ class TaskCommHandler:
         It may be run in a background thread on the main node,
         or synchronously, depending on the :class:`JobExecutor`.
 
+        May raise :class:`JobCancelledError` to signal that the acquisition has
+        been cancelled for some reason.
+
         Parameters
         ----------
         task : TaskProtocol

--- a/src/libertem/exceptions.py
+++ b/src/libertem/exceptions.py
@@ -11,3 +11,11 @@ class ExecutorSpecException(Exception):
     Executor or its resources / workers
     """
     pass
+
+
+class UDFRunCancelled(Exception):
+    """
+    Raised when the UDF run was cancelled, either when the job was cancelled
+    using :meth:`AsyncJobExecutor.cancel`, or when the underlying data source
+    was interrupted.
+    """

--- a/src/libertem/executor/pipelined.py
+++ b/src/libertem/executor/pipelined.py
@@ -771,8 +771,6 @@ class PipelinedExecutor(BaseJobExecutor):
         id_to_task = {}
         tasks_uuid = str(uuid.uuid4())
 
-        drain_on_error = True
-
         try:
             self._validate_worker_state()
             task_comm_handler.start()
@@ -864,8 +862,7 @@ class PipelinedExecutor(BaseJobExecutor):
             # `in_flight` and actually sending the task to the queue, we should
             # have a timeout here to not wait infinitely long.
             try:
-                if drain_on_error:
-                    self._drain_response_queue(in_flight=in_flight[0])
+                self._drain_response_queue(in_flight=in_flight[0])
             except RuntimeError as e2:
                 raise e2 from e
             # if from a worker, this is the first exception that got put into the queue

--- a/src/libertem/udf/__init__.py
+++ b/src/libertem/udf/__init__.py
@@ -1,9 +1,11 @@
-from .base import UDF, UDFMeta, UDFData, UDFFrameMixin, UDFTileMixin, UDFPartitionMixin,\
-    UDFPostprocessMixin, UDFPreprocessMixin, check_cast
+from .base import (
+    UDF, UDFMeta, UDFData, UDFFrameMixin, UDFTileMixin, UDFPartitionMixin,
+    UDFPostprocessMixin, UDFPreprocessMixin, check_cast, UDFRunCancelled,
+)
 from .auto import AutoUDF
 
 
 __all__ = [
     'UDF', 'UDFFrameMixin', 'UDFTileMixin', 'UDFPartitionMixin', 'UDFPostprocessMixin',
-    'UDFPreprocessMixin', 'UDFMeta', 'UDFData', 'check_cast', 'AutoUDF',
+    'UDFPreprocessMixin', 'UDFMeta', 'UDFData', 'check_cast', 'AutoUDF', 'UDFRunCancelled',
 ]

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2389,10 +2389,10 @@ class UDFRunner:
         damage = BufferWrapper(kind='nav', dtype=bool)
         damage.set_shape_ds(dataset.shape, roi)
         damage.allocate()
-        any_result = False
+        num_results = 0
         try:
             for part_results, task in result_iter:
-                any_result = True
+                num_results += 1
                 with tracer.start_as_current_span("_apply_part_result -> UDF.merge"):
                     self._apply_part_result(
                         udfs=self._udfs,
@@ -2405,13 +2405,13 @@ class UDFRunner:
                         udfs=self._udfs,
                         damage=damage
                     )
-            if not any_result or not iterate:
+            if num_results == 0 or not iterate:
                 yield self._make_udf_result(
                     udfs=self._udfs,
                     damage=damage
                 )
         except JobCancelledError:
-            raise UDFRunCancelled
+            raise UDFRunCancelled(f"UDF run cancelled after {num_results} partitions")
 
     async def run_for_dataset_async(
         self,

--- a/tests/executor/test_inline.py
+++ b/tests/executor/test_inline.py
@@ -67,8 +67,10 @@ class CancelledMemoryDataSet(MemoryDataSet):
 def test_cancellation(lt_ctx, default_raw):
     cancel_ds = CancelledMemoryDataSet(data=np.zeros((16, 16, 16, 16)))
 
-    with pytest.raises(UDFRunCancelled):
+    with pytest.raises(UDFRunCancelled) as ex:
         lt_ctx.run_udf(dataset=cancel_ds, udf=SumUDF())
+
+    assert ex.match(r"^UDF run cancelled after \d+ partitions$")
 
     # after cancellation, the executor is still usable:
     _ = lt_ctx.run_udf(dataset=default_raw, udf=SumUDF())

--- a/tests/executor/test_pipelined.py
+++ b/tests/executor/test_pipelined.py
@@ -538,8 +538,10 @@ def test_cancellation(pipelined_ex, default_raw):
 
     cancel_ds = CancelledMemoryDataSet(data=np.zeros((16, 16, 16, 16)))
 
-    with pytest.raises(UDFRunCancelled):
+    with pytest.raises(UDFRunCancelled) as ex:
         ctx.run_udf(dataset=cancel_ds, udf=SumUDF())
+
+    assert ex.match(r"^UDF run cancelled after \d+ partitions$")
 
     # after cancellation, the executor is still usable:
     _ = ctx.run_udf(dataset=default_raw, udf=SumUDF())

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -325,6 +325,8 @@ def test_udf_cancellation(default_raw):
     res_iter = ctx.run_udf_iter(dataset=default_raw, udf=DumbUDF())
 
     # TODO: support `res_iter.cancel_run()` or similar
-    with pytest.raises(UDFRunCancelled):
+    with pytest.raises(UDFRunCancelled) as ex:
         for part in res_iter:
             pass
+
+    assert ex.match(r"^UDF run cancelled after \d+ partitions$")


### PR DESCRIPTION
Previously, the `JobCancelledError` was bubbling up to the user, which is not really part of the public API, and also caused a queue drain in the `PipelinedExecutor`. This PR replaces it with a properly documented `UDFRunCancelled` exception.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
