### PR TITLE
Update codecov uploader binary version

### DIFF
--- a/scripts/codecov.sh
+++ b/scripts/codecov.sh
@@ -3,8 +3,8 @@
 set -e
 
 # pin the version so we can compare sha
-curl -Os https://uploader.codecov.io/v0.1.17/linux/codecov
-echo 'ca88335829e3a5b589674a200fdd1dae8f2ef27775647bc3aef6677266a6fda2 codecov' | sha256sum -c
+curl -Os https://uploader.codecov.io/v0.6.1/linux/codecov
+echo '0c9b79119b0d8dbe7aaf460dc3bd7c3094ceda06e5ae32b0d11a8ff56e2cc5c5 codecov' | sha256sum -c
 
 chmod +x codecov
 ./codecov $*


### PR DESCRIPTION
This should fix inconsistencies in the coverage reports, where some jobs would be attributed to a merge commit instead of the HEAD of the PR.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
