### PR TITLE
`UDF.get_method()` used to choose implementation in `UDFPartRunner._run_tile`

### DIFF
--- a/src/libertem/common/udf.py
+++ b/src/libertem/common/udf.py
@@ -25,6 +25,12 @@ class TilingPreferences(TypedDict):
     total_size: Union[float, int]
 
 
+class UDFMethodEnum(Enum):
+    TILE = 'tile'
+    FRAME = 'frame'
+    PARTITION = 'partition'
+
+
 class UDFProtocol(Protocol):
     '''
     Parts of the UDF interface required for MIT code in LiberTEM
@@ -64,7 +70,7 @@ class UDFProtocol(Protocol):
     ND_BACKENDS = ND_BACKENDS  #: Set of backends that support n-dimensional arrays
     D2_BACKENDS = D2_BACKENDS  #: Set of backends that only support two-dimensional arrays
 
-    def get_method() -> Literal['tile', 'frame', 'partition']:
+    def get_method() -> Literal[UDFMethodEnum.TILE, UDFMethodEnum.FRAME, UDFMethodEnum.PARTITION]:
         raise NotImplementedError()
 
     def get_tiling_preferences() -> TilingPreferences:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -31,7 +31,7 @@ from libertem.common.buffers import (
     BufferKind, BufferUse, BufferLocation,
 )
 from libertem.common import Shape, Slice
-from libertem.common.udf import TilingPreferences, UDFProtocol
+from libertem.common.udf import TilingPreferences, UDFProtocol, UDFMethodEnum
 from libertem.common.math import prod
 from libertem.io.dataset.base import (
     TilingScheme, Negotiator, Partition, DataSet, get_coordinates
@@ -1096,13 +1096,17 @@ class UDFBase(UDFProtocol):
         else:
             raise ValueError(f"Backend can be {BACKENDS}, got {self._backend}")
 
-    def get_method(self) -> Literal['tile', 'frame', 'partition']:
-        if hasattr(self, 'process_tile'):
-            return 'tile'
-        elif hasattr(self, 'process_frame'):
-            return 'frame'
-        elif hasattr(self, 'process_partition'):
-            return 'partition'
+    def get_method(self) -> Literal[
+        UDFMethodEnum.TILE,
+        UDFMethodEnum.FRAME,
+        UDFMethodEnum.PARTITION
+    ]:
+        if isinstance(self, UDFTileMixin):
+            return UDFMethodEnum.TILE
+        elif isinstance(self, UDFFrameMixin):
+            return UDFMethodEnum.FRAME
+        elif isinstance(self, UDFPartitionMixin):
+            return UDFMethodEnum.PARTITION
         else:
             raise TypeError("UDF should implement one of the `process_*` methods")
 

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2117,12 +2117,15 @@ class UDFPartRunner:
         roi: Optional[np.ndarray],
     ) -> None:
         for udf in udfs:
-            if udf.get_method() == UDFMethodEnum.TILE:
+            udf_method = udf.get_method()
+            if udf_method == UDFMethodEnum.TILE:
+                assert isinstance(udf, UDFTileMixin)  # mypy!
                 udf.set_contiguous_views_for_tile(partition, tile)
                 udf.set_slice(tile.tile_slice)
                 udf.set_tile_idx(tile.scheme_idx)
                 udf.process_tile(device_tile)
-            elif udf.get_method() == UDFMethodEnum.FRAME:
+            elif udf_method == UDFMethodEnum.FRAME:
+                assert isinstance(udf, UDFFrameMixin)  # mypy!
                 tile_slice = tile.tile_slice
                 for frame_idx, frame in enumerate(device_tile):
                     frame_slice = Slice(
@@ -2143,7 +2146,8 @@ class UDFPartRunner:
                     udf.set_slice(frame_slice)
                     udf.set_views_for_frame(partition, tile, frame_idx)
                     udf.process_frame(frame)
-            elif udf.get_method() == UDFMethodEnum.PARTITION:
+            elif udf_method == UDFMethodEnum.PARTITION:
+                assert isinstance(udf, UDFPartitionMixin)  # mypy!
                 # Internal checks for dataset consistency
                 assert partition.slice.adjust_for_roi(roi) == tile.tile_slice
                 udf.set_views_for_tile(partition, tile)

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2115,12 +2115,12 @@ class UDFPartRunner:
         roi: Optional[np.ndarray],
     ) -> None:
         for udf in udfs:
-            if isinstance(udf, UDFTileMixin):
+            if udf.get_method() == UDFMethodEnum.TILE:
                 udf.set_contiguous_views_for_tile(partition, tile)
                 udf.set_slice(tile.tile_slice)
                 udf.set_tile_idx(tile.scheme_idx)
                 udf.process_tile(device_tile)
-            elif isinstance(udf, UDFFrameMixin):
+            elif udf.get_method() == UDFMethodEnum.FRAME:
                 tile_slice = tile.tile_slice
                 for frame_idx, frame in enumerate(device_tile):
                     frame_slice = Slice(
@@ -2141,7 +2141,7 @@ class UDFPartRunner:
                     udf.set_slice(frame_slice)
                     udf.set_views_for_frame(partition, tile, frame_idx)
                     udf.process_frame(frame)
-            elif isinstance(udf, UDFPartitionMixin):
+            elif udf.get_method() == UDFMethodEnum.PARTITION:
                 # Internal checks for dataset consistency
                 assert partition.slice.adjust_for_roi(roi) == tile.tile_slice
                 udf.set_views_for_tile(partition, tile)

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -9,6 +9,7 @@ from libertem.io.dataset.memory import MemoryDataSet
 from libertem.io.dataset.base import TilingScheme, DataTile
 from libertem.io.dataset.raw import RawFileDataSet, RawPartition
 from libertem.utils.devices import detect
+from libertem.exceptions import UDFException
 from libertem.common.backend import set_use_cpu, set_use_cuda
 from libertem.common.buffers import reshaped_view
 from libertem.udf.sumsigudf import SumSigUDF
@@ -770,3 +771,16 @@ def test_previous_attrs(lt_ctx, cls):
     # the current alternative
     with pytest.raises(AttributeError, match='self.meta.'):
         lt_ctx.run_udf(dataset=ds, udf=cls())
+
+
+class BadGetMethodUDF(SumUDF):
+    def get_method(self):
+        return 42
+
+
+def test_bad_get_method(lt_ctx):
+    ds = lt_ctx.load('memory', data=np.ones((2, 2, 4, 4)))
+    # Check that we get an attribute error that points to
+    # the current alternative
+    with pytest.raises(UDFException):
+        lt_ctx.run_udf(dataset=ds, udf=BadGetMethodUDF())


### PR DESCRIPTION
Closes #1508 

- Shifts the string identifiers "frame", "tile", "partition" onto `libertem.common.udf.UDFMethodEnum`
- Default `UDF.get_method()` performs the runtime protocol check previously in `UDFPartRunner._run_tile` and returns an enum member that `UDFPartRunner` matches against
- Additional checking added to verify `UDF.get_method()` return is valid (both is an enum member, and actually implements the desired Protocol)
- Additional test cases for invalid `UDF.get_method()` implementations

Notes:
- Returning an enum member from `get_method` is technically a breaking change, because `UDFMethodEnum.FRAME == 'frame'` is `False`, if we want to be completely backwards compatible we would need to use a `StrEnum` (either from the PyPi package or as a backport from 3.11). I think the API is/was not public though so no real requirement to do this!
- I had to add explicit `assert isinstance(udf, UDFFrameMixin)` inside `_run_tile` for each method in order to make `mypy` happy, this is just additional runtime overhead!
- The current implementation (nor the previous implementation) doesn't store the processing mode that the UDF wants to use, which adds a little bit of overhead, but also more importantly doesn't guarantee the processing mode can't change in the time between tiling scheme negotiation and actually processing tiles. On the one hand this would be a 'strange' thing for a UDF to do, but could be a hard to track down bug.
- I haven't added any documentation yet, would have to decide if this should be public facing?

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code