### PR TITLE
Reduce number of warnings from tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,13 +4,13 @@ import os
 import importlib.util
 import platform
 import threading
-import pkg_resources
 from functools import partial
 import warnings
 import contextlib
 import socket
 import logging
 
+from importlib_metadata import distributions
 import numpy as np
 import pytest
 import h5py
@@ -1121,7 +1121,10 @@ def b():
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_benchmark_generate_json(config, benchmarks, include_data, machine_info, commit_info):
-    machine_info["freeze"] = [(d.key, d.version) for d in pkg_resources.working_set]
+    machine_info["freeze"] = [
+        (d.metadata['Name'], d.version)
+        for d in distributions()
+    ]
     yield
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ import contextlib
 import socket
 import logging
 
-from importlib_metadata import distributions
+from importlib.metadata import distributions
 import numpy as np
 import pytest
 import h5py

--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ setup(
         'empyre>=0.3.0',
         'defusedxml',
         'typing-extensions',  # backwards-compatibility for newer typing constructs
+        'importlib_metadata',  # backwards-compatibility for importlib.metadata
         'opentelemetry-api',
         'tblib',
         'tomli',

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,6 @@ setup(
         'empyre>=0.3.0',
         'defusedxml',
         'typing-extensions',  # backwards-compatibility for newer typing constructs
-        'importlib_metadata',  # backwards-compatibility for importlib.metadata
         'opentelemetry-api',
         'tblib',
         'tomli',

--- a/src/libertem/executor/utils/dask_inplace.py
+++ b/src/libertem/executor/utils/dask_inplace.py
@@ -1,7 +1,11 @@
 from collections import namedtuple
 import itertools
+from typing import Union
+from numbers import Number
 
 import dask
+import numpy as np
+import numpy.typing as nt
 
 
 fake_np_flags = namedtuple('Flags', ['c_contiguous'])
@@ -78,7 +82,11 @@ class DaskInplaceWrapper:
             combined_slice = combine_slices_multid(self._slice, key, self._array.shape)
             return self._array[combined_slice]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value: Union[nt.ArrayLike, Number]):
+        if not np.isscalar(value) and value.size == 1:
+            # Avoids deprecated Numpy behaviour of implicitly
+            # extracting a scalar from an array during assignment
+            value = value.item()
         try:
             if self._slice is None:
                 self._array[key] = value

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -141,9 +141,9 @@ class BloDataSet(DataSet):
 
     def initialize(self, executor):
         self._header = h = executor.run_function(self._read_header)
-        NY = int(h['NY'])
-        NX = int(h['NX'])
-        DP_SZ = int(h['DP_SZ'])
+        NY = int(h['NY'][0])
+        NX = int(h['NX'][0])
+        DP_SZ = int(h['DP_SZ'][0])
         self._image_count = NY * NX
         if self._nav_shape is None:
             self._nav_shape = (NY, NX)
@@ -247,7 +247,7 @@ class BloDataSet(DataSet):
                 native_dtype=self._endianess + "u1",
                 sig_shape=self.shape.sig,
                 frame_header=6,
-                file_header=int(self.header['Data_offset_2']),
+                file_header=int(self.header['Data_offset_2'][0]),
             )
         ], frame_header_bytes=6)
 

--- a/src/libertem/io/dataset/tvips.py
+++ b/src/libertem/io/dataset/tvips.py
@@ -126,32 +126,32 @@ class SeriesHeader(NamedTuple):
 def read_series_header(path: str) -> SeriesHeader:
     with open(path, 'rb') as f:
         arr = np.fromfile(f, dtype=series_header_dtype, count=1)
-    version = int(arr['IVersion'])
+    version = int(arr['IVersion'][0])
     if version not in [1, 2]:
         raise DataSetException(f"Unknown TVIPS header version: {version}")
-    size = int(arr['ISize'])
+    size = int(arr['ISize'][0])
     if size != SERIES_HEADER_SIZE:
         raise DataSetException(
             f"Invalid header size {size}, should be 256. Maybe not a TVIPS file?"
         )
-    bpp = int(arr['IBPP'])
+    bpp = int(arr['IBPP'][0])
     if bpp not in [8, 16]:
         raise DataSetException(
             f"unknown bpp value: {bpp} (should be either 8 or 16)"
         )
-    img_header_bytes = int(arr['IImgHeaderBytes'])
+    img_header_bytes = int(arr['IImgHeaderBytes'][0])
     if version == 1:
         img_header_bytes = 12
     return SeriesHeader(
-        version=int(arr['IVersion']),
-        xdim=int(arr['IXDim']),
-        ydim=int(arr['IYDim']),
-        xbin=int(arr['IXBin']),
-        ybin=int(arr['IYBin']),
+        version=int(arr['IVersion'][0]),
+        xdim=int(arr['IXDim'][0]),
+        ydim=int(arr['IYDim'][0]),
+        xbin=int(arr['IXBin'][0]),
+        ybin=int(arr['IYBin'][0]),
         bpp=bpp,
-        pixel_size_nm=int(arr['IPixelSize']),
-        high_tension_kv=int(arr['IHT']),
-        mag_total=int(arr['IMagTotal']),
+        pixel_size_nm=int(arr['IPixelSize'][0]),
+        high_tension_kv=int(arr['IHT'][0]),
+        mag_total=int(arr['IMagTotal'][0]),
         frame_header_bytes=img_header_bytes,
     )
 
@@ -206,8 +206,8 @@ def _image_header_for_idx(f: IO[bytes], series_header: SeriesHeader, idx: int) -
 def _scan_for_idx(f: IO[bytes], series_header: SeriesHeader, idx: int) -> tuple[int, int]:
     arr = _image_header_for_idx(f, series_header, idx)
     # this assumes integer scan coordinates:
-    scan_y = int(arr['Scan_y'])
-    scan_x = int(arr['Scan_x'])
+    scan_y = int(arr['Scan_y'][0])
+    scan_x = int(arr['Scan_x'][0])
     scan = (scan_y, scan_x)
     return scan
 

--- a/src/libertem/viz/bqp.py
+++ b/src/libertem/viz/bqp.py
@@ -73,8 +73,6 @@ class BQLive2DPlot(Live2DPlot):
         # Make sure y points down
         # See https://libertem.github.io/LiberTEM/concepts.html#coordinate-system
         scale_y = LinearScale(min=1, max=0)
-        scales = {'x': scale_x,
-                  'y': scale_y}
         axis_x = Axis(scale=scale_x, label='x')
         axis_y = Axis(scale=scale_y, label='y', orientation='vertical')
 
@@ -82,7 +80,6 @@ class BQLive2DPlot(Live2DPlot):
         aspect = s[1] / s[0]
 
         figure = Figure(
-            scales=scales,
             axes=[axis_x, axis_y],
             scale_x=scale_x,
             scale_y=scale_y,

--- a/tests/executor/test_dask_inplace_wrapper.py
+++ b/tests/executor/test_dask_inplace_wrapper.py
@@ -310,6 +310,9 @@ def test_random_set_with_array(repeat_number, shape):
         # tests failing for things outside of our control
         return
 
+    if set_values.size == 1:
+        set_values = set_values.item()
+
     # Strange-ish case of Dask supporting an assignment but Numpy raises!
     if np.isscalar(slice_into):
         # Would raise TypeError if using subslice even if None

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -57,6 +57,8 @@ def test_run_udf_with_io_backend(lt_ctx, default_raw):
     assert np.array(res['intensity']).shape == (128, 128)
 
 
+# ignore 'no plottable channels' from NoOpUDF:
+@pytest.mark.filterwarnings('ignore:no plottable channels:UserWarning')
 @pytest.mark.parametrize('progress', (True, False))
 @pytest.mark.parametrize('plots', (None, True))
 def test_multi_udf(lt_ctx, default_raw, progress, plots):
@@ -74,6 +76,7 @@ def test_multi_udf(lt_ctx, default_raw, progress, plots):
             assert np.all(res[key].data == combined_res[index][key].data)
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')  # ignore 'no plottable channels' from NoOpUDF
 @pytest.mark.parametrize('progress', (True, False))
 @pytest.mark.parametrize('plots', (None, True))
 @pytest.mark.asyncio
@@ -99,6 +102,7 @@ async def test_multi_udf_async(lt_ctx, default_raw, progress, plots):
             assert np.all(single_res[index][key].data == combined_res[index][key].data)
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')  # ignore 'no plottable channels' from NoOpUDF
 @pytest.mark.parametrize('progress', (True, False))
 @pytest.mark.parametrize('plots', (None, True))
 def test_udf_iter(lt_ctx, default_raw, progress, plots):
@@ -118,6 +122,7 @@ def test_udf_iter(lt_ctx, default_raw, progress, plots):
             assert np.all(ref_item == res_item)
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')  # ignore 'no plottable channels' from NoOpUDF
 @pytest.mark.parametrize('progress', (True, False))
 @pytest.mark.parametrize('plots', (None, True))
 @pytest.mark.asyncio
@@ -140,6 +145,7 @@ async def test_udf_iter_async(lt_ctx, default_raw, progress, plots):
             assert np.all(ref_item == res_item)
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')  # ignore 'no plottable channels' from NoOpUDF
 @pytest.mark.parametrize(
     'plots', (
         True,

--- a/tests/viz/test_gms.py
+++ b/tests/viz/test_gms.py
@@ -35,4 +35,5 @@ def test_empty(monkeypatch, lt_ctx, default_raw):
 
     plot = GMSLive2DPlot(dataset=default_raw, udf=udf, channel=extract)
 
-    lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=[plot])
+    with pytest.warns(UserWarning, match='^Plot is not displayed, not plotting'):
+        lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=[plot])

--- a/tests/viz/test_mpl.py
+++ b/tests/viz/test_mpl.py
@@ -47,4 +47,5 @@ def test_empty(monkeypatch, lt_ctx, default_raw):
 
     plot = MPLLive2DPlot(dataset=default_raw, udf=udf, channel=extract)
 
-    lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=[plot])
+    with pytest.warns(UserWarning, match='^Plot is not displayed, not plotting'):
+        lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=[plot])


### PR DESCRIPTION
Part of #1414 

- Fixes usage of `pkg_resources` → `importlib_metadata`
- Fixes some deprecation warnings added in numpy 1.25 
- Fixes wrong usage of `bqplot`
- Ignore expected warnings thrown by our own code (plotting related mostly)

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
