### PR TITLE
Converter for `(sig, nav)` DM4 files

### DIFF
--- a/docs/source/changelog/features/convert_transposed.rst
+++ b/docs/source/changelog/features/convert_transposed.rst
@@ -3,4 +3,4 @@
 * A function :meth:`libertem.contrib.convert_transposed.convert_dm4_transposed`
   has been added to efficiently convert Gatan Digital Micrograph STEM datasets
   stored in :code:`(sig, nav)` ordering to numpy .npy files in :code:`(nav_sig)`
-  ordering (:pr:`1509`).
+  ordering (:pr:`1520`).

--- a/docs/source/changelog/features/convert_transposed.rst
+++ b/docs/source/changelog/features/convert_transposed.rst
@@ -1,0 +1,6 @@
+[Feature] Converter for transposed DM4 datasets
+===============================================
+* A function :function:`libertem.contrib.convert_transposed.convert_dm4_transposed`
+  has been added to efficiently convert Gatan Digital Micrograph STEM datasets
+  stored in :code:`(sig, nav)` ordering to numpy .npy files in :code:`(nav_sig)`
+  ordering (:pr:`1509`).

--- a/docs/source/changelog/features/convert_transposed.rst
+++ b/docs/source/changelog/features/convert_transposed.rst
@@ -1,6 +1,6 @@
 [Feature] Converter for transposed DM4 datasets
 ===============================================
-* A function :function:`libertem.contrib.convert_transposed.convert_dm4_transposed`
+* A function :meth:`libertem.contrib.convert_transposed.convert_dm4_transposed`
   has been added to efficiently convert Gatan Digital Micrograph STEM datasets
   stored in :code:`(sig, nav)` ordering to numpy .npy files in :code:`(nav_sig)`
   ordering (:pr:`1509`).

--- a/docs/source/reference/dataset.rst
+++ b/docs/source/reference/dataset.rst
@@ -67,6 +67,10 @@ be inferred from the parameters.
 
 .. autoclass:: libertem.io.dataset.dm.StackedDMDataSet
 
+DM4 datsets stored in a transposed format :code:`(sig, nav)` can
+be converted to C-ordered data compatible with LiberTEM using the contrib function
+:function:`~libertem.contrib.convert_transposed.convert_dm4_transposed`.
+
 .. _`empad`:
 
 EMPAD
@@ -143,6 +147,11 @@ Dask
 ~~~~
 
 .. autoclass:: libertem.io.dataset.dask.DaskDataSet
+
+Converters
+~~~~~~~~~~
+
+.. autofunction:: libertem.contrib.convert_transposed.convert_dm4_transposed
 
 Internal DataSet API
 --------------------

--- a/docs/source/reference/dataset.rst
+++ b/docs/source/reference/dataset.rst
@@ -69,7 +69,7 @@ be inferred from the parameters.
 
 DM4 datsets stored in a transposed format :code:`(sig, nav)` can
 be converted to C-ordered data compatible with LiberTEM using the contrib function
-:function:`~libertem.contrib.convert_transposed.convert_dm4_transposed`.
+:meth:`~libertem.contrib.convert_transposed.convert_dm4_transposed`.
 
 .. _`empad`:
 
@@ -149,7 +149,7 @@ Dask
 .. autoclass:: libertem.io.dataset.dask.DaskDataSet
 
 Converters
-~~~~~~~~~~
+----------
 
 .. autofunction:: libertem.contrib.convert_transposed.convert_dm4_transposed
 

--- a/src/libertem/contrib/convert_transposed.py
+++ b/src/libertem/contrib/convert_transposed.py
@@ -63,6 +63,50 @@ def convert_dm4_transposed(
     dataset_index: Optional[int] = None,
     progress: bool = False,
 ):
+    """
+    Convenience function to convert a transposed Gatan Digital Micrograph
+    (.dm4) STEM dataset into a numpy (.npy) file with standard ordering for
+    processing with LiberTEM.
+
+    Transposed .dm4 files are stored in :code:`(sig, nav)` order, i.e.
+    all frame values for a given signal pixel are stored as blocks,
+    which means that extracting a single frame requires traversal of the
+    whole file. LiberTEM requires :code:`(nav, sig)` order for processing
+    using the UDF interface, i.e. each frame is stored sequentially.
+
+    .. versionadded:: 0.13.0
+
+    Parameters
+    ----------
+
+    dm4_path : PathLike
+        The path to the .dm4 file
+    out_path : PathLike
+        The path to the output .npy file
+    ctx : libertem.api.Context, optional
+        The Context to use to perform the conversion, by default None
+        in which case a Dask-based context will be created (optionally)
+        following the :code:`num_cpus` argument.
+    num_cpus : int, optional
+        When :code:`ctx` is not supplied, this argument limits
+        the number of CPUs to perform the conversion. This can be
+        important as conversion is a RAM-intensive operation and limiting
+        the number of CPUs can help reduce bottlenecking.
+    dataset_index : int, optional
+        If the .dm4 file contains multiple datasets, this can be used
+        to select the dataset to convert
+        (see :class:`~libertem.io.dataset.dm_single.SingleDMDataSet`)
+        for more information.
+    progress : bool, optional
+        Whether to display a progress bar during conversion, by default False
+
+    Raises
+    ------
+    DataSetException
+        If the DM4 dataset is not stored as transposed
+    ValueError
+        If both :code:`ctx` and :code:`num_cpus` are supplied
+    """
     if ctx is not None and num_cpus is not None:
         raise ValueError('Either supply a Context or number of cpus to use in conversion')
     elif ctx is None:

--- a/src/libertem/contrib/convert_transposed.py
+++ b/src/libertem/contrib/convert_transposed.py
@@ -1,7 +1,14 @@
-from typing import Tuple
+import os
+from typing import Tuple, Optional, TYPE_CHECKING
 
+import libertem.api as lt
+from libertem.io.dataset.base import DataSetException
+from libertem.io.dataset.dm_single import SingleDMDataSet
 from libertem.common import Shape
 from libertem.udf.record import RecordUDF
+
+if TYPE_CHECKING:
+    from libertem.api import Context, DataSet
 
 
 class ConvertTransposedDatasetUDF(RecordUDF):
@@ -31,3 +38,37 @@ class ConvertTransposedDatasetUDF(RecordUDF):
         self.task_data.memmap[
             :, flat_sig_origin:flat_sig_origin + n_sig_px
         ] = partition
+
+
+def _convert_transposed_ds(
+    ctx: 'Context',
+    ds: 'DataSet',
+    out_path: os.PathLike,
+    **run_kwargs,
+):
+    ctx.run_udf(
+        ds,
+        ConvertTransposedDatasetUDF(
+            out_path,
+        ),
+        **run_kwargs,
+    )
+
+
+def convert_dm4_transposed(
+    dm4_path: os.PathLike,
+    out_path: os.PathLike,
+    ctx: Optional['Context'] = None,
+    num_cpus: Optional[int] = None,
+    dataset_index: Optional[int] = None,
+    progress: bool = False,
+):
+    if ctx is not None and num_cpus is not None:
+        raise ValueError('Either supply a Context or number of cpus to use in conversion')
+    elif ctx is None:
+        ctx = lt.Context.make_with('dask', cpus=num_cpus)
+    ds_meta = SingleDMDataSet._read_metadata(dm4_path, use_ds=dataset_index)
+    if ds_meta['c_order']:
+        raise DataSetException('The DM4 data is not transposed')
+    ds = ctx.load('dm', dm4_path, force_c_order=True, dataset_index=dataset_index)
+    return _convert_transposed_ds(ctx, ds, out_path, progress=progress)

--- a/src/libertem/contrib/convert_transposed.py
+++ b/src/libertem/contrib/convert_transposed.py
@@ -1,0 +1,33 @@
+from typing import Tuple
+
+from libertem.common import Shape
+from libertem.udf.record import RecordUDF
+
+
+class ConvertTransposedDatasetUDF(RecordUDF):
+    def get_method(self):
+        return self.UDF_METHOD.PARTITION
+
+    @property
+    def _ds_shape(self) -> Shape:
+        nav_shape = self.meta.dataset_shape.sig.to_tuple()
+        sig_shape = self.meta.dataset_shape.nav.to_tuple()
+        return Shape(nav_shape + sig_shape, sig_dims=len(sig_shape))
+
+    @property
+    def _memmap_flat_shape(self) -> Tuple[int, ...]:
+        return (self._ds_shape.nav.size, self._ds_shape.sig.size)
+
+    def process_partition(self, partition):
+        # partition will be of shape (n_sig_pix, *ds.shape.nav)
+        n_sig_px = partition.shape[0]
+        # flatten the nav dimensions
+        partition = partition.reshape((n_sig_px, -1))
+        # Do the transpose, this is fast but becomes costly
+        # the moment we assign into the memmap
+        partition = partition.T
+        # the LT flat nav origin is actually the sig origin in the memmap
+        flat_sig_origin = self.meta.slice.origin[0]
+        self.task_data.memmap[
+            :, flat_sig_origin:flat_sig_origin + n_sig_px
+        ] = partition

--- a/src/libertem/io/dataset/dm_single.py
+++ b/src/libertem/io/dataset/dm_single.py
@@ -39,6 +39,9 @@ class SingleDMDataSet(DMDataSet):
     :code:`(flat_sig, flat_nav)` then the dataset will raise an exception
     unless the `force_c_order` argument. is set to true.
 
+    A converted for F/C-hybrid files is provided as
+    :meth:`~libertem.contrib.convert_transposed.convert_dm4_transposed`.
+
     Note
     ----
     In the Web-GUI a 2D-image or 3D-stack/spectrum image will have extra

--- a/src/libertem/io/dataset/dm_single.py
+++ b/src/libertem/io/dataset/dm_single.py
@@ -39,7 +39,7 @@ class SingleDMDataSet(DMDataSet):
     :code:`(flat_sig, flat_nav)` then the dataset will raise an exception
     unless the `force_c_order` argument. is set to true.
 
-    A converted for F/C-hybrid files is provided as
+    A converter for F/C-hybrid files is provided as
     :meth:`~libertem.contrib.convert_transposed.convert_dm4_transposed`.
 
     Note

--- a/tests/io/test_convert_transposed.py
+++ b/tests/io/test_convert_transposed.py
@@ -1,5 +1,6 @@
 import pathlib
 import numpy as np
+import pytest
 
 from libertem.udf.raw import PickUDF
 from libertem.udf.sum import SumUDF
@@ -8,27 +9,58 @@ from libertem.contrib.convert_transposed import _convert_transposed_ds
 from utils import _mk_random
 
 
-def test_functional(lt_ctx, tmpdir_factory):
+@pytest.mark.parametrize(
+    'nav_shape',
+    [
+        (6,),
+        (3, 4),
+    ]
+)
+@pytest.mark.parametrize(
+    'sig_shape',
+    [
+        (8,),
+        (7, 5),
+    ]
+)
+def test_functional(lt_ctx, nav_shape, sig_shape, tmpdir_factory):
+    nav_dims = len(nav_shape)
+    sig_dims = len(sig_shape)
+
     dir = pathlib.Path(tmpdir_factory.mktemp('convert_transposed'))
-    data = _mk_random(size=(7, 5, 3, 4), dtype='float32')
-    converted_data = np.moveaxis(data, (0, 1, 2, 3), (2, 3, 0, 1))
-    ds = lt_ctx.load('memory', data=data, num_partitions=2)
+    data = _mk_random(size=sig_shape + nav_shape, dtype='float32')
+    # Transpose to put the nav dims before the sig dims, but retaining
+    # the order of the dimensions within each group
+    # e.g. (0, 1, 2, 3) => (2, 3, 0, 1)
+    converted_data = np.moveaxis(
+        data,
+        tuple(range(data.ndim)),
+        tuple((*range(nav_dims, data.ndim), *range(nav_dims))),
+    )
+    ds = lt_ctx.load(
+        'memory',
+        data=data,
+        # sig_dims=nav_dims because nav_dims are at the end!
+        # needed so that we correctly partition the array
+        sig_dims=nav_dims,
+        num_partitions=2,
+    )
 
     convert_path = dir / 'out.npy'
     _convert_transposed_ds(lt_ctx, ds, convert_path)
 
-    ds_npy = lt_ctx.load('npy', path=convert_path)
+    # Now that we are transposed sig_dims=sig_dims
+    ds_npy = lt_ctx.load('npy', path=convert_path, sig_dims=sig_dims)
     assert ds_npy.shape.to_tuple() == converted_data.shape
 
-    for check_slice in (
-        np.s_[1, 3],
-        np.s_[2, 0],
-        np.s_[0, 1],
-    ):
+    for _ in range(3):
+        check_slice = tuple(
+            np.random.randint(0, n) for n in nav_shape
+        )
         roi = np.zeros(ds_npy.shape.nav, dtype=bool)
         roi[check_slice] = True
         frame = lt_ctx.run_udf(ds_npy, PickUDF(), roi=roi)['intensity'].data.squeeze()
         assert np.allclose(frame, converted_data[check_slice])
 
     sum_res = lt_ctx.run_udf(ds_npy, SumUDF())['intensity'].data
-    assert np.allclose(sum_res, converted_data.sum(axis=(0, 1)))
+    assert np.allclose(sum_res, converted_data.sum(axis=tuple(range(nav_dims))))

--- a/tests/io/test_convert_transposed.py
+++ b/tests/io/test_convert_transposed.py
@@ -4,7 +4,7 @@ import pytest
 
 from libertem.udf.raw import PickUDF
 from libertem.udf.sum import SumUDF
-from libertem.contrib.convert_transposed import _convert_transposed_ds
+from libertem.contrib.convert_transposed import convert_dm4_transposed, _convert_transposed_ds
 
 from utils import _mk_random
 
@@ -64,3 +64,17 @@ def test_functional(lt_ctx, nav_shape, sig_shape, tmpdir_factory):
 
     sum_res = lt_ctx.run_udf(ds_npy, SumUDF())['intensity'].data
     assert np.allclose(sum_res, converted_data.sum(axis=tuple(range(nav_dims))))
+
+
+def test_both_args_raise(lt_ctx):
+    with pytest.raises(ValueError):
+        convert_dm4_transposed(
+            'tata.dm4',
+            'out.npy',
+            ctx=lt_ctx,
+            num_cpus=42,
+        )
+
+
+# Tests on actual DM4 datasets are in tests/io/datasets/test_dm_single.py
+# to use the dm4 file fixtures defined there

--- a/tests/io/test_convert_transposed.py
+++ b/tests/io/test_convert_transposed.py
@@ -1,0 +1,34 @@
+import pathlib
+import numpy as np
+
+from libertem.udf.raw import PickUDF
+from libertem.udf.sum import SumUDF
+from libertem.contrib.convert_transposed import _convert_transposed_ds
+
+from utils import _mk_random
+
+
+def test_functional(lt_ctx, tmpdir_factory):
+    dir = pathlib.Path(tmpdir_factory.mktemp('convert_transposed'))
+    data = _mk_random(size=(7, 5, 3, 4), dtype='float32')
+    converted_data = np.moveaxis(data, (0, 1, 2, 3), (2, 3, 0, 1))
+    ds = lt_ctx.load('memory', data=data, num_partitions=2)
+
+    convert_path = dir / 'out.npy'
+    _convert_transposed_ds(lt_ctx, ds, convert_path)
+
+    ds_npy = lt_ctx.load('npy', path=convert_path)
+    assert ds_npy.shape.to_tuple() == converted_data.shape
+
+    for check_slice in (
+        np.s_[1, 3],
+        np.s_[2, 0],
+        np.s_[0, 1],
+    ):
+        roi = np.zeros(ds_npy.shape.nav, dtype=bool)
+        roi[check_slice] = True
+        frame = lt_ctx.run_udf(ds_npy, PickUDF(), roi=roi)['intensity'].data.squeeze()
+        assert np.allclose(frame, converted_data[check_slice])
+
+    sum_res = lt_ctx.run_udf(ds_npy, SumUDF())['intensity'].data
+    assert np.allclose(sum_res, converted_data.sum(axis=(0, 1)))

--- a/tests/io/test_convert_transposed.py
+++ b/tests/io/test_convert_transposed.py
@@ -2,8 +2,6 @@ import pathlib
 import numpy as np
 import pytest
 
-from libertem.udf.raw import PickUDF
-from libertem.udf.sum import SumUDF
 from libertem.contrib.convert_transposed import convert_dm4_transposed, _convert_transposed_ds
 
 from utils import _mk_random
@@ -52,18 +50,7 @@ def test_functional(lt_ctx, nav_shape, sig_shape, tmpdir_factory):
     # Now that we are transposed sig_dims=sig_dims
     ds_npy = lt_ctx.load('npy', path=convert_path, sig_dims=sig_dims)
     assert ds_npy.shape.to_tuple() == converted_data.shape
-
-    for _ in range(3):
-        check_slice = tuple(
-            np.random.randint(0, n) for n in nav_shape
-        )
-        roi = np.zeros(ds_npy.shape.nav, dtype=bool)
-        roi[check_slice] = True
-        frame = lt_ctx.run_udf(ds_npy, PickUDF(), roi=roi)['intensity'].data.squeeze()
-        assert np.allclose(frame, converted_data[check_slice])
-
-    sum_res = lt_ctx.run_udf(ds_npy, SumUDF())['intensity'].data
-    assert np.allclose(sum_res, converted_data.sum(axis=tuple(range(nav_dims))))
+    assert np.allclose(converted_data, np.load(convert_path))
 
 
 def test_both_args_raise(lt_ctx):


### PR DESCRIPTION
Adds converter for `(sig, nav)` DM4 files to `(nav, sig)` NPY files so that these can be processed using LiberTEM.

Add a single user-facing function at `libertem.contrib.convert_transposed.convert_dm4_transposed`.

Uses `process_partition` and a modified `RecordUDF` to load blocks of the file, generally avoiding the multiple-traversal / page fault issue explored in #1328.

This  converts the data to a numpy file, but I think it would be possible to extend it to create a new, c-ordered DM4 file with the same tags / structure + the special flag to denote a c-ordered file.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code