### PR TITLE
Revert "Pin Python 3.7 version in CI for macos-latest"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Choose Python version ${{ matrix.python_version }}
-        if: ${{ matrix.os != 'macos-latest' || matrix.python_version != '3.7' }}
         uses: actions/setup-python@v4
         with:
           python-version: '${{ matrix.python_version }}'
-          cache: 'pip'
-      # workaround for https://github.com/actions/setup-python/issues/682
-      - name: Choose Python version 3.7.16 for macos-latest
-        if: ${{ matrix.os == 'macos-latest' && matrix.python_version == '3.7' }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.7.16'
           cache: 'pip'
       - run: |
            [[ "${{ matrix.os }}" = "ubuntu-latest" ]] && sudo apt-get install -y libcap-dev || true

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ setup(
         'opentelemetry-api',
         'tblib',
         'tomli',
-        'sparseconverter>=0.3.2',
+        'sparseconverter>=0.3.3',
     ],
     extras_require={
         # NumPy interfacing issue on Win 11, Python 3.10


### PR DESCRIPTION
This reverts commit 917a1fbe33adf78fe66d7f0c8c57547d16a46f27.

Also require current `sparseconverter` version, which should fix #1467 

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
