### PR TITLE
Update benchmarks

### DIFF
--- a/benchmarks/io/test_dask.py
+++ b/benchmarks/io/test_dask.py
@@ -40,7 +40,9 @@ class TestChunking:
         nblock_params,
         ids=tuple(f'nblocks: {c}' for c in nblock_params)
     )
-    def test_dask_nav_chunking(shared_dist_ctx_globaldask, large_raw_file, nblocks, benchmark):
+    def test_dask_nav_chunking(
+        self, shared_dist_ctx_globaldask, large_raw_file, nblocks, benchmark
+    ):
         _run_benchmark(shared_dist_ctx_globaldask, large_raw_file, nblocks, benchmark,
                     preserve_dim=True, min_size=None)
 
@@ -216,7 +218,7 @@ def _delayed_libertem_bench(ctx, ds, benchmark):
             dataset=ds,
             udf=SumUDF()
         )
-        result['intensity'].raw_data.compute()
+        result['intensity'].raw_data
     benchmark(doit)
 
 

--- a/benchmarks/udf/test_simple_udf.py
+++ b/benchmarks/udf/test_simple_udf.py
@@ -10,7 +10,7 @@ from libertem.common.backend import set_use_cpu, set_use_cuda
 class NoopSigUDF(UDF):
     def get_result_buffers(self):
         return {
-            "sigbuf": self.buffer(kind="sig", dtype=np.int, where="device")
+            "sigbuf": self.buffer(kind="sig", dtype=int, where="device")
         }
 
     def process_tile(self, tile):

--- a/benchmarks/udf/test_transfer.py
+++ b/benchmarks/udf/test_transfer.py
@@ -125,7 +125,7 @@ class Test:
     @pytest.mark.parametrize(
         'method', ('preshared_file', 'file', 'executor')
     )
-    def test_param(shared_dist_ctx, benchmark, tmp_path, method):
+    def test_param(self, shared_dist_ctx, benchmark, tmp_path, method):
         data = np.zeros(1024*1024, dtype=np.float32)
 
         ds = shared_dist_ctx.load(
@@ -162,7 +162,7 @@ class Test:
     @pytest.mark.parametrize(
         'method', ('file', 'executor')
     )
-    def test_result(shared_dist_ctx, benchmark, tmp_path, method):
+    def test_result(self, shared_dist_ctx, benchmark, tmp_path, method):
         if method == 'file':
             udf = CheatResultUDF(str(tmp_path))
         else:


### PR DESCRIPTION
* Some dask benchmarks don't need `.compute()` anymore (why?)
* Remove deprecated `np.int` usage
* class-based tests must take `self` as first argument - fixtures used as first parameter won't override it anymore!

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
