### PR TITLE
Allow empty list of stable tags

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -216,6 +216,8 @@ def get_latest_stable_tag():
             key=parse_version
         )
     )
+    if len(sorted_stable_tags) == 0:
+        return None
     return sorted_stable_tags[-1]
 
 


### PR DESCRIPTION
GitHub actions does a shallow clone, so if the current commit is not tagged, the list of tags will be empty (or if the tag is not a stable version tag, the filtered tag list will be empty). We only use `get_latest_stable_tag` to find out if the current commit has a stable tag, so this should be fine™.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
