### PR TITLE
Add COMUDF

### DIFF
--- a/docs/source/changelog/features/com_udf.rst
+++ b/docs/source/changelog/features/com_udf.rst
@@ -7,5 +7,5 @@
   but without the additional overhead constraints of analyses,
   meaning CoM can now be performed during live processing
   or subclassed to perform integrated CoM
-  as in `https://github.com/LiberTEM/LiberTEM-iCoM`_
+  as in `LiberTEM-iCoM <https://github.com/LiberTEM/LiberTEM-iCoM>`_
   (:pr:`1392`).

--- a/docs/source/changelog/features/com_udf.rst
+++ b/docs/source/changelog/features/com_udf.rst
@@ -1,7 +1,7 @@
 [Features] Centre-of-Mass calculation UDF
 =========================================
 
-* Adds COMUDF to perform virtual CoM calculations via
+* Adds CoMUDF to perform virtual CoM calculations via
   the standard `run_udf` interface. This replicates the
   existing :code:`Context.create_com_analysis` functionality
   but without the additional overhead constraints of analyses,

--- a/docs/source/changelog/features/com_udf.rst
+++ b/docs/source/changelog/features/com_udf.rst
@@ -1,0 +1,11 @@
+[Features] Centre-of-Mass calculation UDF
+=========================================
+
+* Adds COMUDF to perform virtual CoM calculations via
+  the standard `run_udf` interface. This replicates the
+  existing :code:`Context.create_com_analysis` functionality
+  but without the additional overhead constraints of analyses,
+  meaning CoM can now be performed during live processing
+  or subclassed to perform integrated CoM
+  as in `https://github.com/LiberTEM/LiberTEM-iCoM`_
+  (:pr:`1392`).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,6 +67,8 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx_issues',
     'sphinx_rtd_theme',
+    'sphinx_toolbox.more_autodoc.autonamedtuple',
+    'enum_tools.autoenum',
 ]
 
 bibtex_bibfiles = ['references-libertem.bib']

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -19,7 +19,7 @@ Analysis API
    :members: MasksResultSet, SingleMaskResultSet
 
 .. automodule:: libertem.analysis.com
-   :members: COMResultSet, guess_corrections, GuessResult
+   :members: COMResultSet
 
 .. automodule:: libertem.analysis.sum
    :members: SumResultSet

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -129,7 +129,20 @@ Centre-of-Mass
 ##############
 
 .. autoclass:: libertem.udf.com.CoMUDF
+    :members: with_params
+
+The :code:`CoMUDF` has two helper classes used to parametrise it:
+
+.. autoclass:: libertem.udf.com.CoMParams
+
+.. autoclass:: libertem.udf.com.RegressionOptions
     :members:
+
+There is also a function available to guess sensible CoM parameters:
+
+.. autofunction:: libertem.udf.com.guess_corrections
+
+.. autoclass:: libertem.udf.com.GuessResult
 
 .. _`masks udf`:
 

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -133,16 +133,15 @@ Centre-of-Mass
 
 The :code:`CoMUDF` has two helper classes used to parametrise it:
 
-.. autoclass:: libertem.udf.com.CoMParams
+.. autonamedtuple:: libertem.udf.com.CoMParams
 
-.. autoclass:: libertem.udf.com.RegressionOptions
-    :members:
+.. autoenum:: libertem.udf.com.RegressionOptions
 
 There is also a function available to guess sensible CoM parameters:
 
 .. autofunction:: libertem.udf.com.guess_corrections
 
-.. autoclass:: libertem.udf.com.GuessResult
+.. autonamedtuple:: libertem.udf.com.GuessResult
 
 .. _`masks udf`:
 

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -123,6 +123,14 @@ Sum per frame
 .. autoclass:: libertem.udf.sumsigudf.SumSigUDF
     :members:
 
+.. _`com udf`:
+
+Centre-of-Mass
+##############
+
+.. autoclass:: libertem.udf.com.COMUDF
+    :members:
+
 .. _`masks udf`:
 
 Apply masks

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -128,7 +128,7 @@ Sum per frame
 Centre-of-Mass
 ##############
 
-.. autoclass:: libertem.udf.com.COMUDF
+.. autoclass:: libertem.udf.com.CoMUDF
     :members:
 
 .. _`masks udf`:

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -5,6 +5,8 @@ sphinxcontrib-bibtex>=2
 # https://github.com/sloria/sphinx-issues/issues/125
 sphinx-issues!=3.0.0
 sphinx-rtd-theme
+sphinx-toolbox
+enum-tools[sphinx]
 nbsphinx!=0.8.8
 nbsphinx_link
 ipython

--- a/src/libertem/analysis/com.py
+++ b/src/libertem/analysis/com.py
@@ -1,6 +1,6 @@
 import logging
 import inspect
-from typing import Dict, NamedTuple, Optional, Tuple, Type, Union, TYPE_CHECKING
+from typing import Dict, Type, TYPE_CHECKING
 
 import numpy as np
 
@@ -8,8 +8,15 @@ from libertem import masks
 from libertem.web.rpc import ProcedureProtocol
 from .base import AnalysisResult, AnalysisResultSet
 from .masks import BaseMasksAnalysis
-from libertem.corrections import coordinates
+
 from .helper import GeneratorHelper
+
+# Keep imports for backwards compatibility!
+from libertem.udf.com import (  # noqa: 401
+    com_masks_factory, com_masks_generic, center_shifts, apply_correction,
+    divergence, curl_2d, magnitude,
+    coordinate_check, GuessResult, guess_corrections
+)
 
 if TYPE_CHECKING:
     from libertem.web.rpc import RPCContext
@@ -80,234 +87,6 @@ class ComTemplate(GeneratorHelper):
             save.append(f"np.save('com_result_{channel}.npy', com_result['{channel}'].raw_data)")
 
         return '\n'.join(save)
-
-
-def com_masks_factory(detector_y, detector_x, cy, cx, r):
-    def disk_mask():
-        return masks.circular(
-            centerX=cx, centerY=cy,
-            imageSizeX=detector_x,
-            imageSizeY=detector_y,
-            radius=r,
-        )
-
-    return [
-        disk_mask,
-        lambda: masks.gradient_y(
-            imageSizeX=detector_x,
-            imageSizeY=detector_y,
-        ) * disk_mask(),
-        lambda: masks.gradient_x(
-            imageSizeX=detector_x,
-            imageSizeY=detector_y,
-        ) * disk_mask(),
-    ]
-
-
-def com_masks_generic(detector_y, detector_x, base_mask_factory):
-    """
-    Create a CoM mask stack with a generic selection mask factory
-
-    Parameters
-    ----------
-    detector_y : int
-        The detector height
-    detector_x : int
-        The detector width
-    base_mask_factory : () -> np.array
-        A factory function for creating the selection mask
-
-    Returns
-    -------
-    List[Function]
-        The mask stack as a list of factory functions
-    """
-    return [
-        base_mask_factory,
-        lambda: masks.gradient_y(
-            imageSizeX=detector_x,
-            imageSizeY=detector_y,
-        ) * base_mask_factory(),
-        lambda: masks.gradient_x(
-            imageSizeX=detector_x,
-            imageSizeY=detector_y,
-        ) * base_mask_factory(),
-    ]
-
-
-def center_shifts(img_sum, img_y, img_x, ref_y, ref_x):
-    x_centers = np.divide(img_x, img_sum, where=img_sum != 0)
-    y_centers = np.divide(img_y, img_sum, where=img_sum != 0)
-    x_centers[img_sum == 0] = ref_x
-    y_centers[img_sum == 0] = ref_y
-    x_centers -= ref_x
-    y_centers -= ref_y
-    return (y_centers, x_centers)
-
-
-def apply_correction(y_centers, x_centers, scan_rotation, flip_y, forward=True):
-    shape = y_centers.shape
-    if flip_y:
-        transform = coordinates.flip_y()
-    else:
-        transform = coordinates.identity()
-    # Transformations are applied right to left
-    transform = coordinates.rotate_deg(scan_rotation) @ transform
-    y_centers = y_centers.reshape(-1)
-    x_centers = x_centers.reshape(-1)
-    if not forward:
-        transform = np.linalg.inv(transform)
-    y_transformed, x_transformed = transform @ (y_centers, x_centers)
-    y_transformed = y_transformed.reshape(shape)
-    x_transformed = x_transformed.reshape(shape)
-    return (y_transformed, x_transformed)
-
-
-def divergence(y_centers, x_centers):
-    return np.gradient(y_centers, axis=0) + np.gradient(x_centers, axis=1)
-
-
-def curl_2d(y_centers, x_centers):
-    # https://en.wikipedia.org/wiki/Curl_(mathematics)#Usage
-    # DFy/dx - dFx/dy
-    # axis 0 is y, axis 1 is x
-    return np.gradient(y_centers, axis=1) - np.gradient(x_centers, axis=0)
-
-
-def magnitude(y_centers, x_centers):
-    return np.sqrt(y_centers**2 + x_centers**2)
-
-
-def coordinate_check(y_centers, x_centers, roi=None):
-    '''
-    Calculate the RMS curl as a function of :code:`scan_rotation` and :code:`flip_y`.
-
-    The curl for a purely electrostatic field is zero. That means
-    the correct settings for :code:`scan_rotation` and :code:`flip_y` should
-    minimize the RMS curl for atomic resolution STEM of non-magnetic specimens
-    along a high-symmetry zone axis.
-
-    Parameters
-    ----------
-    y_centers, x_centers : numpy.ndarray
-        2D arrays with y and x component of the center of mass shift for each
-        scan position, as returned by :meth:`center_shifts` or
-        :meth:`apply_correction`
-    roi : Optional[numpy.ndarray]
-        Selector for values to consider in the statistics, compatible
-        with indexing an array with the shape of y_centers and x_centers.
-        By default, everything except the last row and last column are used
-        since these contain artefacts.
-
-    Returns
-    -------
-    (straight, flipped)
-        Root mean square of the curl as a function of :code:`scan_rotation` from
-        0 to 359 degrees in steps of one, with :code:`flip_y=False` (straight)
-        and code:`flip_y=True` (flipped).
-    '''
-    straight = np.zeros(360)
-    flipped = np.zeros(360)
-    if roi is None:
-        # The last row and column contain artifacts
-        roi = (slice(0, -1), slice(0, -1))
-    for angle in range(360):
-        for flip_y in (True, False):
-            y_transformed, x_transformed = apply_correction(
-                y_centers, x_centers, scan_rotation=angle, flip_y=flip_y
-            )
-            curl = curl_2d(y_transformed, x_transformed)
-            result = np.sqrt(np.mean(curl[roi]**2))
-            if flip_y:
-                flipped[angle] = result
-            else:
-                straight[angle] = result
-    return (straight, flipped)
-
-
-class GuessResult(NamedTuple):
-    scan_rotation: int
-    flip_y: bool
-    cy: float
-    cx: float
-
-
-def guess_corrections(
-    y_centers: np.ndarray,
-    x_centers: np.ndarray,
-    roi: Optional[Union[np.ndarray, Tuple[slice, ...]]] = None,
-) -> GuessResult:
-    '''
-    Guess corrections for center shift, :code:`scan_rotation` and :code:`flip_y` from CoM data
-
-    This function can generate a CoM parameter guess for atomic resolution 4D STEM data
-    by using the following assumptions:
-
-    * The field is purely electrostatic, i.e. the RMS curl should be minimized
-    * There is no net field over the field of view and no descan error,
-      i.e. the mean deflection is zero.
-    * Atomic resolution STEM means that the divergence will be negative at atom columns
-      and consequently the histogram of divergence will have a stronger tail towards
-      negative values than towards positive values.
-
-    If any corrections were applied when generating the input data, please note that the corrections
-    should be applied relative to these previous value. In particular, the
-    center corrections returned by this function have to be back-transformed to the uncorrected
-    coordinate system, for example with :code:`apply_correction(..., forward=False)`
-
-    Parameters
-    ----------
-    y_centers, x_centers : numpy.ndarray
-        2D arrays with y and x component of the center of mass shift for each
-        scan position, as returned by :meth:`center_shifts` or
-        :meth:`apply_correction`
-    roi : Optional[numpy.ndarray]
-        Selector for values to consider in the statistics, compatible
-        with indexing an array with the shape of y_centers and x_centers.
-        By default, everything except the last row and last column are used
-        since these contain artefacts.
-
-
-    Returns
-    -------
-    GuessResult : relative to current values
-    '''
-    if roi is None:
-        # The last row and column contain artefacts
-        roi = (slice(0, -1), slice(0, -1))
-    straight, flipped = coordinate_check(y_centers, x_centers, roi=roi)
-    # The one with lower minima is the correct one
-    flip_y = bool(np.min(flipped) < np.min(straight))
-    if flip_y:
-        angle = np.argmin(flipped)
-    else:
-        angle = np.argmin(straight)
-
-    corrected_y, corrected_x = apply_correction(
-        y_centers, x_centers, scan_rotation=angle, flip_y=flip_y
-    )
-    # There are two equivalent angles that minimize RMS curl since a 180°
-    # rotation inverts the coordinates and just flips the sign for divergence
-    # and curl. To distinguish the two, the distribution of the divergence is
-    # analyzed. With negative electrons and positive nuclei, the beam is
-    # deflected towards the nuclei and the divergence is negative there. Since
-    # the beam is deflected most strongly near the nuclei, the histogram should
-    # have more values at the negative end of the range than at the positive
-    # end.
-    div = divergence(corrected_y, corrected_x)[roi]
-    all_range = np.maximum(-np.min(div), np.max(div))
-    hist, bins = np.histogram(div, range=(-all_range, all_range), bins=5)
-    polarity_off = np.sum(hist[:1]) < np.sum(hist[-1:])
-    if polarity_off:
-        angle += 180
-    if angle > 180:
-        angle -= 360
-    return GuessResult(
-        scan_rotation=int(angle),
-        flip_y=flip_y,
-        cy=np.mean(y_centers[roi]),
-        cx=np.mean(x_centers[roi])
-    )
 
 
 class COMResultSet(AnalysisResultSet):

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -607,6 +607,8 @@ class CoMUDF(UDF):
                 valid_field = field[valid]
                 res = np.linalg.lstsq(inp[valid], valid_field, rcond=None)
                 result[:] = res[0]
+            else:
+                raise ValueError(f'Unrecognized regression option {com_params.regression}')
         else:
             regression = np.array(com_params.regression)
             if regression.shape != (3, 2):

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -11,7 +11,7 @@ from libertem.common.math import prod
 from libertem.udf.base import UDF
 
 
-class COMParams(NamedTuple):
+class CoMParams(NamedTuple):
     cy: Optional[float] = None
     cx: Optional[float] = None
     r: float = float('inf')
@@ -247,7 +247,7 @@ def guess_corrections(
     )
 
 
-class COMUDF(UDF):
+class CoMUDF(UDF):
     """
     Perform centre-of-mass analysis on the dataset
 
@@ -257,7 +257,7 @@ class COMUDF(UDF):
     sub-classable.
 
     To parametrise the CoM calculation, use the constructor
-    :classmethod:`COMUDF.with_params`.
+    :classmethod:`CoMUDF.with_params`.
 
     .. versionadded:: 0.12.0
 
@@ -294,20 +294,20 @@ class COMUDF(UDF):
 
     Parameters
     ----------
-    com_params : COMParams
-        A :class:`COMParams` instance containing the parameters
-        for this UDF. By default will create a COMParams instance
+    com_params : CoMParams
+        A :class:`CoMParams` instance containing the parameters
+        for this UDF. By default will create a CoMParams instance
         which performs whole-frame CoM with results in the coordinates
         of the frame # CHECKTHIS
 
     Examples
     --------
-    >>> udf = COMUDF()
+    >>> udf = CoMUDF()
     >>> result = ctx.run_udf(dataset=dataset, udf=udf)
     >>> result["magnitude"].data.shape
     (16, 16)
     """
-    def __init__(self, com_params: COMParams = COMParams()):
+    def __init__(self, com_params: CoMParams = CoMParams()):
         super().__init__(com_params=com_params)
 
     @classmethod
@@ -322,7 +322,7 @@ class COMUDF(UDF):
         flip_y: bool = False,
     ):
         """
-        Returns an instantiated COMUDF with a given set of parameters
+        Returns an instantiated CoMUDF with a given set of parameters
 
         Parameters
         ----------
@@ -362,7 +362,7 @@ class COMUDF(UDF):
         if ri >= r:
             raise ValueError('Inner radius must be less than outer radius for annular CoM')
         return cls(
-            com_params=COMParams(
+            com_params=CoMParams(
                 cy=cy, cx=cx, r=r, ri=ri,
                 scan_rotation=scan_rotation, flip_y=flip_y,
             )
@@ -397,7 +397,7 @@ class COMUDF(UDF):
             ),
         }
 
-    def get_params(self) -> COMParams:
+    def get_params(self) -> CoMParams:
         sig_shape = tuple(self.meta.dataset_shape.sig)
         cy = self.params.com_params.cy
         if cy is None:
@@ -412,7 +412,7 @@ class COMUDF(UDF):
         scan_rotation = self.params.com_params.scan_rotation
         flip_y = self.params.com_params.flip_y
 
-        cp = COMParams(
+        cp = CoMParams(
             cy=cy, cx=cx, r=r, ri=ri, scan_rotation=scan_rotation, flip_y=flip_y,
         )
         return cp
@@ -421,9 +421,9 @@ class COMUDF(UDF):
         sig_shape = tuple(self.meta.dataset_shape.sig)
         com_params = self.get_params()
         if len(sig_shape) != 2:
-            raise ValueError('COMUDF only works with 2D sig shape.')
+            raise ValueError('CoMUDF only works with 2D sig shape.')
         if len(self.meta.dataset_shape.nav) != 2:
-            raise ValueError('COMUDF only works with 2D nav shape.')
+            raise ValueError('CoMUDF only works with 2D nav shape.')
 
         if com_params.ri is None or np.isclose(com_params.ri, 0.):
             mask_factory = com_masks_factory(

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -439,7 +439,6 @@ class CoMUDF(UDF):
             The regression that was used is available in the :code:`'regression'`
             result buffer.
 
-
         .. note::
             Using a regression correction calculated on the data itself may
             distort valid results, such as the effect of long-range fields.

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -1,4 +1,6 @@
+from enum import IntEnum
 from typing import NamedTuple, Optional, Tuple, Union
+from typing_extensions import Literal
 
 import numpy as np
 from sparseconverter import CUPY_BACKENDS
@@ -11,6 +13,20 @@ from libertem.common.math import prod
 from libertem.udf.base import UDF
 
 
+class RegressionOptions(IntEnum):
+    """
+    Possible values of the regression functionality
+    implemented in :class:`~libertem.udf.com.CoMUDF`
+    """
+    NO_REGRESSION = -1
+    SUBTRACT_MEAN = 0
+    SUBTRACT_LINEAR = 1
+
+
+# Needed because poor enum support in mypy?
+RegressionOptionsT = Union[np.ndarray, Literal[-1, 0, 1]]
+
+
 class CoMParams(NamedTuple):
     cy: Optional[float] = None
     cx: Optional[float] = None
@@ -18,7 +34,7 @@ class CoMParams(NamedTuple):
     ri: Union[float, None] = 0.
     scan_rotation: float = 0.
     flip_y: bool = False
-    regression: Union[np.ndarray, int] = -1
+    regression: RegressionOptionsT = RegressionOptions.NO_REGRESSION
 
 
 def com_masks_factory(detector_y, detector_x, cy, cx, r):
@@ -325,7 +341,7 @@ class CoMUDF(UDF):
         ri: float = 0.,
         scan_rotation: float = 0.,
         flip_y: bool = False,
-        regression: Union[np.ndarray, int] = -1
+        regression: RegressionOptionsT = RegressionOptions.NO_REGRESSION,
     ):
         """
         Returns an instantiated CoMUDF with a given set of parameters

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -1,5 +1,4 @@
 from typing import NamedTuple, Optional, Tuple, Union
-from collections import namedtuple
 
 import numpy as np
 from sparseconverter import CUPY_BACKENDS
@@ -12,11 +11,13 @@ from libertem.common.math import prod
 from libertem.udf.base import UDF
 
 
-COMParams = namedtuple(
-    'COMParams',
-    ('cy', 'cx', 'r', 'ri', 'scan_rotation', 'flip_y'),
-    defaults=(None, None, None, None, None, None)
-)
+class COMParams(NamedTuple):
+    cy: Optional[float] = None
+    cx: Optional[float] = None
+    r: Optional[float] = None
+    ri: Optional[float] = None
+    scan_rotation: Optional[float] = None
+    flip_y: Optional[bool] = None
 
 
 def com_masks_factory(detector_y, detector_x, cy, cx, r):

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -304,8 +304,8 @@ class COMUDF(UDF):
     --------
     >>> udf = COMUDF()
     >>> result = ctx.run_udf(dataset=dataset, udf=udf)
-    >>> result["magnitude"].raw_data.shape
-    (32, 32)
+    >>> result["magnitude"].data.shape
+    (16, 16)
     """
     def __init__(self, com_params: COMParams = COMParams()):
         super().__init__(com_params=com_params)

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -356,13 +356,13 @@ class CoMUDF(UDF):
     >>> udf = CoMUDF.with_params(cy=7.2, cx=6.8, r=4.)
     >>> result = ctx.run_udf(dataset=dataset, udf=udf)
     >>> result["raw_shifts"].data.shape
-    (16, 16)
+    (16, 16, 2)
 
     >>> # Whole-frame CoM corrected to have zero-mean shift
     >>> udf = CoMUDF.with_params(regression=0)
     >>> result = ctx.run_udf(dataset=dataset, udf=udf)
     >>> result["raw_shifts"].data.shape
-    (16, 16)
+    (16, 16, 2)
     """
     def __init__(self, com_params: CoMParams = CoMParams()):
         super().__init__(com_params=com_params)

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -384,10 +384,7 @@ class COMUDF(UDF):
             raw_shifts = raw_shifts[roi]
             field = field[roi]
             mag = mag[roi]
-            div2 = div[roi]
-            dumped = div[np.invert(roi)]
-            div = div2
-            assert np.allclose(dumped, np.nan, equal_nan=True)
+            div = div[roi]
             curl = curl[roi]
         else:
             raw_shifts = raw_shifts.reshape((-1, 2))

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -1,0 +1,405 @@
+from typing import NamedTuple, Optional, Tuple, Union
+from collections import namedtuple
+
+import numpy as np
+from sparseconverter import CUPY_BACKENDS
+
+from libertem import masks
+from libertem.corrections import coordinates
+from libertem.udf.masks import ApplyMasksEngine
+from libertem.common.container import MaskContainer
+from libertem.udf.base import UDF
+
+
+COMParams = namedtuple(
+    'COMParams',
+    ('cy', 'cx', 'r', 'ri', 'scan_rotation', 'flip_y'),
+    defaults=(None, None, None, None, None, None)
+)
+
+
+def com_masks_factory(detector_y, detector_x, cy, cx, r):
+    def disk_mask():
+        return masks.circular(
+            centerX=cx, centerY=cy,
+            imageSizeX=detector_x,
+            imageSizeY=detector_y,
+            radius=r,
+        )
+
+    return [
+        disk_mask,
+        lambda: masks.gradient_y(
+            imageSizeX=detector_x,
+            imageSizeY=detector_y,
+        ) * disk_mask(),
+        lambda: masks.gradient_x(
+            imageSizeX=detector_x,
+            imageSizeY=detector_y,
+        ) * disk_mask(),
+    ]
+
+
+def com_masks_generic(detector_y, detector_x, base_mask_factory):
+    """
+    Create a CoM mask stack with a generic selection mask factory
+
+    Parameters
+    ----------
+    detector_y : int
+        The detector height
+    detector_x : int
+        The detector width
+    base_mask_factory : () -> np.array
+        A factory function for creating the selection mask
+
+    Returns
+    -------
+    List[Function]
+        The mask stack as a list of factory functions
+    """
+    return [
+        base_mask_factory,
+        lambda: masks.gradient_y(
+            imageSizeX=detector_x,
+            imageSizeY=detector_y,
+        ) * base_mask_factory(),
+        lambda: masks.gradient_x(
+            imageSizeX=detector_x,
+            imageSizeY=detector_y,
+        ) * base_mask_factory(),
+    ]
+
+
+def center_shifts(img_sum, img_y, img_x, ref_y, ref_x):
+    x_centers = np.divide(img_x, img_sum, where=img_sum != 0)
+    y_centers = np.divide(img_y, img_sum, where=img_sum != 0)
+    x_centers[img_sum == 0] = ref_x
+    y_centers[img_sum == 0] = ref_y
+    x_centers -= ref_x
+    y_centers -= ref_y
+    return (y_centers, x_centers)
+
+
+def apply_correction(y_centers, x_centers, scan_rotation, flip_y, forward=True):
+    shape = y_centers.shape
+    if flip_y:
+        transform = coordinates.flip_y()
+    else:
+        transform = coordinates.identity()
+    # Transformations are applied right to left
+    transform = coordinates.rotate_deg(scan_rotation) @ transform
+    y_centers = y_centers.reshape(-1)
+    x_centers = x_centers.reshape(-1)
+    if not forward:
+        transform = np.linalg.inv(transform)
+    y_transformed, x_transformed = transform @ (y_centers, x_centers)
+    y_transformed = y_transformed.reshape(shape)
+    x_transformed = x_transformed.reshape(shape)
+    return (y_transformed, x_transformed)
+
+
+def divergence(y_centers, x_centers):
+    return np.gradient(y_centers, axis=0) + np.gradient(x_centers, axis=1)
+
+
+def curl_2d(y_centers, x_centers):
+    # https://en.wikipedia.org/wiki/Curl_(mathematics)#Usage
+    # DFy/dx - dFx/dy
+    # axis 0 is y, axis 1 is x
+    return np.gradient(y_centers, axis=1) - np.gradient(x_centers, axis=0)
+
+
+def magnitude(y_centers, x_centers):
+    return np.sqrt(y_centers**2 + x_centers**2)
+
+
+def coordinate_check(y_centers, x_centers, roi=None):
+    '''
+    Calculate the RMS curl as a function of :code:`scan_rotation` and :code:`flip_y`.
+
+    The curl for a purely electrostatic field is zero. That means
+    the correct settings for :code:`scan_rotation` and :code:`flip_y` should
+    minimize the RMS curl for atomic resolution STEM of non-magnetic specimens
+    along a high-symmetry zone axis.
+
+    Parameters
+    ----------
+    y_centers, x_centers : numpy.ndarray
+        2D arrays with y and x component of the center of mass shift for each
+        scan position, as returned by :meth:`center_shifts` or
+        :meth:`apply_correction`
+    roi : Optional[numpy.ndarray]
+        Selector for values to consider in the statistics, compatible
+        with indexing an array with the shape of y_centers and x_centers.
+        By default, everything except the last row and last column are used
+        since these contain artefacts.
+
+    Returns
+    -------
+    (straight, flipped)
+        Root mean square of the curl as a function of :code:`scan_rotation` from
+        0 to 359 degrees in steps of one, with :code:`flip_y=False` (straight)
+        and code:`flip_y=True` (flipped).
+    '''
+    straight = np.zeros(360)
+    flipped = np.zeros(360)
+    if roi is None:
+        # The last row and column contain artifacts
+        roi = (slice(0, -1), slice(0, -1))
+    for angle in range(360):
+        for flip_y in (True, False):
+            y_transformed, x_transformed = apply_correction(
+                y_centers, x_centers, scan_rotation=angle, flip_y=flip_y
+            )
+            curl = curl_2d(y_transformed, x_transformed)
+            result = np.sqrt(np.mean(curl[roi]**2))
+            if flip_y:
+                flipped[angle] = result
+            else:
+                straight[angle] = result
+    return (straight, flipped)
+
+
+class GuessResult(NamedTuple):
+    scan_rotation: int
+    flip_y: bool
+    cy: float
+    cx: float
+
+
+def guess_corrections(
+    y_centers: np.ndarray,
+    x_centers: np.ndarray,
+    roi: Optional[Union[np.ndarray, Tuple[slice, ...]]] = None,
+) -> GuessResult:
+    '''
+    Guess corrections for center shift, :code:`scan_rotation` and :code:`flip_y` from CoM data
+
+    This function can generate a CoM parameter guess for atomic resolution 4D STEM data
+    by using the following assumptions:
+
+    * The field is purely electrostatic, i.e. the RMS curl should be minimized
+    * There is no net field over the field of view and no descan error,
+      i.e. the mean deflection is zero.
+    * Atomic resolution STEM means that the divergence will be negative at atom columns
+      and consequently the histogram of divergence will have a stronger tail towards
+      negative values than towards positive values.
+
+    If any corrections were applied when generating the input data, please note that the corrections
+    should be applied relative to these previous value. In particular, the
+    center corrections returned by this function have to be back-transformed to the uncorrected
+    coordinate system, for example with :code:`apply_correction(..., forward=False)`
+
+    Parameters
+    ----------
+    y_centers, x_centers : numpy.ndarray
+        2D arrays with y and x component of the center of mass shift for each
+        scan position, as returned by :meth:`center_shifts` or
+        :meth:`apply_correction`
+    roi : Optional[numpy.ndarray]
+        Selector for values to consider in the statistics, compatible
+        with indexing an array with the shape of y_centers and x_centers.
+        By default, everything except the last row and last column are used
+        since these contain artefacts.
+
+
+    Returns
+    -------
+    GuessResult : relative to current values
+    '''
+    if roi is None:
+        # The last row and column contain artefacts
+        roi = (slice(0, -1), slice(0, -1))
+    straight, flipped = coordinate_check(y_centers, x_centers, roi=roi)
+    # The one with lower minima is the correct one
+    flip_y = bool(np.min(flipped) < np.min(straight))
+    if flip_y:
+        angle = np.argmin(flipped)
+    else:
+        angle = np.argmin(straight)
+
+    corrected_y, corrected_x = apply_correction(
+        y_centers, x_centers, scan_rotation=angle, flip_y=flip_y
+    )
+    # There are two equivalent angles that minimize RMS curl since a 180°
+    # rotation inverts the coordinates and just flips the sign for divergence
+    # and curl. To distinguish the two, the distribution of the divergence is
+    # analyzed. With negative electrons and positive nuclei, the beam is
+    # deflected towards the nuclei and the divergence is negative there. Since
+    # the beam is deflected most strongly near the nuclei, the histogram should
+    # have more values at the negative end of the range than at the positive
+    # end.
+    div = divergence(corrected_y, corrected_x)[roi]
+    all_range = np.maximum(-np.min(div), np.max(div))
+    hist, bins = np.histogram(div, range=(-all_range, all_range), bins=5)
+    polarity_off = np.sum(hist[:1]) < np.sum(hist[-1:])
+    if polarity_off:
+        angle += 180
+    if angle > 180:
+        angle -= 360
+    return GuessResult(
+        scan_rotation=int(angle),
+        flip_y=flip_y,
+        cy=np.mean(y_centers[roi]),
+        cx=np.mean(x_centers[roi])
+    )
+
+
+class COMUDF(UDF):
+    def __init__(self, com_params: COMParams = COMParams()):
+        super().__init__(com_params=com_params)
+
+    def get_backends(self):
+        return self.BACKEND_ALL
+
+    def get_result_buffers(self):
+        dtype = np.result_type(self.meta.input_dtype, np.float32)
+        return {
+            'raw_mask_result': self.buffer(
+                kind='nav', dtype=dtype, extra_shape=(3, ), where='device', use='private'
+            ),
+            'raw_shifts': self.buffer(
+                kind='nav', dtype=dtype, extra_shape=(2, ), use='result_only'
+            ),
+            'field': self.buffer(
+                kind='nav', dtype=dtype, extra_shape=(2, ), use='result_only'
+            ),
+            'magnitude': self.buffer(
+                kind='nav', dtype=dtype, use='result_only'
+            ),
+            'divergence': self.buffer(
+                kind='nav', dtype=dtype, use='result_only'
+            ),
+            'curl': self.buffer(
+                kind='nav', dtype=dtype, use='result_only'
+            ),
+        }
+
+    def get_params(self) -> COMParams:
+        sig_shape = tuple(self.meta.dataset_shape.sig)
+        cy = self.params.com_params.cy
+        if cy is None:
+            cy = sig_shape[0] // 2
+
+        cx = self.params.com_params.cx
+        if cx is None:
+            cx = sig_shape[1] // 2
+
+        r = self.params.com_params.r
+        if r is None:
+            r = np.inf
+
+        ri = self.params.com_params.ri
+
+        scan_rotation = self.params.com_params.scan_rotation
+        if scan_rotation is None:
+            scan_rotation = 0
+
+        flip_y = self.params.com_params.flip_y
+        if flip_y is None:
+            flip_y = False
+
+        return COMParams(
+            cy=cy, cx=cx, r=r, ri=ri, scan_rotation=scan_rotation, flip_y=flip_y,
+        )
+
+    def get_task_data(self):
+        sig_shape = tuple(self.meta.dataset_shape.sig)
+        com_params = self.get_params()
+        if len(sig_shape) != 2:
+            raise ValueError('COMUDF only works with 2D sig shape.')
+        if len(self.meta.dataset_shape.nav) != 2:
+            raise ValueError('COMUDF only works with 2D nav shape.')
+
+        if com_params.ri is None:
+            mask_factory = com_masks_factory(
+                detector_y=sig_shape[0],
+                detector_x=sig_shape[1],
+                cx=com_params.cx,
+                cy=com_params.cy,
+                r=com_params.r,
+            )
+        else:
+            mask_factory = com_masks_generic(
+                detector_y=sig_shape[0],
+                detector_x=sig_shape[1],
+                base_mask_factory=lambda: masks.ring(
+                    imageSizeY=sig_shape[0],
+                    imageSizeX=sig_shape[1],
+                    centerY=com_params.cy,
+                    centerX=com_params.cx,
+                    radius=com_params.r,
+                    radius_inner=com_params.ri,
+                )
+            )
+        if self.meta.array_backend in CUPY_BACKENDS:
+            backend = self.BACKEND_CUPY
+        else:
+            backend = self.BACKEND_NUMPY
+
+        masks_container = MaskContainer(
+            mask_factories=mask_factory, dtype=np.float32, use_sparse=False,
+            count=3, backend=backend
+        )
+        return {
+            'com_params': com_params,
+            'engine': ApplyMasksEngine(masks=masks_container, meta=self.meta, use_torch=True)
+        }
+
+    def process_tile(self, tile):
+        raw_result = self.task_data.engine.process_tile(tile)
+        self.results.raw_mask_result[:] += self.forbuf(
+            raw_result, self.results.raw_mask_result
+        )
+
+    def get_results(self):
+        com_params = self.get_params()
+        raw_mask_result = self.results.get_buffer('raw_mask_result')
+        raw_shifts = center_shifts(
+            img_sum=raw_mask_result.data[..., 0],
+            img_y=raw_mask_result.data[..., 1],
+            img_x=raw_mask_result.data[..., 2],
+            ref_y=com_params.cy,
+            ref_x=com_params.cx,
+        )
+        field = apply_correction(
+            y_centers=raw_shifts[0],
+            x_centers=raw_shifts[1],
+            scan_rotation=com_params.scan_rotation,
+            flip_y=com_params.flip_y,
+        )
+        roi = self.meta.roi
+        field_y = field[0]
+        field_x = field[1]
+
+        raw_shifts = np.moveaxis(np.array(raw_shifts), 0, -1)
+        field = np.moveaxis(np.array(field), 0, -1)
+        mag = magnitude(
+            y_centers=field_y, x_centers=field_x
+        )
+        div = divergence(y_centers=field_y, x_centers=field_x)
+        curl = curl_2d(y_centers=field_y, x_centers=field_x)
+        if self.meta.roi is not None:
+            raw_shifts = raw_shifts[roi]
+            field = field[roi]
+            mag = mag[roi]
+            div2 = div[roi]
+            dumped = div[np.invert(roi)]
+            div = div2
+            assert np.allclose(dumped, np.nan, equal_nan=True)
+            curl = curl[roi]
+        else:
+            raw_shifts = raw_shifts.reshape((-1, 2))
+            field = field.reshape((-1, 2))
+            mag = mag.reshape(-1)
+            div = div.reshape(-1)
+            curl = curl.reshape(-1)
+
+        return {
+            'raw_shifts': raw_shifts,
+            'field': field,
+            'magnitude': mag,
+            'divergence': div,
+            'curl': curl,
+        }

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -57,8 +57,11 @@ class ApplyMasksEngine:
                 return result
 
         elif (
-            self.meta.array_backend in (UDF.BACKEND_SCIPY_COO, UDF.BACKEND_SCIPY_CSR, UDF.BACKEND_SCIPY_CSC)
-            and self.masks.use_sparse
+            self.meta.array_backend in (
+                UDF.BACKEND_SCIPY_COO,
+                UDF.BACKEND_SCIPY_CSR,
+                UDF.BACKEND_SCIPY_CSC
+            ) and self.masks.use_sparse
             and 'sparse.pydata' in self.masks.use_sparse
         ):
 

--- a/tests/executor/test_delayed.py
+++ b/tests/executor/test_delayed.py
@@ -29,7 +29,19 @@ class CountUDF(UDF):
         self.results.count[:] = np.ones(tile.shape[:1], dtype=np.int32)
 
     def get_result_buffers(self):
-        return {'count': self.buffer(kind='nav', dtype=np.int32)}
+        return {
+            'count': self.buffer(kind='nav', dtype=np.int32),
+            'total': self.buffer(
+                kind='single',
+                dtype=np.int32,
+                use='result_only'
+            ),
+        }
+
+    def get_results(self):
+        return {
+            'total': self.results.count.sum()
+        }
 
 
 class StrUDF(UDF):
@@ -43,7 +55,7 @@ class StrUDF(UDF):
 class MySumUDF(UDF):
     def get_result_buffers(self):
         return {
-            'intensity': self.buffer(kind='sig', dtype=self.meta.input_dtype)
+            'intensity': self.buffer(kind='sig', dtype=self.meta.input_dtype),
         }
 
     def process_tile(self, tile):
@@ -163,7 +175,13 @@ def count(udf_params, ds_dict):
     udf = CountUDF(**udf_params)
     naive_result = np.ones(flat_nav_data.shape[:1], dtype=np.int32)
     naive_result = fill_nav_with_roi(ds_shape, naive_result, roi, fill=0)
-    return {'udf': udf, 'naive_result': {'count': naive_result}}
+    return {
+        'udf': udf,
+        'naive_result': {
+            'count': naive_result,
+            'total': naive_result.sum(),
+        }
+    }
 
 
 def string(udf_params, ds_dict):

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -310,3 +310,9 @@ def test_com_regression_linear_2(lt_ctx, use_roi, regression):
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
     assert_allclose(res['regression'].data, [[-2, 1], [2, 1], [3, 4]], atol=1e-14)
     assert_allclose(res['field'].raw_data, 0, atol=1e-12)
+
+
+def test_invalid_regression_val(lt_ctx, npy_8x8x8x8_ds):
+    udf = com.CoMUDF.with_params(regression=5)
+    with pytest.raises(ValueError):
+        lt_ctx.run_udf(npy_8x8x8x8_ds, udf)

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -250,7 +250,7 @@ def test_com_regression_linear(lt_ctx, use_roi, regression):
     udf = com.CoMUDF.with_params(cy=3, cx=3, regression=regression)
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
     assert_allclose(res['regression'].data, [[-2, 42], [2, 0], [0, -1]], atol=1e-14)
-    assert_allclose(res['field'].raw_data, 0, atol=1e-13)
+    assert_allclose(res['field'].raw_data, 0, atol=1e-12)
 
 
 @pytest.mark.parametrize(
@@ -275,4 +275,4 @@ def test_com_regression_linear_2(lt_ctx, use_roi, regression):
     udf = com.CoMUDF.with_params(cy=3, cx=3, regression=regression)
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
     assert_allclose(res['regression'].data, [[-2, 1], [2, 1], [3, 4]], atol=1e-14)
-    assert_allclose(res['field'].raw_data, 0, atol=1e-13)
+    assert_allclose(res['field'].raw_data, 0, atol=1e-12)

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -15,7 +15,7 @@ from utils import _mk_random, set_device_class
 
 
 @pytest.mark.parametrize(
-    'backend', (None, ) + tuple(com.COMUDF().get_backends())
+    'backend', (None, ) + tuple(com.CoMUDF().get_backends())
 )
 def test_com(lt_ctx, delayed_ctx, backend):
     with set_device_class(get_device_class(backend)):
@@ -31,8 +31,8 @@ def test_com(lt_ctx, delayed_ctx, backend):
             array_backends=(backend, ) if backend is not None else None
         )
 
-        com_result = lt_ctx.run_udf(udf=com.COMUDF(), dataset=dataset)
-        com_delayed = delayed_ctx.run_udf(udf=com.COMUDF(), dataset=dataset)
+        com_result = lt_ctx.run_udf(udf=com.CoMUDF(), dataset=dataset)
+        com_delayed = delayed_ctx.run_udf(udf=com.CoMUDF(), dataset=dataset)
 
         com_analysis = lt_ctx.create_com_analysis(dataset=dataset)
         analysis_result = lt_ctx.run(com_analysis)
@@ -93,7 +93,7 @@ def test_com_params(lt_ctx, repeat):
     scan_rotation = random.choice((0., 13.3, 233))
     flip_y = random.choice((True, False))
 
-    com_udf = com.COMUDF.with_params(
+    com_udf = com.CoMUDF.with_params(
         cy=cy,
         cx=cx,
         r=ro,
@@ -119,7 +119,7 @@ def test_com_params(lt_ctx, repeat):
        or (np.isclose(com_dict['mask_radius_inner'], 0.) and random.choice((True, False)))):
         com_dict['mask_radius_inner'] = None
 
-    com_result = lt_ctx.run_udf(udf=com.COMUDF(com_params), dataset=dataset)
+    com_result = lt_ctx.run_udf(udf=com.CoMUDF(com_params), dataset=dataset)
     com_analysis = lt_ctx.create_com_analysis(dataset=dataset, **com_dict)
     analysis_result = lt_ctx.run(com_analysis)
 
@@ -149,7 +149,7 @@ def test_com_roi(lt_ctx, repeat):
 
     roi = np.random.choice([True, False], dataset.shape.nav)
 
-    com_result = lt_ctx.run_udf(udf=com.COMUDF(), dataset=dataset, roi=roi)
+    com_result = lt_ctx.run_udf(udf=com.CoMUDF(), dataset=dataset, roi=roi)
 
     com_analysis = lt_ctx.create_com_analysis(dataset=dataset)
     analysis_result = lt_ctx.run(com_analysis, roi=roi)

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -141,6 +141,40 @@ def test_com_params(lt_ctx, repeat):
     )
 
 
+def test_com_invalid_annulus_params():
+    with pytest.raises(ValueError):
+        com.CoMUDF.with_params(
+            r=5.,
+            ri=10.,
+        )
+
+
+def test_invalid_sig_shape(lt_ctx):
+    ds = lt_ctx.load(
+        'memory',
+        data=np.zeros((2, 2, 4, 4, 4)),
+        sig_dims=3,
+        num_partitions=1,  # avoid a warning
+    )
+    udf = com.CoMUDF()
+    with pytest.raises(ValueError):
+        lt_ctx.run_udf(ds, udf)
+
+
+@pytest.mark.parametrize('dims', (1, 3))
+def test_invalid_nav_shape(lt_ctx, dims):
+    nav_shape = (2,) * dims
+    ds = lt_ctx.load(
+        'memory',
+        data=np.zeros(nav_shape + (4, 4)),
+        sig_dims=2,
+        num_partitions=1,  # avoid a warning
+    )
+    udf = com.CoMUDF()
+    with pytest.raises(ValueError):
+        lt_ctx.run_udf(ds, udf)
+
+
 @pytest.mark.parametrize('repeat', range(10))
 def test_com_roi(lt_ctx, repeat):
 

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -78,106 +78,101 @@ def test_com(lt_ctx, delayed_ctx, backend):
         )
 
 
-def test_com_params(lt_ctx):
-    for i in range(10):
-        data = _mk_random((16, 8, 32, 64))
-        dataset = MemoryDataSet(data=data)
+@pytest.mark.parametrize('repeat', range(10))
+def test_com_params(lt_ctx, repeat):
+    data = _mk_random((16, 8, 32, 64))
+    dataset = MemoryDataSet(data=data)
 
-        cy = random.choice((None, 2.1, 17))
-        cx = random.choice((None, 3.7, 23))
-        r = random.choice((None, 10.2, 19))
-        ri = random.choice((None, 3.1, 9))
-        scan_rotation = random.choice((None, 13.3, 233))
-        flip_y = random.choice((None, True, False))
+    cy = random.choice((None, 2.1, 17))
+    cx = random.choice((None, 3.7, 23))
+    r = random.choice((None, 10.2, 19))
+    ri = random.choice((None, 3.1, 9))
+    scan_rotation = random.choice((None, 13.3, 233))
+    flip_y = random.choice((None, True, False))
 
-        com_params = com.COMParams(
-            cy=cy,
-            cx=cx,
-            r=r,
-            ri=ri,
-            scan_rotation=scan_rotation,
-            flip_y=flip_y,
-        )
-        com_dict = {
-            p: getattr(com_params, p) for p in (
-                'cy', 'cx', 'scan_rotation', 'flip_y'
-            ) if getattr(com_params, p) is not None
-        }
+    com_params = com.COMParams(
+        cy=cy,
+        cx=cx,
+        r=r,
+        ri=ri,
+        scan_rotation=scan_rotation,
+        flip_y=flip_y,
+    )
+    com_dict = {
+        p: getattr(com_params, p) for p in (
+            'cy', 'cx', 'scan_rotation', 'flip_y'
+        ) if getattr(com_params, p) is not None
+    }
 
-        if com_params.r is not None:
-            com_dict['mask_radius'] = com_params.r
-        if com_params.ri is not None:
-            com_dict['mask_radius_inner'] = com_params.ri
+    if com_params.r is not None:
+        com_dict['mask_radius'] = com_params.r
+    if com_params.ri is not None:
+        com_dict['mask_radius_inner'] = com_params.ri
 
-        if com_params.r is None and com_params.ri is not None:
-            continue  # not supported by COMAnalysis
+    if com_params.r is None and com_params.ri is not None:
+        return  # not supported by COMAnalysis
 
-        com_result = lt_ctx.run_udf(udf=com.COMUDF(com_params), dataset=dataset)
+    com_result = lt_ctx.run_udf(udf=com.COMUDF(com_params), dataset=dataset)
 
-        com_analysis = lt_ctx.create_com_analysis(dataset=dataset, **com_dict)
-        analysis_result = lt_ctx.run(com_analysis)
+    com_analysis = lt_ctx.create_com_analysis(dataset=dataset, **com_dict)
+    analysis_result = lt_ctx.run(com_analysis)
 
-        assert_allclose(
-            com_result['field'],
-            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
-        )
-        assert_allclose(
-            com_result['magnitude'],
-            analysis_result.magnitude.raw_data,
-        )
-        assert_allclose(
-            com_result['divergence'],
-            analysis_result.divergence.raw_data,
-        )
-        assert_allclose(
-            com_result['curl'],
-            analysis_result.curl.raw_data,
-        )
+    assert_allclose(
+        com_result['field'],
+        np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+    )
+    assert_allclose(
+        com_result['magnitude'],
+        analysis_result.magnitude.raw_data,
+    )
+    assert_allclose(
+        com_result['divergence'],
+        analysis_result.divergence.raw_data,
+    )
+    assert_allclose(
+        com_result['curl'],
+        analysis_result.curl.raw_data,
+    )
 
 
-def test_com_roi(lt_ctx):
-    for i in range(10):
-        data = _mk_random((16, 8, 32, 64))
-        dataset = MemoryDataSet(data=data)
+@pytest.mark.parametrize('repeat', range(10))
+def test_com_roi(lt_ctx, repeat):
 
-        roi = np.random.choice([True, False], dataset.shape.nav)
+    data = _mk_random((16, 8, 32, 64))
+    dataset = MemoryDataSet(data=data)
 
-        com_result = lt_ctx.run_udf(udf=com.COMUDF(), dataset=dataset, roi=roi)
+    roi = np.random.choice([True, False], dataset.shape.nav)
 
-        com_analysis = lt_ctx.create_com_analysis(dataset=dataset)
-        analysis_result = lt_ctx.run(com_analysis, roi=roi)
+    com_result = lt_ctx.run_udf(udf=com.COMUDF(), dataset=dataset, roi=roi)
 
-        assert_allclose(
-            com_result['field'],
-            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
-        )
-        assert_allclose(
-            com_result['magnitude'],
-            analysis_result.magnitude.raw_data,
-        )
-        for y in range(com_result['divergence'].data.shape[0]):
-            for x in range(com_result['divergence'].data.shape[1]):
-                res = com_result['divergence'].data[y, x]
-                ref = analysis_result.divergence.raw_data[y, x]
-                if not np.allclose(ref, res, equal_nan=True):
-                    print(y, x, ref, res)
+    com_analysis = lt_ctx.create_com_analysis(dataset=dataset)
+    analysis_result = lt_ctx.run(com_analysis, roi=roi)
 
-        # The Analysis may return non-NaN values outside of the ROI
-        # if all neighbors are within the ROI because of the way how np.gradient works.
-        # It can directly return the result for the entire nav buffer, i.e. also set
-        # values outside of the ROI.
-        # The UDF cannot set values outside of the ROI to exactly replicate the Analysis
-        # because of the way how get_results() and UDF result buffers for kind='nav' work.
-        # Instead of equality for the entire result, we test for equality within the ROI
-        # and only NaN outside of the ROI for the UDF result.
-        inverted_roi = np.invert(roi)
-        assert_allclose(
-            com_result['divergence'].data[roi],
-            analysis_result.divergence.raw_data[roi],
-        )
-        assert np.all(np.isnan(com_result['divergence'].data[inverted_roi]))
-        assert_allclose(
-            com_result['curl'].data[roi],
-            analysis_result.curl.raw_data[roi],
-        )
-        assert np.all(np.isnan(com_result['curl'].data[inverted_roi]))
+    assert_allclose(
+        com_result['field'],
+        np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+    )
+    assert_allclose(
+        com_result['magnitude'],
+        analysis_result.magnitude.raw_data,
+    )
+
+    # The Analysis may return non-NaN values outside of the ROI
+    # if all neighbors are within the ROI because of the way how np.gradient works.
+    # It can directly return the result for the entire nav buffer, i.e. also set
+    # values outside of the ROI.
+    # The UDF cannot set values outside of the ROI to exactly replicate the Analysis
+    # because of the way how get_results() and UDF result buffers for kind='nav' work.
+    # Instead of equality for the entire result, we test for equality within the ROI
+    # and only NaN outside of the ROI for the UDF result.
+    inverted_roi = np.invert(roi)
+    assert_allclose(
+        com_result['divergence'].data[roi],
+        analysis_result.divergence.raw_data[roi],
+    )
+    assert np.all(np.isnan(com_result['divergence'].data[inverted_roi]))
+    assert_allclose(
+        com_result['curl'].data[roi],
+        analysis_result.curl.raw_data[roi],
+    )
+    assert np.all(np.isnan(com_result['curl'].data[inverted_roi]))

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -1,0 +1,172 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+import random
+
+import libertem.udf.com as com
+from sparseconverter import (
+    SPARSE_BACKENDS, NUMPY, SPARSE_COO, get_device_class,
+    CUPY_SCIPY_CSC
+)
+
+from libertem.io.dataset.memory import MemoryDataSet
+
+from utils import _mk_random, set_device_class
+
+
+@pytest.mark.parametrize(
+    'backend', (None, ) + tuple(com.COMUDF().get_backends())
+)
+def test_com(lt_ctx, delayed_ctx, backend):
+    with set_device_class(get_device_class(backend)):
+        if backend in SPARSE_BACKENDS:
+            data = _mk_random((16, 8, 32, 64), array_backend=SPARSE_COO)
+        else:
+            data = _mk_random((16, 8, 32, 64), array_backend=NUMPY)
+
+        dataset = MemoryDataSet(
+            data=data, tileshape=(8, 32, 64),
+            num_partitions=2,
+            sig_dims=2,
+            array_backends=(backend, ) if backend is not None else None
+        )
+
+        com_result = lt_ctx.run_udf(udf=com.COMUDF(), dataset=dataset)
+        com_delayed = delayed_ctx.run_udf(udf=com.COMUDF(), dataset=dataset)
+
+        com_analysis = lt_ctx.create_com_analysis(dataset=dataset)
+        analysis_result = lt_ctx.run(com_analysis)
+
+        if backend is CUPY_SCIPY_CSC:
+            pytest.xfail(
+                'For unknown reasons the dot product seems to be unstable '
+                'for cupyx.scipy.csc_matrix'
+            )
+
+        assert_allclose(
+            com_result['field'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+        )
+        assert_allclose(
+            com_result['magnitude'],
+            analysis_result.magnitude.raw_data,
+        )
+        assert_allclose(
+            com_result['divergence'],
+            analysis_result.divergence.raw_data,
+        )
+        assert_allclose(
+            com_result['curl'],
+            analysis_result.curl.raw_data,
+        )
+
+        assert_allclose(
+            com_delayed['field'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+        )
+        assert_allclose(
+            com_delayed['magnitude'],
+            analysis_result.magnitude.raw_data,
+        )
+        assert_allclose(
+            com_delayed['divergence'],
+            analysis_result.divergence.raw_data,
+        )
+        assert_allclose(
+            com_delayed['curl'],
+            analysis_result.curl.raw_data,
+        )
+
+
+def test_com_params(lt_ctx):
+    for i in range(10):
+        data = _mk_random((16, 8, 32, 64))
+        dataset = MemoryDataSet(data=data)
+
+        cy = random.choice((None, 2.1, 17))
+        cx = random.choice((None, 3.7, 23))
+        r = random.choice((None, 10.2, 19))
+        ri = random.choice((None, 3.1, 9))
+        scan_rotation = random.choice((None, 13.3, 233))
+        flip_y = random.choice((None, True, False))
+
+        com_params = com.COMParams(
+            cy=cy,
+            cx=cx,
+            r=r,
+            ri=ri,
+            scan_rotation=scan_rotation,
+            flip_y=flip_y,
+        )
+        com_dict = {
+            p: getattr(com_params, p) for p in (
+                'cy', 'cx', 'scan_rotation', 'flip_y'
+            ) if getattr(com_params, p) is not None
+        }
+
+        if com_params.r is not None:
+            com_dict['mask_radius'] = com_params.r
+        if com_params.ri is not None:
+            com_dict['mask_radius_inner'] = com_params.ri
+
+        if com_params.r is None and com_params.ri is not None:
+            continue  # not supported by COMAnalysis
+
+        com_result = lt_ctx.run_udf(udf=com.COMUDF(com_params), dataset=dataset)
+
+        com_analysis = lt_ctx.create_com_analysis(dataset=dataset, **com_dict)
+        analysis_result = lt_ctx.run(com_analysis)
+
+        assert_allclose(
+            com_result['field'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+        )
+        assert_allclose(
+            com_result['magnitude'],
+            analysis_result.magnitude.raw_data,
+        )
+        assert_allclose(
+            com_result['divergence'],
+            analysis_result.divergence.raw_data,
+        )
+        assert_allclose(
+            com_result['curl'],
+            analysis_result.curl.raw_data,
+        )
+
+
+def test_com_roi(lt_ctx):
+    for i in range(10):
+        data = _mk_random((16, 8, 32, 64))
+        dataset = MemoryDataSet(data=data)
+
+        roi = np.random.choice([True, False], dataset.shape.nav)
+
+        com_result = lt_ctx.run_udf(udf=com.COMUDF(), dataset=dataset, roi=roi)
+
+        com_analysis = lt_ctx.create_com_analysis(dataset=dataset)
+        analysis_result = lt_ctx.run(com_analysis, roi=roi)
+
+        assert_allclose(
+            com_result['field'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+        )
+        assert_allclose(
+            com_result['magnitude'],
+            analysis_result.magnitude.raw_data,
+        )
+        for y in range(com_result['divergence'].data.shape[0]):
+            for x in range(com_result['divergence'].data.shape[1]):
+                res = com_result['divergence'].data[y, x]
+                ref = analysis_result.divergence.raw_data[y, x]
+                if not np.allclose(ref, res, equal_nan=True):
+                    print(y, x, ref, res)
+
+        assert_allclose(
+            com_result['divergence'],
+            analysis_result.divergence.raw_data,
+        )
+        assert_allclose(
+            com_result['curl'],
+            analysis_result.curl.raw_data,
+        )

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -85,35 +85,41 @@ def test_com_params(lt_ctx, repeat):
 
     cy = random.choice((None, 2.1, 17))
     cx = random.choice((None, 3.7, 23))
-    r = random.choice((None, 10.2, 19))
-    ri = random.choice((None, 3.1, 9))
-    scan_rotation = random.choice((None, 13.3, 233))
-    flip_y = random.choice((None, True, False))
+    ro = random.choice((float('inf'), 10.2, 19))
+    ri = random.choice((0., 3.1, 9))
+    if np.isinf(ro):
+        # Non-zero ri not supported by analysis API
+        ri = 0.
+    scan_rotation = random.choice((0., 13.3, 233))
+    flip_y = random.choice((True, False))
 
-    com_params = com.COMParams(
+    com_udf = com.COMUDF.with_params(
         cy=cy,
         cx=cx,
-        r=r,
+        r=ro,
         ri=ri,
         scan_rotation=scan_rotation,
         flip_y=flip_y,
     )
-    com_dict = {
-        p: getattr(com_params, p) for p in (
-            'cy', 'cx', 'scan_rotation', 'flip_y'
-        ) if getattr(com_params, p) is not None
-    }
+    com_params = com_udf.params.com_params
 
-    if com_params.r is not None:
-        com_dict['mask_radius'] = com_params.r
-    if com_params.ri is not None:
-        com_dict['mask_radius_inner'] = com_params.ri
+    com_dict = {}
+    com_dict['cy'] = com_params.cy
+    com_dict['cx'] = com_params.cx
+    com_dict['scan_rotation'] = com_params.scan_rotation
+    com_dict['flip_y'] = com_params.flip_y
+    com_dict['mask_radius'] = com_params.r
+    com_dict['mask_radius_inner'] = com_params.ri
 
-    if com_params.r is None and com_params.ri is not None:
-        return  # not supported by COMAnalysis
+    # Test the analysis default None parameters
+    if np.isinf(com_dict['mask_radius']) and random.choice((True, False)):
+        com_dict['mask_radius'] = None
+
+    if (com_dict['mask_radius'] is None
+       or (np.isclose(com_dict['mask_radius_inner'], 0.) and random.choice((True, False)))):
+        com_dict['mask_radius_inner'] = None
 
     com_result = lt_ctx.run_udf(udf=com.COMUDF(com_params), dataset=dataset)
-
     com_analysis = lt_ctx.create_com_analysis(dataset=dataset, **com_dict)
     analysis_result = lt_ctx.run(com_analysis)
 


### PR DESCRIPTION
Adds `COMUDF`, continued from #1392 .

Notes:
- The default analysis parameters have been lifted into the definition of the `COMParams(NamedTuple)`, which makes the default functionality a bit clearer without digging into the code of `get_task_data`.
- Added a `@classmethod` `COMUDF.with_params(...)` to allow construction of a UDF with the desired `COMParams`, but mainly to give a clear place where the behaviour of each parameter is documented.
- Added a `raw_com` result buffer for the position of the CoM in the coordinate system of the frame - i.e. COMUDF returns the CoM, in addition to the *shift* in the CoM + field-derived results.
- Documented all of the result buffers in the docstring of `COMUDF`, again for visibility.

Two ideas:
- Any enthusiasm for renaming the UDF `CoMUDF` ? It would make it feel like less of a global variable, to me.
- I've always wondered about implementing a mode where the `raw_shifts` (and hence field++) are calculated from the *mean* of `raw_com` result, so that any error in the specification of `cy`/`cx` relative to the actual data centre doesn't give shifts / field which are all offset in one direction. Could also return the mean value and/or reference value in a result-only buffer for transparency. Any thoughts on that?

* [x] Check if this is still compatible with the `iCoM` repo

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code
