### PR TITLE
Specify resources, load dataset from `libertem-server` CLI

### DIFF
--- a/docs/source/changelog/features/gui-resource-cli.rst
+++ b/docs/source/changelog/features/gui-resource-cli.rst
@@ -1,0 +1,7 @@
+[Feature] Specify server resources from command line
+====================================================
+* You can now specify the local server compute resources from the
+  command line when launching :code:`libertem-server`. Additionally,
+  a dataset can be passed as command line argument which will be opened
+  using the URL fragment (see :pr:`1518`). (:issue:`1419`,
+  :pr:`1534`).

--- a/docs/source/changelog/features/gui-resource-cli.rst
+++ b/docs/source/changelog/features/gui-resource-cli.rst
@@ -4,4 +4,4 @@
   command line when launching :code:`libertem-server`. Additionally,
   a dataset can be passed as command line argument which will be opened
   using the URL fragment (see :pr:`1518`). (:issue:`1419`,
-  :pr:`1534`).
+  :pr:`1535`).

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -216,6 +216,12 @@ To modify the configuration of the server (address, port, autorization etc.), th
     :code:`-t, --token-path` was added and :code:`-h, --host` was re-enabled.
 .. versionadded:: 0.9.0
     :code:`--preload` and :code:`--insecure` were added.
+.. versionadded:: 0.13.0
+    :code:`--cpus <int>` and :code:`--gpus <int>` were added to preconfigure
+    the cluster resources
+.. versionadded:: 0.13.0
+    :code:`--open_ds <path>` was added to preconfigure the dataset opened
+    when connecting to the server
 
 To access LiberTEM remotely, you can use :ref:`use SSH forwarding <ssh forwarding>`
 or our :ref:`jupyter integration`, if you already have JupyterHub or JupyterLab

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -220,7 +220,7 @@ To modify the configuration of the server (address, port, autorization etc.), th
     :code:`--cpus <int>` and :code:`--gpus <int>` were added to preconfigure
     the cluster resources
 .. versionadded:: 0.13.0
-    :code:`--open_ds <path>` was added to preconfigure the dataset opened
+    :code:`--open-ds <path>` was added to preconfigure the dataset opened
     when connecting to the server
 
 To access LiberTEM remotely, you can use :ref:`use SSH forwarding <ssh forwarding>`

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -65,8 +65,8 @@ def main(port, local_directory, browser, cpus, gpus, open_ds, log_level,
     from libertem.common.threading import set_num_threads_env
     from libertem.common.tracing import maybe_setup_tracing
     token = get_token(token_path)
-    is_localhost = host in ['localhost', '127.0.0.1', '::1']
-    if token is None and not is_localhost and not insecure:
+    from .server import is_localhost
+    if token is None and not is_localhost(host) and not insecure:
         raise click.UsageError(
             f'listening on non-localhost {host}:{port} currently requires token authentication '
             f'or --insecure'

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -1,4 +1,6 @@
 from typing import Tuple
+import os
+import platform
 
 import click
 import logging
@@ -51,6 +53,11 @@ def get_token(token_path):
               default=False, is_flag=True)
 def main(port, local_directory, browser, cpus, gpus, open_ds, log_level,
          insecure, host="localhost", token_path=None, preload: Tuple[str, ...] = ()):
+    # Mitigation for https://stackoverflow.com/questions/71283820/
+    #   directory-parameter-on-windows-has-trailing-backslash-replaced-with-double-quote
+    if (open_ds and platform.system() == 'Windows' and open_ds[-1] == '"'
+            and not os.path.exists(open_ds) and os.path.exists(open_ds[:-1])):
+        open_ds = open_ds[:-1]
     is_custom_port = port is not None
     if port is None:
         port = 9000

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -33,7 +33,7 @@ def get_token(token_path):
               default=None, type=int)
 @click.option('-g', '--gpus', help='number of gpu worker processes to use,[default: select in GUI]',
               default=None, type=int)
-@click.option('-o', '--open_ds', help='dataset to preload via URL action',
+@click.option('-o', '--open-ds', help='dataset to preload via URL action',
               default=None, type=str)
 @click.option('-l', '--log-level',
               help=f"set logging level. Default is 'info'. {log_values}",

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -37,7 +37,11 @@ def get_token(token_path):
               type=click.Path(exists=True))
 @click.option('--preload', help=preload_help, default=(), type=str, multiple=True)
 @click.option('--insecure',
-              help="allow to bind to non-localhost without token auth",
+              help=(
+                  "Allow connections from non-localhost without token authorization. "
+                  "Applies only when combined with --host <address> "
+                  "(use `--insecure -h 0.0.0.0` to accept any connection)"
+              ),
               default=False, is_flag=True)
 def main(port, local_directory, browser, log_level, insecure, host="localhost",
         token_path=None, preload: Tuple[str, ...] = ()):

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -238,9 +238,11 @@ def run(
         port = _port
 
     main(bound_sockets, event_registry, shared_state, token)
-    if executor_spec is not None:
-        # Must happen after main() so that Dask uses our event loop
-        shared_state.create_and_set_executor(executor_spec)
+
+    async def create_and_set_executor():
+        if executor_spec is not None:
+            # Must happen after main() so that Dask uses our event loop
+            shared_state.create_and_set_executor(executor_spec)
 
     try:
         is_ipv6 = isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address)
@@ -270,4 +272,5 @@ LiberTEM listening on {url}"""
     # Strictly necessary only on Windows, but doesn't do harm in any case.
     # FIXME check later if the unknown root cause was fixed upstream
     asyncio.ensure_future(nannynanny())
+    asyncio.ensure_future(create_and_set_executor())
     loop.run_forever()

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -252,13 +252,16 @@ def run(
     msg = f"""
 
 LiberTEM listening on {url}"""
-    if not is_localhost(host):
+    parts = urllib.parse.urlsplit(url)
+    if parts.hostname in ('0.0.0.0', '::'):
         hostname = socket.gethostname()
-        parts = urllib.parse.urlsplit(url)
         mod_url = parts._replace(netloc=f'{hostname}:{parts.port}')
         msg = msg + f"""
                       {urllib.parse.urlunsplit(mod_url)}
 """
+    else:
+        # For display consistency
+        msg = msg + "\n"
     log.info(msg)
     if browser:
         webbrowser.open(url)

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -241,7 +241,10 @@ def run(
 
     async def create_and_set_executor():
         if executor_spec is not None:
-            # Must happen after main() so that Dask uses our event loop
+            # Executor creation is blocking (and slow) but we
+            # need to run this within the main loop so that Distributed
+            # attaches to that rather than trying to create its own, see:
+            # https://github.com/LiberTEM/LiberTEM/pull/1535#pullrequestreview-1699340445
             shared_state.create_and_set_executor(executor_spec)
 
     try:

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -233,6 +233,9 @@ def run(
         port = _port
 
     main(bound_sockets, event_registry, shared_state, token)
+    if executor_spec is not None:
+        # Must happen after main() so that Dask uses our event loop
+        shared_state.add_executor(executor_spec)
 
     try:
         is_ipv6 = isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address)

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -3,6 +3,7 @@ import sys
 import logging
 import asyncio
 import signal
+import socket
 import select
 import threading
 import webbrowser
@@ -205,7 +206,10 @@ def port_from_sockets(*sockets):
     return ports[0]
 
 
-def run(host, port, browser, local_directory, numeric_level, token, preload, strict_port):
+def run(
+    host, port, browser, local_directory, numeric_level,
+    token, preload, strict_port, executor_spec, open_ds,
+):
     logging.basicConfig(
         level=numeric_level,
         format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
@@ -235,7 +239,15 @@ def run(host, port, browser, local_directory, numeric_level, token, preload, str
     except ValueError:
         is_ipv6 = False
     url = f'http://[{host}]:{port}' if is_ipv6 else f'http://{host}:{port}'
-    log.info(f"listening on {url}")
+    if open_ds is not None:
+        url = f'{url}/#action=open&path={open_ds}'
+    hostname = socket.gethostname()
+    msg = f"""
+
+LiberTEM listening on {url}
+                      {url.replace(host, hostname)}
+"""
+    log.info(msg)
     if browser:
         webbrowser.open(url)
     loop = asyncio.get_event_loop()

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -235,7 +235,7 @@ def run(
     main(bound_sockets, event_registry, shared_state, token)
     if executor_spec is not None:
         # Must happen after main() so that Dask uses our event loop
-        shared_state.add_executor(executor_spec)
+        shared_state.create_and_set_executor(executor_spec)
 
     try:
         is_ipv6 = isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address)

--- a/src/libertem/web/state.py
+++ b/src/libertem/web/state.py
@@ -2,6 +2,7 @@ import os
 import copy
 import typing
 import itertools
+import logging
 
 import psutil
 
@@ -18,6 +19,8 @@ from .models import (
     AnalysisDetails, AnalysisInfo, AnalysisResultInfo, CompoundAnalysisInfo, AnalysisParameters,
     DatasetInfo, JobInfo, SerializedJobInfo,
 )
+
+log = logging.getLogger(__name__)
 
 
 class ExecutorState:
@@ -46,6 +49,13 @@ class ExecutorState:
         self.executor = executor
         self.cluster_params = params
         self.context = Context(executor=executor.ensure_sync())
+        try:
+            # Exposing the scheduler address allows use of
+            # libertem-server to spin up a LT-compatible
+            # persistent dask cluster
+            log.info(f'Scheduler at {self.context.executor.client.scheduler.address}')
+        except AttributeError:
+            pass
 
     def get_cluster_params(self):
         return self.cluster_params

--- a/src/libertem/web/state.py
+++ b/src/libertem/web/state.py
@@ -421,8 +421,8 @@ class SharedState:
         Any existing executor will first closed by the call
         to self.executor_state._set_executor
         """
-        from .connect import create_executor  # circular import
-        executor, params = create_executor(
+        from .connect import create_executor_external  # circular import
+        executor, params = create_executor_external(
             spec,
             self.get_local_directory(),
             self.get_preload(),

--- a/src/libertem/web/state.py
+++ b/src/libertem/web/state.py
@@ -1,7 +1,6 @@
 import os
 import copy
 import typing
-from typing import Dict
 import itertools
 import logging
 
@@ -413,10 +412,18 @@ class SharedState:
     def get_preload(self) -> typing.Tuple[str, ...]:
         return self.preload
 
-    def add_executor(self, executor_spec: Dict[str, int]):
+    def create_and_set_executor(self, spec: typing.Dict[str, int]):
+        """
+        Create a new executor from spec, a dict[str, int]
+        compatible with the main arguments of cluster_spec().
+        Any values not in spec are filled from a call to detect()
+
+        Any existing executor will first closed by the call
+        to self.executor_state._set_executor
+        """
         from .connect import create_executor  # circular import
         executor, params = create_executor(
-            executor_spec,
+            spec,
             self.get_local_directory(),
             self.get_preload(),
         )

--- a/src/libertem/web/state.py
+++ b/src/libertem/web/state.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import typing
+from typing import Dict
 import itertools
 import logging
 
@@ -412,7 +413,7 @@ class SharedState:
     def get_preload(self) -> typing.Tuple[str, ...]:
         return self.preload
 
-    def add_executor(self, executor_spec):
+    def add_executor(self, executor_spec: Dict[str, int]):
         from .connect import create_executor  # circular import
         executor, params = create_executor(
             executor_spec,

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -47,7 +47,7 @@ def test_preload_executor(tmpdir_factory):
     state = SharedState()
     state.set_local_directory(workdir)
     state.set_preload(())
-    state.add_executor(
+    state.create_and_set_executor(
         {
             'cpus': 2,
             'cudas': 0,

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -41,7 +41,7 @@ async def test_job_state_remove(async_executor):
     assert len(job_state.jobs) == 0
 
 
-@pytest.mark.slow
+@pytest.mark.web_api
 def test_preload_executor(tmpdir_factory):
     workdir = tmpdir_factory.mktemp('preload_workdir')
     state = SharedState()

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -1,7 +1,9 @@
 import uuid
 import pytest
 
-from libertem.web.state import JobState, ExecutorState
+from libertem.executor.base import AsyncAdapter
+from libertem.executor.dask import DaskJobExecutor
+from libertem.web.state import JobState, ExecutorState, SharedState
 
 
 pytestmark = []
@@ -37,3 +39,29 @@ async def test_job_state_remove(async_executor):
     assert job_state.get_for_dataset_id(dataset_id) == set()
     assert job_state.get_for_analysis_id(analysis_id) == set()
     assert len(job_state.jobs) == 0
+
+
+@pytest.mark.slow
+def test_preload_executor(tmpdir_factory):
+    workdir = tmpdir_factory.mktemp('preload_workdir')
+    state = SharedState()
+    state.set_local_directory(workdir)
+    state.set_preload(())
+    state.add_executor(
+        {
+            'cpus': 2,
+            'cudas': 0,
+        },
+    )
+    assert isinstance(state.executor_state.executor, AsyncAdapter)
+    sync_exec = state.executor_state.executor.ensure_sync()
+    assert isinstance(sync_exec, DaskJobExecutor)
+    resources = sync_exec.get_resource_details()
+    assert resources[0]['cpu'] == 2
+    assert resources[0]['cuda'] == 0
+    assert resources[0]['service'] == 1
+
+    def test_fn():
+        return 42
+
+    assert 42 == sync_exec.run_function(test_fn)


### PR DESCRIPTION
Closes #1419 

Adds the following CLI options:

- `-c / --cpus <int>` specify the number of CPU workers
- `-g / --gpus <int>` specify the number of GPU workers
- `-o / --open-ds <path>` specify the dataset to open via URL fragment (#1518 )

Also improves the log message for the connection address (more prominent, adds a version with hostname), and improves the help text for `--insecure` (#1534 ).

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code
