### PR TITLE
Fix "RuntimeError: no running event loop" at `libertem-server` startup

### DIFF
--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -101,3 +101,9 @@ def main(port, local_directory, browser, cpus, gpus, open_ds, log_level,
             token, preload, is_custom_port, executor_spec, open_ds,
             snooze_timeout,
         )
+
+
+# to enable calling this without using the entry point script,
+# for example using `python -m libertem.web.cli`:
+if __name__ == "__main__":
+    main()

--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -220,9 +220,11 @@ def run(
         format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
     )
 
+    loop = asyncio.get_event_loop()
+
     # shared state:
     event_registry = EventRegistry()
-    executor_state = ExecutorState(snooze_timeout=snooze_timeout)
+    executor_state = ExecutorState(snooze_timeout=snooze_timeout, loop=loop)
     shared_state = SharedState(executor_state=executor_state)
 
     executor_state.set_local_directory(local_directory)
@@ -274,7 +276,6 @@ def run(
         log.info(msg)
         if browser:
             webbrowser.open(url)
-        loop = asyncio.get_event_loop()
         handle_signal(shared_state)
         # Strictly necessary only on Windows, but doesn't do harm in any case.
         # FIXME check later if the unknown root cause was fixed upstream

--- a/src/libertem/web/state.py
+++ b/src/libertem/web/state.py
@@ -38,7 +38,11 @@ class ExecutorState:
     Be sure to explicitly call the `shutdown` method to clean up, otherwise
     there may be dangling resources preventing a clean shutdown.
     """
-    def __init__(self, snooze_timeout: typing.Optional[float] = None):
+    def __init__(
+        self,
+        loop: typing.Optional[asyncio.AbstractEventLoop] = None,
+        snooze_timeout: typing.Optional[float] = None,
+    ):
         self.executor = None
         self.cluster_params = {}
         self.context: typing.Optional[Context] = None
@@ -51,7 +55,9 @@ class ExecutorState:
             snooze_timeout and (snooze_timeout * 0.1) or 30.0,
         )
         self._snooze_task = asyncio.ensure_future(self._snooze_check_task())
-        self._loop = asyncio.get_running_loop()
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self._loop = loop
         self._keep_alive = 0
         self.local_directory = "dask-worker-space"
         self.preload: typing.Tuple[str, ...] = ()

--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -13,6 +13,18 @@ def event_loop_policy(request):
     return asyncio.get_event_loop_policy()  # TODO: windows fixes
 
 
+if sys.version_info < (3, 8) and sys.platform.startswith("win"):
+    # pytest-asyncio on Python 3.7 needs a bit of help...
+    # don't do this on current versions, as overriding event_loop
+    # on current pytest-asyncio is deprecated.
+    @pytest.fixture(scope='session')
+    def event_loop():
+        """Create an instance of the default event loop for each test case."""
+        loop = asyncio.WindowsProactorEventLoopPolicy().new_event_loop()
+        yield loop
+        loop.close()
+
+
 @pytest.mark.asyncio
 async def test_libertem_server_cli_startup():
     CTRL_C = signal.SIGINT

--- a/tests/server/test_startup.py
+++ b/tests/server/test_startup.py
@@ -289,11 +289,11 @@ async def test_libertem_server_cli_startup():
     # total deadline, basically how long it takes to import all the dependencies
     # and start the web API
     # (no executor startup is done here)
-    deadline = time.monotonic() + 5
+    deadline = time.monotonic() + 15
     while True:
         if time.monotonic() > deadline:
             assert False, 'timeout'
-        line = await asyncio.wait_for(p.stderr.readline(), 2)
+        line = await asyncio.wait_for(p.stderr.readline(), 5)
         if not line:  # EOF
             assert False, 'subprocess is dead'
         line = line.decode("utf8")
@@ -301,12 +301,23 @@ async def test_libertem_server_cli_startup():
         if 'LiberTEM listening on' in line:
             break
 
+    async def _debug():
+        while True:
+            line = await asyncio.wait_for(p.stderr.readline(), 5)
+            if not line:  # EOF
+                return
+            line = line.decode("utf8")
+            print('Line@_debug:', line, end='')
+
+    asyncio.ensure_future(_debug())
+
     try:
         # now, let's kill the subprocess:
         # ctrl+s twice should do the job:
         p.send_signal(signal.SIGINT)
-        await asyncio.sleep(0.1)
-        p.send_signal(signal.SIGINT)
+        await asyncio.sleep(0.5)
+        if p.returncode is None:
+            p.send_signal(signal.SIGINT)
 
         # wait for the process to stop, but max. 1 second:
         ret = await asyncio.wait_for(p.wait(), 1)

--- a/tests/server/test_startup.py
+++ b/tests/server/test_startup.py
@@ -1,4 +1,8 @@
+import time
 import json
+import sys
+import asyncio
+import signal
 
 import pytest
 import websockets
@@ -272,3 +276,45 @@ async def test_initial_state_analyses(
                 "cy": 1,
             },
         }
+
+
+@pytest.mark.asyncio
+async def test_libertem_server_cli_startup():
+    # make sure we can start `libertem-server` and stop it again using ctrl+c
+    # this is kind of a smoke test, which should cover the main cli functions.
+    p = await asyncio.create_subprocess_exec(
+        sys.executable, '-m', 'libertem.web.cli', '--no-browser',
+        stderr=asyncio.subprocess.PIPE,
+    )
+    # total deadline, basically how long it takes to import all the dependencies
+    # and start the web API
+    # (no executor startup is done here)
+    deadline = time.monotonic() + 5
+    while True:
+        if time.monotonic() > deadline:
+            assert False, 'timeout'
+        line = await asyncio.wait_for(p.stderr.readline(), 2)
+        if not line:  # EOF
+            assert False, 'subprocess is dead'
+        line = line.decode("utf8")
+        print('Line:', line, end='')
+        if 'LiberTEM listening on' in line:
+            break
+
+    try:
+        # now, let's kill the subprocess:
+        # ctrl+s twice should do the job:
+        p.send_signal(signal.SIGINT)
+        await asyncio.sleep(0.1)
+        p.send_signal(signal.SIGINT)
+
+        # wait for the process to stop, but max. 1 second:
+        ret = await asyncio.wait_for(p.wait(), 1)
+        assert ret == 0
+    except Exception:
+        if p.returncode is None:
+            p.terminate()
+            await asyncio.sleep(0.2)
+        if p.returncode is None:
+            p.kill()
+        raise

--- a/tests/server/test_startup.py
+++ b/tests/server/test_startup.py
@@ -1,8 +1,4 @@
-import time
 import json
-import sys
-import asyncio
-import signal
 
 import pytest
 import websockets
@@ -276,56 +272,3 @@ async def test_initial_state_analyses(
                 "cy": 1,
             },
         }
-
-
-@pytest.mark.asyncio
-async def test_libertem_server_cli_startup():
-    # make sure we can start `libertem-server` and stop it again using ctrl+c
-    # this is kind of a smoke test, which should cover the main cli functions.
-    p = await asyncio.create_subprocess_exec(
-        sys.executable, '-m', 'libertem.web.cli', '--no-browser',
-        stderr=asyncio.subprocess.PIPE,
-    )
-    # total deadline, basically how long it takes to import all the dependencies
-    # and start the web API
-    # (no executor startup is done here)
-    deadline = time.monotonic() + 15
-    while True:
-        if time.monotonic() > deadline:
-            assert False, 'timeout'
-        line = await asyncio.wait_for(p.stderr.readline(), 5)
-        if not line:  # EOF
-            assert False, 'subprocess is dead'
-        line = line.decode("utf8")
-        print('Line:', line, end='')
-        if 'LiberTEM listening on' in line:
-            break
-
-    async def _debug():
-        while True:
-            line = await asyncio.wait_for(p.stderr.readline(), 5)
-            if not line:  # EOF
-                return
-            line = line.decode("utf8")
-            print('Line@_debug:', line, end='')
-
-    asyncio.ensure_future(_debug())
-
-    try:
-        # now, let's kill the subprocess:
-        # ctrl+s twice should do the job:
-        p.send_signal(signal.SIGINT)
-        await asyncio.sleep(0.5)
-        if p.returncode is None:
-            p.send_signal(signal.SIGINT)
-
-        # wait for the process to stop, but max. 1 second:
-        ret = await asyncio.wait_for(p.wait(), 1)
-        assert ret == 0
-    except Exception:
-        if p.returncode is None:
-            p.terminate()
-            await asyncio.sleep(0.2)
-        if p.returncode is None:
-            p.kill()
-        raise


### PR DESCRIPTION
Fix for the following exception at startup:

```
Line:   File "/home/alex/miniconda/envs/libertem/lib/python3.9/runpy.py", line 197, in _run_module_as_main
Line:     return _run_code(code, main_globals, None,
Line:   File "/home/alex/miniconda/envs/libertem/lib/python3.9/runpy.py", line 87, in _run_code
Line:     exec(code, run_globals)
Line:   File "/home/alex/source/LiberTEM/src/libertem/web/cli.py", line 109, in <module>
Line:     main()
Line:   File "/home/alex/miniconda/envs/libertem/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
Line:     return self.main(*args, **kwargs)
Line:   File "/home/alex/miniconda/envs/libertem/lib/python3.9/site-packages/click/core.py", line 1055, in main
Line:     rv = self.invoke(ctx)
Line:   File "/home/alex/miniconda/envs/libertem/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
Line:     return ctx.invoke(self.callback, **ctx.params)
Line:   File "/home/alex/miniconda/envs/libertem/lib/python3.9/site-packages/click/core.py", line 760, in invoke
Line:     return __callback(*args, **kwargs)
Line:   File "/home/alex/source/LiberTEM/src/libertem/web/cli.py", line 99, in main
Line:     run(
Line:   File "/home/alex/source/LiberTEM/src/libertem/web/server.py", line 225, in run
Line:     executor_state = ExecutorState(snooze_timeout=snooze_timeout)
Line:   File "/home/alex/source/LiberTEM/src/libertem/web/state.py", line 54, in __init__
Line:     self._loop = asyncio.get_running_loop()
Line: RuntimeError: no running event loop
```

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
