### PR TITLE
Run `web_api` tests with `PYTHONASYNCIODEBUG=1`

### DIFF
--- a/src/libertem/web/state.py
+++ b/src/libertem/web/state.py
@@ -51,6 +51,7 @@ class ExecutorState:
             snooze_timeout and (snooze_timeout * 0.1) or 30.0,
         )
         self._snooze_task = asyncio.ensure_future(self._snooze_check_task())
+        self._loop = asyncio.get_running_loop()
         self._keep_alive = 0
         self.local_directory = "dask-worker-space"
         self.preload: typing.Tuple[str, ...] = ()
@@ -151,7 +152,7 @@ class ExecutorState:
         return self.context
 
     def shutdown(self):
-        self._snooze_task.cancel()
+        self._loop.call_soon_threadsafe(self._snooze_task.cancel)
         if self.context is not None:
             self.context.close()
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,9 @@ passenv=
 commands=
     pip freeze
     pytest --durations=5 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg -m "web_api and not dist" --junitxml=junit.xml {posargs:tests/}
+setenv=
+    PYTHONASYNCIODEBUG=1
+    {[testenv]setenv}
 
 [testenv:numba_coverage]
 commands=


### PR DESCRIPTION
Fix snooze task cancellation being called from the wrong thread (which was caught by this change).

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
