### PR TITLE
Hashable `Shape`

### DIFF
--- a/docs/source/changelog/misc/hashable_shape.rst
+++ b/docs/source/changelog/misc/hashable_shape.rst
@@ -1,0 +1,4 @@
+[Misc] Shape class is now hashable
+==================================
+* The :code:`Shape` class is now hashable allowing it to be used
+  in a :code:`dict` and :code:`set`. (:pr:`1507`).

--- a/src/libertem/common/shape.py
+++ b/src/libertem/common/shape.py
@@ -162,6 +162,9 @@ class Shape:
     def __getitem__(self, k):
         return tuple(self)[k]
 
+    def __hash__(self):
+        return hash(((self._nav_shape + self._sig_shape), self._sig_dims))
+
     def __len__(self) -> int:
         return len(self._sig_shape) + len(self._nav_shape)
 

--- a/tests/common/test_shape.py
+++ b/tests/common/test_shape.py
@@ -91,3 +91,14 @@ def test_shape_add_2():
     s = Shape((12, 13, 14, 15), sig_dims=2)
     s_add = s + (1, 2)
     assert tuple(s_add) == (12, 13, 14, 15, 1, 2) and s_add.sig.dims == 4
+
+
+def test_can_hash():
+    shape = (12, 13, 14, 15)
+    sd1 = Shape(shape, sig_dims=1)
+    mapping = {sd1: 55}
+    sd2 = Shape(shape, sig_dims=2)
+    mapping[sd2] = 66
+    assert len(mapping) == 2
+    mapping.pop(sd1)
+    assert sd1 not in mapping.keys()


### PR DESCRIPTION
Brings `Shape` into line with `Slice` by adding the `__hash__` method.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code