### PR TITLE
Pin `scikit-learn` to `<1.3.0` and `dask!=2023.6.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup(
         'scikit-image',
         'cloudpickle',
         'jsonschema',
-        'scikit-learn',
+        'scikit-learn<1.3.0',
         'tqdm',
         'threadpoolctl>=3.0',
         'nbformat',

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ setup(
         "scipy",
         "sparse",
         "distributed>=2.19.0",
+        "dask!=2023.6.1",  # work around broken ipython exception handler
         "click",
         "tornado>=5",
         "matplotlib",


### PR DESCRIPTION
This works around:

- Breakage in `hdbscan` https://github.com/scikit-learn-contrib/hdbscan/issues/597 caused by API changes in `scikit-learn` 1.3.0. Needs a new `hdbscan` release to be fixed.
- Brakage in `dask==2023.6.1`, hopefully fixed in the next release via https://github.com/dask/dask/pull/10385 or similar

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
