### PR TITLE
Fix _baked_revision building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import subprocess
 import distutils
 import shutil
 from setuptools.command.sdist import sdist
-from setuptools.command.build_py import build_py
 from setuptools import setup, find_packages
 
 
@@ -70,13 +69,6 @@ class BakedRevisionBuilderSdist(sdist):
         super().make_release_tree(base_dir, files)
 
 
-class BakedRevisionBuilderBuildPy(build_py):
-    def run(self):
-        if not self.dry_run:
-            write_baked_revision(self.build_lib)
-        super().run()
-
-
 def mkpath(path):
     if not os.path.exists(path):
         os.makedirs(path)
@@ -106,7 +98,7 @@ def get_git_rev():
 
 
 def write_baked_revision(base_dir):
-    dest_dir = os.path.join(base_dir, 'libertem')
+    dest_dir = os.path.join(base_dir, 'src', 'libertem')
     baked_dest = os.path.join(dest_dir, '_baked_revision.py')
     mkpath(dest_dir)
 
@@ -202,7 +194,6 @@ setup(
         'build_client': BuildClientCommand,
         'copy_client': CopyClientCommand,
         'sdist': BakedRevisionBuilderSdist,
-        'build_py': BakedRevisionBuilderBuildPy,
     },
     keywords="electron microscopy",
     description="Open pixelated STEM framework",


### PR DESCRIPTION
We use `python -m build` these days, which uses PEP517 isolated builds. This means the `build_py` command is executed not on the source tree, but on a copy built from the sdist. There, we can't get the git revision anymore...
It also turns out that the baked revision in the sdist was written to a bad path (libertem/_baked_revision.py vs
src/libertem/_baked_revision.py), and by fixing that, the wheel now also contains the correct revision.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
