### PR TITLE
Fix web API test cases

### DIFF
--- a/tests/server/test_dataset.py
+++ b/tests/server/test_dataset.py
@@ -165,7 +165,7 @@ async def test_initial_state_after_reconnect(
             'type': 'RAW',
             'sync_offset': 0
         }
-        assert len(initial_msg["datasets"][0]["diagnostics"]) == 6
+        assert len(initial_msg["datasets"][0]["diagnostics"]) == 7
 
 
 @pytest.mark.asyncio
@@ -224,4 +224,4 @@ async def test_prime_cache(
             'type': 'RAW',
             'sync_offset': 0
         }
-        assert len(initial_msg["datasets"][0]["diagnostics"]) == 6
+        assert len(initial_msg["datasets"][0]["diagnostics"]) == 7


### PR DESCRIPTION
As they are not run in CI, these tests didn't get updated for #1475 and had an out-of-date assertion:

- `test_initial_state_after_reconnect`
- `test_prime_cache`

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
