### PR TITLE
Catch `PermissionError` when doing `os.stat()` on file or directory

### DIFF
--- a/src/libertem/io/fs.py
+++ b/src/libertem/io/fs.py
@@ -80,7 +80,7 @@ def get_fs_listing(path):
         full_path = os.path.join(path, name)
         try:
             s = os.stat(full_path)
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             # this can happen either because of a TOCTOU-like race condition
             # or for example for things like broken softlinks
             continue

--- a/tests/io/test_io_fs.py
+++ b/tests/io/test_io_fs.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from libertem.io.fs import get_fs_listing, FSError
+from libertem.io.fs import get_fs_listing
 
 
 def test_get_fs_listing_permission_of_subdir(tmpdir_factory):
@@ -20,11 +20,14 @@ def test_get_fs_listing_permission_of_subdir(tmpdir_factory):
 
     # patch os.stat to fail for `sub2`:
     with mock.patch('os.stat', side_effect=mock_stat):
-        get_fs_listing(tmpdir)
+        listing = get_fs_listing(tmpdir)
+
+        dir_names = [
+            entry['name']
+            for entry in listing['dirs']
+        ]
+        assert 'sub2' not in dir_names
 
         # no direct access to `sub2`
         with pytest.raises(PermissionError):
             os.stat(no_access_dir)
-
-        with pytest.raises(FSError):
-            get_fs_listing(no_access_dir)

--- a/tests/io/test_io_fs.py
+++ b/tests/io/test_io_fs.py
@@ -20,11 +20,11 @@ def test_get_fs_listing_permission_of_subdir(tmpdir_factory):
 
     # patch os.stat to fail for `sub2`:
     with mock.patch('os.stat', side_effect=mock_stat):
-        listing = get_fs_listing(tmpdir)
+        get_fs_listing(tmpdir)
 
         # no direct access to `sub2`
         with pytest.raises(PermissionError):
             os.stat(no_access_dir)
-    
+
         with pytest.raises(FSError):
             get_fs_listing(no_access_dir)

--- a/tests/io/test_io_fs.py
+++ b/tests/io/test_io_fs.py
@@ -1,0 +1,30 @@
+import os
+from unittest import mock
+
+import pytest
+
+from libertem.io.fs import get_fs_listing, FSError
+
+
+def test_get_fs_listing_permission_of_subdir(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp('get_fs_listing')
+    tmpdir.mkdir('sub1')
+    no_access_dir = tmpdir.mkdir('sub2')
+
+    orig_stat = os.stat
+
+    def mock_stat(path):
+        if os.path.normpath(path) == os.path.normpath(no_access_dir):
+            raise PermissionError(f"[Errno 13] Access is denied: '{path}'")
+        return orig_stat(path)
+
+    # patch os.stat to fail for `sub2`:
+    with mock.patch('os.stat', side_effect=mock_stat):
+        listing = get_fs_listing(tmpdir)
+
+        # no direct access to `sub2`
+        with pytest.raises(PermissionError):
+            os.stat(no_access_dir)
+    
+        with pytest.raises(FSError):
+            get_fs_listing(no_access_dir)

--- a/tests/io/test_io_fs.py
+++ b/tests/io/test_io_fs.py
@@ -13,10 +13,10 @@ def test_get_fs_listing_permission_of_subdir(tmpdir_factory):
 
     orig_stat = os.stat
 
-    def mock_stat(path):
+    def mock_stat(path, *args, **kwargs):
         if os.path.normpath(path) == os.path.normpath(no_access_dir):
             raise PermissionError(f"[Errno 13] Access is denied: '{path}'")
-        return orig_stat(path)
+        return orig_stat(path, *args, **kwargs)
 
     # patch os.stat to fail for `sub2`:
     with mock.patch('os.stat', side_effect=mock_stat):


### PR DESCRIPTION
Fixes #1491 

Adding a test case for this is nontrivial, still thinking about it.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code