### PR TITLE
Optimise `MIBDataSet` to read headers in parallel + respect ulimit NOFILE

### DIFF
--- a/src/libertem/common/backend.py
+++ b/src/libertem/common/backend.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from typing import Optional
 
 
@@ -106,3 +107,13 @@ def get_device_class():
         return "cuda"
     else:
         return "cpu"
+
+
+def set_file_limit():
+    if platform.system() == "Windows":
+        # Windows has no problem opening huge numbers of files
+        return
+
+    import resource
+    _, hard_lim = resource.getrlimit(resource.RLIMIT_NOFILE)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (hard_lim, hard_lim))

--- a/src/libertem/executor/pipelined.py
+++ b/src/libertem/executor/pipelined.py
@@ -17,7 +17,7 @@ import time
 from tblib import pickling_support
 import cloudpickle
 from opentelemetry import trace
-from libertem.common.backend import set_use_cpu, set_use_cuda
+from libertem.common.backend import set_use_cpu, set_use_cuda, set_file_limit
 
 from libertem.common.executor import (
     Environment, TaskProtocol, WorkerContext, WorkerQueue,
@@ -588,6 +588,8 @@ def pipelined_worker(
     try:
         if early_setup:
             early_setup()
+
+        set_file_limit()
 
         # FIXME: explicitly propagate exporter settings to the workers?
         # right now taken care of by environment variables...

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1173,11 +1173,11 @@ class MIBDataSet(DataSet):
         filesizes = {}
         for entry in os.scandir(os.path.dirname(self._path)):
             if entry.is_file() and entry.path.endswith('.mib'):
-                filesizes[entry.path] = entry.stat().st_size
+                filesizes[str(entry.path)] = entry.stat().st_size
 
         res = {}
         for path, header in zip(fnames, header_bytes):
-            res[path] = MIBHeaderReader._parse_header_bytes(header, filesizes[path])
+            res[path] = MIBHeaderReader._parse_header_bytes(header, filesizes[str(path)])
         return res
 
     def _filenames(self):

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1196,7 +1196,9 @@ class MIBDataSet(DataSet):
         if num_files > 16384:
             warnings.warn(
                 f"Saving data in many small files (here: {num_files}) is not efficient, "
-                "please increase the \"Images Per File\" parameter when acquiring data",
+                "please increase the \"Images Per File\" parameter when acquiring data. If ",
+                "this leads to \"Too many open files\" errors, on POSIX systems you can increase ",
+                "the maximum open files limit using the \"ulimit\" shell command.",
                 RuntimeWarning
             )
         self._filename_cache = fns

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1,7 +1,6 @@
 import re
 import os
 import platform
-import resource
 from glob import glob, escape
 import logging
 from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Tuple, Union
@@ -1274,6 +1273,7 @@ class MIBDataSet(DataSet):
         # Try to limit the partition to some fraction of the max_open files limit
         limit_n_files = float('inf')
         if platform.system() != "Windows":
+            import resource
             # Windows has no problem opening huge numbers of files
             limit_n_files, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
             # Being too close to the NOFILE limit is risky!

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1165,8 +1165,12 @@ class MIBDataSet(DataSet):
     def _preread_headers(self):
         fnames = self._filenames()
 
-        with ThreadPoolExecutor() as p:
-            header_and_size = p.map(MIBHeaderReader._read_header_bytes, fnames)
+        if len(fnames) > 512:
+            # Default ThreadPoolExecutor allocates 5 threads per CPU on the machine
+            with ThreadPoolExecutor() as p:
+                header_and_size = p.map(MIBHeaderReader._read_header_bytes, fnames)
+        else:
+            header_and_size = tuple(map(MIBHeaderReader._read_header_bytes, fnames))
 
         res = {}
         for path, (header, filesize) in zip(fnames, header_and_size):

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -133,10 +133,11 @@ def get_image_count_and_sig_shape(
     disable_glob: bool = False,
 ) -> Tuple[int, Tuple[int, int]]:
     fns = get_filenames(path, disable_glob=disable_glob)
+    headers = MIBDataSet._preread_headers(fns)
     count = 0
     files = []
-    for path in fns:
-        f = MIBHeaderReader(path)
+    for path, fields in headers.items():
+        f = MIBHeaderReader(path, fields=fields)
         count += f.fields['num_images']
         files.append(f)
     try:

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1037,7 +1037,7 @@ class MIBDataSet(DataSet):
                  nav_shape=None, sig_shape=None, sync_offset=0, io_backend=None):
         super().__init__(io_backend=io_backend)
         self._sig_dims = 2
-        self._path = path
+        self._path = str(path)
         self._nav_shape = tuple(nav_shape) if nav_shape else nav_shape
         self._sig_shape = tuple(sig_shape) if sig_shape else sig_shape
         self._sync_offset = sync_offset

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1192,10 +1192,11 @@ class MIBDataSet(DataSet):
         if self._filename_cache is not None:
             return self._filename_cache
         fns = get_filenames(self._path, disable_glob=self._disable_glob)
-        if len(fns) > 16384:
+        num_files = len(fns)
+        if num_files > 16384:
             warnings.warn(
-                "Saving data in many small files (here: %d) is not efficient, please increase "
-                "the \"Images Per File\" parameter when acquiring data",
+                f"Saving data in many small files (here: {num_files}) is not efficient, "
+                "please increase the \"Images Per File\" parameter when acquiring data",
                 RuntimeWarning
             )
         self._filename_cache = fns

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1270,29 +1270,6 @@ class MIBDataSet(DataSet):
         assert self.meta is not None and base_shape[-1] == self.meta.shape[-1]
         return base_shape
 
-    def get_num_partitions(self) -> int:
-        # Try to limit the partition to some fraction of the max_open files limit
-        limit_n_files = float('inf')
-        if platform.system() != "Windows":
-            import resource
-            # Windows has no problem opening huge numbers of files
-            limit_n_files, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-            # Being too close to the NOFILE limit is risky!
-            # Even 50% seems to be too much, sometimes
-            limit_n_files = max(1, int(limit_n_files * 0.33))
-        # Get the num partitions based on sensible chunk byte-sizes
-        num_part_standard = super().get_num_partitions()
-        # Assume the files are evenly sized. Given we already have
-        # the filesizes stored in the MIBHeader we could do a
-        # better approximation here but this will generally be correct.
-        fileset = self._get_fileset()
-        num_files = len(fileset)
-        files_per_part = max(1, num_files // num_part_standard)
-        if files_per_part > limit_n_files:
-            # The +1 is to account for an eventual partial file at the end
-            return (num_files // limit_n_files) + 1
-        return num_part_standard
-
     def get_partitions(self):
         first_file = self._files_sorted[0]
         fileset = self._get_fileset()

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -2,7 +2,7 @@ import re
 import os
 from glob import glob, escape
 import logging
-from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Tuple, Union, Any, Dict
+from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Tuple, Union
 from typing_extensions import Literal, TypedDict
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -785,9 +785,10 @@ class MIBHeaderReader:
             filesize = os.fstat(f.fileno()).st_size
 
         self._fields = self._parse_header_bytes(header, filesize)
+        return self._fields
 
     @staticmethod
-    def _parse_header_bytes(header: str, filesize: int) -> Dict[str, Any]:
+    def _parse_header_bytes(header: str, filesize: int) -> HeaderDict:
         parts = header.split(",")
         header_size_bytes = int(parts[2])
         parts = [p

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1196,8 +1196,8 @@ class MIBDataSet(DataSet):
         if num_files > 16384:
             warnings.warn(
                 f"Saving data in many small files (here: {num_files}) is not efficient, "
-                "please increase the \"Images Per File\" parameter when acquiring data. If ",
-                "this leads to \"Too many open files\" errors, on POSIX systems you can increase ",
+                "please increase the \"Images Per File\" parameter when acquiring data. If "
+                "this leads to \"Too many open files\" errors, on POSIX systems you can increase "
                 "the maximum open files limit using the \"ulimit\" shell command.",
                 RuntimeWarning
             )

--- a/src/libertem/preload.py
+++ b/src/libertem/preload.py
@@ -24,3 +24,6 @@ except ImportError:
     pass
 
 import numba.cuda  # see also: #1432
+
+from libertem.common.backend import set_file_limit
+set_file_limit()

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -584,7 +584,7 @@ def test_compare_backends_sparse(lt_ctx, default_mib, buffered_mib, as_sparse):
 
 @needsdata
 @pytest.mark.slow
-def test_run_many_files(lt_ctx, tmpdir_factory):
+def test_run_many_files(lt_ctx):
     # import tarfile
     # archive = pathlib.Path(MIB_TESTDATA_PATH).parent / 'many_mib.tar.gz'
     # outdir = pathlib.Path(tmpdir_factory.mktemp('many_mib_files'))

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import sys
 import json
 from unittest import mock
@@ -579,3 +580,19 @@ def test_compare_backends_sparse(lt_ctx, default_mib, buffered_mib, as_sparse):
     buffered_f0 = lt_ctx.run_udf(dataset=buffered_mib, udf=PickUDF(), roi=roi)['intensity']
 
     assert np.allclose(mm_f0, buffered_f0)
+
+
+@needsdata
+@pytest.mark.slow
+def test_run_many_files(lt_ctx, tmpdir_factory):
+    # import tarfile
+    # archive = pathlib.Path(MIB_TESTDATA_PATH).parent / 'many_mib.tar.gz'
+    # outdir = pathlib.Path(tmpdir_factory.mktemp('many_mib_files'))
+
+    # with tarfile.open(archive, mode='r:gz') as tp:
+    #     tp.extractall(path=outdir)
+
+    out_dir = pathlib.Path(MIB_TESTDATA_PATH).parent / 'many_mib'
+    hdr_path = out_dir / 'w_140 h_139-2map.hdr'
+    nav_shape = (139, 141)
+    lt_ctx.load('mib', path=hdr_path, nav_shape=nav_shape)

--- a/tests/io/test_many_files.py
+++ b/tests/io/test_many_files.py
@@ -1,0 +1,73 @@
+import os
+import pytest
+import numpy as np
+
+from libertem.io.dataset.raw import RawFileDataSet, RawFileSet, RawFile
+
+from utils import get_testdata_path
+
+MANYRAW_TESTDATA_PATH = os.path.join(get_testdata_path(), 'many_raw')
+
+
+def _generate_many_files():
+    # Generates 16k 8x8 uint8 frames
+    # Combined with the below 2-partition dataset and
+    # the two-cpu local_cluster_ctx this is likely to trigger file
+    # limits on a system where this is not set to the hard limit globally
+    frame = np.arange(64).astype(np.uint8)
+    nav_shape = (128, 128)
+    os.mkdir(MANYRAW_TESTDATA_PATH)
+    for idx in range(np.prod(nav_shape)):
+        frame.tofile(os.path.join(MANYRAW_TESTDATA_PATH, f'f{idx:>05d}.raw'))
+
+
+HAVE_TESTDATA = os.path.exists(MANYRAW_TESTDATA_PATH)
+pytestmark = pytest.mark.skipif(not HAVE_TESTDATA, reason="need testdata")  # NOQA
+
+
+class ManyRawFileDataSetMock(RawFileDataSet):
+    """
+    A basic multi-file raw dataset that reads every .raw file
+    in a folder, assuming one image per frame and all files
+    are of an identical size and unordered
+    """
+    def _get_raw_files(self):
+        with os.scandir(self._path) as it:
+            for entry in it:
+                if entry.is_file() and entry.name.endswith('.raw'):
+                    yield entry
+
+    def _get_filesize(self):
+        return sum(p.stat().st_size for p in self._get_raw_files())
+
+    def _get_fileset(self):
+        return RawFileSet([
+            RawFile(
+                path=p.path,
+                start_idx=idx,
+                end_idx=idx + 1,
+                sig_shape=self.shape.sig,
+                native_dtype=self._meta.raw_dtype,
+            )
+            for idx, p in enumerate(self._get_raw_files())])
+
+    def get_num_partitions(self):
+        return 2
+
+
+def test_many_files_read(local_cluster_ctx):
+    """
+    Tests if we can load 8k files per process in a Dask cluster
+    on this system. Depending on the system configuration
+    this test might be a no-op.
+    """
+    ds = ManyRawFileDataSetMock(
+        path=MANYRAW_TESTDATA_PATH,
+        nav_shape=(128, 128),
+        sig_shape=(8, 8),
+        dtype=np.uint8,
+    )
+    ds.initialize(local_cluster_ctx.executor)
+
+    sum_a = local_cluster_ctx.create_sum_analysis(ds)
+    local_cluster_ctx.run(sum_a)

--- a/tests/io/test_many_files.py
+++ b/tests/io/test_many_files.py
@@ -4,25 +4,19 @@ import numpy as np
 
 from libertem.io.dataset.raw import RawFileDataSet, RawFileSet, RawFile
 
-from utils import get_testdata_path
 
-MANYRAW_TESTDATA_PATH = os.path.join(get_testdata_path(), 'many_raw')
-
-
-def _generate_many_files():
+@pytest.fixture(scope='session')
+def generate_many_files(tmpdir_factory):
     # Generates 16k 8x8 uint8 frames
     # Combined with the below 2-partition dataset and
     # the two-cpu local_cluster_ctx this is likely to trigger file
     # limits on a system where this is not set to the hard limit globally
+    datadir = tmpdir_factory.mktemp('many_raw_files')
     frame = np.arange(64).astype(np.uint8)
     nav_shape = (128, 128)
-    os.mkdir(MANYRAW_TESTDATA_PATH)
     for idx in range(np.prod(nav_shape)):
-        frame.tofile(os.path.join(MANYRAW_TESTDATA_PATH, f'f{idx:>05d}.raw'))
-
-
-HAVE_TESTDATA = os.path.exists(MANYRAW_TESTDATA_PATH)
-pytestmark = pytest.mark.skipif(not HAVE_TESTDATA, reason="need testdata")  # NOQA
+        frame.tofile(os.path.join(datadir, f'f{idx:>05d}.raw'))
+    yield datadir
 
 
 class ManyRawFileDataSetMock(RawFileDataSet):
@@ -55,14 +49,14 @@ class ManyRawFileDataSetMock(RawFileDataSet):
         return 2
 
 
-def test_many_files_read(local_cluster_ctx):
+def test_many_files_read(local_cluster_ctx, generate_many_files):
     """
     Tests if we can load 8k files per process in a Dask cluster
     on this system. Depending on the system configuration
     this test might be a no-op.
     """
     ds = ManyRawFileDataSetMock(
-        path=MANYRAW_TESTDATA_PATH,
+        path=generate_many_files,
         nav_shape=(128, 128),
         sig_shape=(8, 8),
         dtype=np.uint8,

--- a/tests/io/test_many_files.py
+++ b/tests/io/test_many_files.py
@@ -22,7 +22,7 @@ def generate_many_files(tmpdir_factory):
     # limits on a system where this is not set to the hard limit globally
     datadir = tmpdir_factory.mktemp('many_raw_files')
     frame = np.arange(64).astype(np.uint8)
-    nav_shape = (128, 128)
+    nav_shape = (128, 100)
     for idx in range(np.prod(nav_shape)):
         frame.tofile(os.path.join(datadir, f'f{idx:>05d}.raw'))
     yield datadir
@@ -66,7 +66,7 @@ def test_many_files_read(local_cluster_ctx, generate_many_files):
     """
     ds = ManyRawFileDataSetMock(
         path=generate_many_files,
-        nav_shape=(128, 128),
+        nav_shape=(128, 100),
         sig_shape=(8, 8),
         dtype=np.uint8,
     )

--- a/tests/io/test_many_files.py
+++ b/tests/io/test_many_files.py
@@ -5,6 +5,15 @@ import numpy as np
 from libertem.io.dataset.raw import RawFileDataSet, RawFileSet, RawFile
 
 
+try:
+    import resource
+    _, hard_lim = resource.getrlimit(resource.RLIMIT_NOFILE)
+    pytestmark = pytest.mark.skipif(hard_lim < 2 ** 14, reason="hard file limit is too low")  # NOQA
+except ModuleNotFoundError:
+    # Not available on Windows
+    pass
+
+
 @pytest.fixture(scope='session')
 def generate_many_files(tmpdir_factory):
     # Generates 16k 8x8 uint8 frames


### PR DESCRIPTION
First stab at optimizing the header-reading code of `MIBDataSet` to use a `ThreadPoolExecutor` when reading a 'large' number of files, particularly useful when opening a dataset of many small files over the network.

The number of workers for this executor is quite sensitive, and I need to do more testing. For now it's limited to `2` on linux and `0.5 * num_cpu` on Windows based on what I've seen so far. I'll try to do some benchmarking tomorrow (made a bit more tricky because of filesystem caching / remote storage server caching).

Also adds a specialised `get_num_partitions` which tries to guess a `num_partitions` value which won't break the `NOFILE` limit for a process (assuming we are running in a process-based executor) on linux (only). There's a lot to improve in this part, but it already has no impact whatsoever on a 'well-acquired' dataset, and lets you actually process a `single-file-per-frame` dataset on linux, which is already a win.


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code