### PR TITLE
Move exceptions to libertem.common

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -167,7 +167,7 @@ to quickly create a synchronous executor for debugging.
 .. note::
     Not all executor types allow specifying number of workers, and
     not all executor types are GPU-capable. In these cases the :code:`make_with`
-    method will raise an :class:`~libertem.exceptions.ExecutorSpecException`.
+    method will raise an :class:`~libertem.common.exceptions.ExecutorSpecException`.
 
 See the :meth:`API documentation <libertem.api.Context.make_with>`
 for more information.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -84,7 +84,7 @@ Miscellaneous
   (:pr:`1453`).
 * Array backend categories are now available in
   :class:`~libertem.udf.base.UDF` (:pr:`1470`).
-* The UDF runner internals will now raise :class:`~libertem.exceptions.UDFRunCancelled`
+* The UDF runner internals will now raise :class:`~libertem.common.exceptions.UDFRunCancelled`
   if a UDF run is cancelled, allowing the user to handle this case (:pr:`1448`).
 * Introduce option for :code:`sparse.GCXS` in
   :class:`~libertem.common.container.MaskContainer` (:pr:`1447`).

--- a/docs/source/changelog/misc/exceptions.rst
+++ b/docs/source/changelog/misc/exceptions.rst
@@ -1,0 +1,5 @@
+[Misc] Moved exception classes to :mod:`libertem.common`
+========================================================
+* Moved exception classes to :mod:`libertem.common` for MIT
+  license compatibility in dataset code. They are re-exported to
+  the old import location for backwards compatibility (:pr:`1543`).

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -9,6 +9,8 @@ Context
 .. automodule:: libertem.api
    :members:
 
+.. autoclass:: libertem.common.exceptions.ExecutorSpecException
+
 Analysis API
 ~~~~~~~~~~~~
 

--- a/docs/source/reference/udf.rst
+++ b/docs/source/reference/udf.rst
@@ -52,6 +52,11 @@ Pre- and postprocessing
 .. autoclass:: libertem.udf.base.UDFPostprocessMixin
     :members:
 
+Exceptions
+##########
+
+.. autoclass:: libertem.common.exceptions.UDFException
+
 .. _`run udf ref`:
 
 Running UDFs
@@ -67,6 +72,10 @@ Result type for UDF result iterators:
 
 .. autoclass:: libertem.udf.base.UDFResults
     :members:
+
+Exception for cancelled UDF run:
+
+.. autoclass:: libertem.common.exceptions.UDFRunCancelled
 
 .. _`buffer udf ref`:
 

--- a/docs/source/udf/basic.rst
+++ b/docs/source/udf/basic.rst
@@ -512,12 +512,12 @@ preview scan is stopped, or scan parameters are changed while the scan is
 running.
 
 In this case, the exception
-:class:`~libertem.exceptions.UDFRunCancelled` is raised, which you can
+:class:`~libertem.common.exceptions.UDFRunCancelled` is raised, which you can
 handle in an appropriate way for your application:
 
 .. testcode:: run
 
-   from libertem.exceptions import UDFRunCancelled
+   from libertem.common.exceptions import UDFRunCancelled
 
    try:
        res = ctx.run_udf(udf=udf, dataset=dataset)

--- a/scripts/licensecheck.py
+++ b/scripts/licensecheck.py
@@ -14,6 +14,8 @@ if __name__ == '__main__':
             mit_key, [
                 k for k in deps[mit_key].get('imports', [])
                 if not k.startswith('libertem.common')
-                and not k.startswith('libertem.io') and k.startswith('libertem')
+                and not k.startswith('libertem.io')
+                and k != 'libertem'  # only contains version info
+                and k.startswith('libertem')
             ]
         )

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -39,7 +39,7 @@ from libertem.udf.base import UDFResultDict, UDF, UDFResults, UDFRunner
 from libertem.udf.auto import AutoUDF
 from libertem.common.async_utils import async_generator, run_agen_get_last, run_gen_get_last
 from libertem.common.sparse import sparse_to_coo, to_dense
-from libertem.exceptions import ExecutorSpecException
+from libertem.common.exceptions import ExecutorSpecException
 
 if TYPE_CHECKING:
     import numpy.typing as nt
@@ -312,7 +312,7 @@ class Context:
 
         Raises
         ------
-        libertem.exceptions.ExecutorSpecException :
+        libertem.common.exceptions.ExecutorSpecException :
             for invalid executor choice or unsupported worker specifications
 
         Returns

--- a/src/libertem/common/exceptions.py
+++ b/src/libertem/common/exceptions.py
@@ -1,0 +1,21 @@
+class UDFException(Exception):
+    """
+    Raised when the UDF interface is somehow misused
+    """
+    pass
+
+
+class ExecutorSpecException(Exception):
+    """
+    Raised when there is an error specifying an
+    Executor or its resources / workers
+    """
+    pass
+
+
+class UDFRunCancelled(Exception):
+    """
+    Raised when the UDF run was cancelled, either when the job was cancelled
+    using :meth:`AsyncJobExecutor.cancel`, or when the underlying data source
+    was interrupted.
+    """

--- a/src/libertem/exceptions.py
+++ b/src/libertem/exceptions.py
@@ -1,21 +1,8 @@
-class UDFException(Exception):
-    """
-    Raised when the UDF interface is somehow misused
-    """
-    pass
+# Was moved to common for MIT license compatibility
+# in dataset code
 
+from libertem.common.exceptions import (
+    UDFException, ExecutorSpecException, UDFRunCancelled
+)
 
-class ExecutorSpecException(Exception):
-    """
-    Raised when there is an error specifying an
-    Executor or its resources / workers
-    """
-    pass
-
-
-class UDFRunCancelled(Exception):
-    """
-    Raised when the UDF run was cancelled, either when the job was cancelled
-    using :meth:`AsyncJobExecutor.cancel`, or when the underlying data source
-    was interrupted.
-    """
+__all__ = ["UDFException", "ExecutorSpecException", "UDFRunCancelled"]

--- a/src/libertem/io/dataset/base/tiling_scheme.py
+++ b/src/libertem/io/dataset/base/tiling_scheme.py
@@ -6,7 +6,7 @@ from typing_extensions import Literal
 
 import numpy as np
 
-from libertem.exceptions import UDFException
+from libertem.common.exceptions import UDFException
 from libertem.io.corrections import CorrectionSet
 from libertem.common import Shape, Slice
 from libertem.common.math import prod

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -26,7 +26,7 @@ from libertem.io.dataset.base.tiling import DataTile
 from libertem.io.dataset.base import DataSetMeta
 from libertem.utils.devices import has_cupy
 from libertem.warnings import UseDiscouragedWarning
-from libertem.exceptions import UDFException
+from libertem.common.exceptions import UDFException
 from libertem.common.buffers import (
     BufferWrapper, AuxBufferWrapper, PlaceholderBufferWrapper,
     BufferKind, BufferUse, BufferLocation,
@@ -46,7 +46,7 @@ from libertem.common.executor import (
     Environment, JobExecutor, TaskCommHandler, NoopCommHandler, TaskProtocol,
     JobCancelledError, ResourceDef,
 )
-from libertem.exceptions import UDFRunCancelled
+from libertem.common.exceptions import UDFRunCancelled
 
 if TYPE_CHECKING:
     from numpy import typing as nt

--- a/tests/executor/test_functional.py
+++ b/tests/executor/test_functional.py
@@ -24,7 +24,7 @@ from libertem.common.executor import (
 from libertem.api import Context
 from libertem.udf.stddev import StdDevUDF
 from libertem.udf.masks import ApplyMasksUDF
-from libertem.exceptions import ExecutorSpecException
+from libertem.common.exceptions import ExecutorSpecException
 from sparseconverter import (
     BACKENDS, CUPY, CUPY_BACKENDS, CUPY_SCIPY_CSR, NUMPY, SCIPY_COO, SPARSE_COO
 )

--- a/tests/executor/test_inline.py
+++ b/tests/executor/test_inline.py
@@ -7,7 +7,7 @@ from libertem.udf.sum import SumUDF
 from libertem.common.executor import (
     TaskCommHandler, TaskProtocol, WorkerQueue, JobCancelledError,
 )
-from libertem.exceptions import UDFRunCancelled
+from libertem.common.exceptions import UDFRunCancelled
 from libertem.io.dataset.memory import MemoryDataSet
 
 

--- a/tests/executor/test_pipelined.py
+++ b/tests/executor/test_pipelined.py
@@ -19,7 +19,7 @@ from libertem.executor.pipelined import (
 )
 import libertem.executor.pipelined
 from libertem.udf import UDF
-from libertem.exceptions import UDFRunCancelled
+from libertem.common.exceptions import UDFRunCancelled
 from libertem.io.dataset.memory import MemoryDataSet
 
 

--- a/tests/io/test_tiling_negotiation.py
+++ b/tests/io/test_tiling_negotiation.py
@@ -2,7 +2,7 @@ import sparse
 import pytest
 import numpy as np
 
-from libertem.exceptions import UDFException
+from libertem.common.exceptions import UDFException
 from libertem.io.corrections import CorrectionSet
 from libertem.io.dataset.base import Negotiator
 from libertem.io.dataset.memory import MemoryDataSet

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,7 +19,7 @@ from libertem.udf.sum import SumUDF
 from libertem.udf.sumsigudf import SumSigUDF
 from libertem.udf.base import NoOpUDF, MergeAttrMapping
 from libertem.api import Context
-from libertem.exceptions import ExecutorSpecException
+from libertem.common.exceptions import ExecutorSpecException
 
 
 def test_ctx_load(lt_ctx, default_raw):

--- a/tests/udf/test_buffer_declarations.py
+++ b/tests/udf/test_buffer_declarations.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from libertem.warnings import UseDiscouragedWarning
-from libertem.exceptions import UDFException
+from libertem.common.exceptions import UDFException
 from libertem.udf.base import UDF
 from libertem.common.buffers import BufferWrapper
 

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -10,7 +10,7 @@ from libertem.io.dataset.memory import MemoryDataSet
 from libertem.io.dataset.base import TilingScheme, DataTile
 from libertem.io.dataset.raw import RawFileDataSet, RawPartition
 from libertem.utils.devices import detect
-from libertem.exceptions import UDFException
+from libertem.common.exceptions import UDFException
 from libertem.common.backend import set_use_cpu, set_use_cuda
 from libertem.common.buffers import reshaped_view
 from libertem.udf.sumsigudf import SumSigUDF


### PR DESCRIPTION
Import to `libertem.io.dataset.base.tiling_scheme.py` was added since last release.

Refs #1542 

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
