### PR TITLE
Update dependency pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,13 +149,12 @@ setup(
         'scikit-image',
         'cloudpickle',
         'jsonschema',
-        'scikit-learn<1.3.0',
+        'scikit-learn',
         'tqdm',
         'threadpoolctl>=3.0',
         'nbformat',
         'nbconvert',
         'autopep8',
-        'pycodestyle<2.11',  # FIXME: workaround for incompatibility w/ autopep8, remove this line once that's fixed!  # NOQA
         'empyre>=0.3.0',
         'defusedxml',
         'typing-extensions',  # backwards-compatibility for newer typing constructs
@@ -163,6 +162,7 @@ setup(
         'tblib',
         'tomli',
         'sparseconverter>=0.3.3',
+        'numexpr!=2.8.6',  # work around broken sanitization, remove this line when fixed
     ],
     extras_require={
         # NumPy interfacing issue on Win 11, Python 3.10


### PR DESCRIPTION
Work around https://github.com/pydata/numexpr/issues/449 and remove outdated pins (`scikit-learn`, `pycodestyle`)

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
