### PR TITLE
Valid data masking

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -61,7 +61,7 @@ Web Interface
   (:issue:`1085`, :pr:`1518`)
 - When launching :code:`libertem-server` additional parameters are now accepted
   to preload a cluster with a given number of CPU and GPU workers, and also preload data. See
-  `the documentation <https://libertem.github.io/LiberTEM/usage.html#configuring-the-libertem-server-advanced>`_
+  `the libertem-server documentation <https://libertem.github.io/LiberTEM/usage.html#configuring-the-libertem-server-advanced>`_
   for more detail.(:issue:`1419`, :pr:`1535`)
 
 Descan compensation
@@ -130,7 +130,7 @@ Many thanks to everyone who has contributed to this release!
 
 The 0.12.0 release is also the first major release for which
 LiberTEM is available on `conda-forge <https://anaconda.org/conda-forge/libertem>`_.
-See `the documentation <https://libertem.github.io/LiberTEM/install.html>`_
+See `the installation documentation <https://libertem.github.io/LiberTEM/install.html>`_
 for installation instructions using :code:`pip` or :code:`conda`.
 
 Features

--- a/docs/source/changelog/bugfix/com.rst
+++ b/docs/source/changelog/bugfix/com.rst
@@ -1,0 +1,5 @@
+[Bugfix] Live center of mass regression
+=======================================
+
+* Fix the :class:`~libertem.udf.com.CoMUDF` automatic offset and gradient
+  compensation to yield reasonable results during live processing (:pr:`1593`).

--- a/docs/source/changelog/features/valid-data-masking.rst
+++ b/docs/source/changelog/features/valid-data-masking.rst
@@ -1,0 +1,10 @@
+[Feature] Valid data masks
+==========================
+
+* Make the mask of already processed navigation elements available
+  to the UDF in :meth:`~libertem.udf.base.UDF.merge` and
+  :meth:`~libertem.udf.base.UDF.get_results` (:issue:`1473`),
+  propagate this information to the result buffers
+  and allow UDFs to override this for results using the new
+  :meth:`~libertem.udf.base.UDF.with_mask` method
+  (:issue:`1449` :pr:`1593`).

--- a/docs/source/changelog/features/valid-data-masking.rst
+++ b/docs/source/changelog/features/valid-data-masking.rst
@@ -1,10 +1,10 @@
 [Feature] Valid data masks
 ==========================
 
-* Make the mask of already processed navigation elements available
-  to the UDF in :meth:`~libertem.udf.base.UDF.merge` and
-  :meth:`~libertem.udf.base.UDF.get_results` (:issue:`1473`),
-  propagate this information to the result buffers
-  and allow UDFs to override this for results using the new
-  :meth:`~libertem.udf.base.UDF.with_mask` method
+* Add endpoints to provide :meth:`~libertem.udf.base.UDF.merge`
+  and :meth:`~libertem.udf.base.UDF.get_results` with information
+  on which parts of the dataset have already been processed
+  (:issue:`1473`). The information is then propagated to the result
+  buffers, and UDFs can override the validity mask for results
+  using the new :meth:`~libertem.udf.base.UDF.with_mask` method
   (:issue:`1449` :pr:`1593`).

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -187,7 +187,7 @@ Post-processing after merging
 
 If you want to implement a post-processing step that is run on the main node
 after merging result buffers, you can override
-:meth:`libertem.udf.base.UDF.get_results`:
+:meth:`~libertem.udf.base.UDF.get_results`:
 
 .. testsetup::
 
@@ -222,22 +222,23 @@ after merging result buffers, you can override
 
     ctx.run_udf(dataset=dataset, udf=AverageUDF())
 
-Note that :meth:`UDF.get_result_buffers` returns a placeholder entry for the
+Note that :meth:`~libertem.udf.base.UDF.get_result_buffers` returns a placeholder entry for the
 :code:`average` result using :code:`use='result_only'`, which is then filled in
-:code:`get_results`.  We don't need to repeat those buffers that should be
+:meth:`~libertem.udf.base.UDF.get_results`.  We don't need to repeat those buffers that should be
 returned unchanged; if you want to omit a buffer from the results completely,
 you can declare it as private with :code:`self.buffer(..., use='private')` in
-:code:`get_result_buffers`.
+:meth:`~libertem.udf.base.UDF.get_result_buffers`.
 
-:meth:`UDF.get_results` should return the results as a dictionary of numpy
+:meth:`~libertem.udf.base.UDF.get_results` should return the results as a dictionary of numpy
 arrays, with the keys matching those returned by
-:meth:`UDF.get_result_buffers`.
+:meth:`~libertem.udf.base.UDF.get_result_buffers`.
 
-When returned from :meth:`Context.run_udf`, all results are wrapped into
-:code:`BufferWrapper` instances. This is done primarily to get convenient
-access to a version of the result that is suitable for visualization, even if
+When returned from :meth:`~libertem.api.Context.run_udf`, all results are wrapped into
+:class:`~libertem.common.buffers.BufferWrapper` instances. This is done primarily to get convenient
+access to a version of the result that is suitable for visualization using
+:attr:`~libertem.common.buffers.BufferWrapper.data`, even if
 a :code:`roi` was used, but still allow access to the raw result using
-:attr:`BufferWrapper.raw_data` attribute.
+:attr:`~libertem.common.buffers.BufferWrapper.raw_data` attribute.
 
 The detailed rules for buffer declarations, :code:`get_result_buffers` and :code:`get_results` are:
 

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -280,10 +280,10 @@ Valid data masking
 ------------------
 
 In various intermediate states, result buffers may be only partially filled
-with valid data. This comes from the fact that we split the data set into
-partitions, and then merge results together as they become available.
-Also, when doing live processing, you may have a direct mapping of acquired
-detector frames to result items, where naturally only positions where we have
+with valid data. This comes from the fact that we split the dataset into
+partitions and then merge results together only as they become available.
+When doing live processing we also have the constraint that not all frames
+have been acquired yet, and so naturally only positions where we have
 received and processed data can be valid in the corresponding result buffer.
 
 Handling partially valid data becomes important when running the UDF. For example,
@@ -331,9 +331,12 @@ Buffer :code:`kind` Default valid mask
 =================== ==================
 
 In your UDF, you can also customize the valid mask that should be returned.
-This is useful if there is no direct mapping between the already processed
-navigation elements and the valid results, or if you are using a :code:`kind='single'`
-buffer which is progressively built up, to override the default of all-valid.
+This is useful if the dataset might contain invalid frames discovered at runtime,
+or if intermediate results cannot be fully valid due to missing information (e.g.
+calculating gradients across partition boundaries). Another example is when using
+a :code:`kind='single'` buffer which is progressively computed; valid-by-default
+might be incorrect if not enough information has been seen (e.g. statistical measures
+or a count of values).
 
 Customizing the valid data mask is done in :meth:`~libertem.udf.UDF.get_results`
 with the :meth:`~libertem.udf.UDF.with_mask` method. For example:
@@ -341,6 +344,7 @@ with the :meth:`~libertem.udf.UDF.with_mask` method. For example:
 .. testsetup::
 
     from libertem.udf import UDF
+    from libertem.common.math import count_nonzero    
 
 
 .. testcode::

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -359,6 +359,9 @@ with the :meth:`~libertem.udf.UDF.with_mask` method. For example:
                 nav_shape = (count_nonzero(self.meta.roi),)
 
             return {
+                # Emulate a kind='nav' result buffer using a kind='sig' buffer for demonstration.
+                # In the real world, such result buffers can be found in the implementations of ptychography
+                # and iCoM since they reconstruct the object in Fourier space
                 'custom_2d': self.buffer(kind='single', dtype=np.float32, extra_shape=nav_shape),
             }
 

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -387,6 +387,12 @@ method, which is available in :meth:`~libertem.udf.UDF.merge` and
 already-processed navigation elements.
 
 .. versionadded:: 0.14.0
+    
+   In previous versions, only :attr:`libertem.udf.base.UDFResults.damage` was
+   available for inspecting the mask of already processed data.
+   This did not account for differences between buffers, and was only available
+   when iterating over results, i.e. with :meth:`~libertem.api.Context.run_udf_iter`.
+
 
 AUX data
 --------

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -276,6 +276,8 @@ by the ROI.
     node, too. Views for aux data are set correctly on the main node. Previously,
     it was only executed on the worker nodes.
 
+.. _`udf valid data masking`:
+
 Valid data masking
 ------------------
 

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -219,7 +219,11 @@ class Context:
     >>> debug_ctx = libertem.api.Context(executor=InlineJobExecutor())
     """
 
-    def __init__(self, executor: Optional[JobExecutor] = None, plot_class=None):
+    def __init__(
+        self,
+        executor: Optional[JobExecutor] = None,
+        plot_class: Optional['Live2DPlot'] = None,
+    ):
         import traceback
         if executor is None:
             executor = self._create_local_executor()
@@ -385,14 +389,14 @@ class Context:
         return cls(executor=executor, plot_class=plot_class)
 
     @property
-    def plot_class(self):
+    def plot_class(self) -> type['Live2DPlot']:
         if self._plot_class is None:
             from libertem.viz.mpl import MPLLive2DPlot
             self._plot_class = MPLLive2DPlot
         return self._plot_class
 
     @plot_class.setter
-    def plot_class(self, value):
+    def plot_class(self, value: type['Live2DPlot']):
         self._plot_class = value
 
     def load(self, filetype: str, *args, io_backend=None, **kwargs) -> DataSet:
@@ -1420,7 +1424,13 @@ class Context:
             for bufferset in buffers
         ]
 
-    def _prepare_plots(self, udfs, dataset, roi, plots):
+    def _prepare_plots(
+        self,
+        udfs: list[UDF],
+        dataset: DataSet,
+        roi: RoiT,
+        plots,
+    ) -> list['Live2DPlot']:
         runner_cls = self.executor.get_udf_runner()
         dry_results = runner_cls.dry_run(udfs, dataset, roi)
 
@@ -1467,7 +1477,14 @@ class Context:
                 plots.append(p0)
         return plots
 
-    def _update_plots(self, plots, udfs, udf_results, damage, force=False):
+    def _update_plots(
+        self,
+        plots: list['Live2DPlot'],
+        udfs: list[UDF],
+        udf_results: tuple[dict[str, BufferWrapper], ...],
+        damage: np.ndarray,
+        force: bool = False,
+    ):
         for plot in plots:
             udf = plot.get_udf()
             udf_index = udfs.index(udf)

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -202,7 +202,7 @@ class ArrayWithMask(Generic[T]):
     to instantiate it.
     """
 
-    def __init__(self, arr: T, mask: np.ndarray):
+    def __init__(self, arr: T, mask: Union[np.ndarray, bool]):
         if isinstance(mask, int):
             mask = np.array([mask])
         try:

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -203,7 +203,10 @@ class ArrayWithMask(Generic[T]):
     """
 
     def __init__(self, arr: T, mask: Union[np.ndarray, bool]):
-        if isinstance(mask, int):
+        """
+        :meta private:
+        """
+        if isinstance(mask, bool):
             mask = np.array([mask])
         try:
             mask = np.broadcast_to(mask, arr.shape)
@@ -211,6 +214,10 @@ class ArrayWithMask(Generic[T]):
             raise InvalidMaskError(
                 f"`arr` and `mask` must have compatible shapes "
                 f"(arr.shape={arr.shape} vs mask.shape={mask.shape})"
+            )
+        if mask.dtype != np.dtype('bool'):
+            raise InvalidMaskError(
+                f"`mask` should have `dtype=bool` (have {mask.dtype})"
             )
         self._arr = arr
         self._mask = mask

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -228,6 +228,8 @@ def get_inner_slice(arr: np.ndarray, axis: int = 0) -> tuple[slice, ...]:
     """
     Get a slice into `arr` across `axis` where the values on all other axes are non-zero.
     This will be the first contiguous slice, not necessarily the largest.
+
+    :meta private:
     """
     ax_min = arr.shape[axis]
     ax_max = 0
@@ -260,6 +262,9 @@ def get_inner_slice(arr: np.ndarray, axis: int = 0) -> tuple[slice, ...]:
 
 @numba.njit(cache=True)
 def get_bbox_2d(arr, eps=1e-8) -> tuple[int, ...]:
+    """
+    :meta private:
+    """
     xmin = arr.shape[1]
     ymin = arr.shape[0]
     xmax = 0
@@ -283,6 +288,9 @@ def get_bbox_2d(arr, eps=1e-8) -> tuple[int, ...]:
 
 
 def get_bbox(arr: np.ndarray) -> tuple[int, ...]:
+    """
+    :meta private:
+    """
     if arr.ndim == 2:
         # 4x faster specialization in numba for 2D:
         return get_bbox_2d(arr)
@@ -297,6 +305,9 @@ def get_bbox(arr: np.ndarray) -> tuple[int, ...]:
 
 
 def get_bbox_slice(arr: np.ndarray) -> tuple[slice, ...]:
+    """
+    :meta private:
+    """
     bbox = get_bbox(arr)
     res = []
     for pair in batched(bbox, 2):

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -546,8 +546,23 @@ class BufferWrapper:
 
     @property
     def masked_data(self) -> np.ma.MaskedArray:
+        """
+        Same as :property:`data`, but masked to the valid data, as a numpy
+        masked array.
+        """
         mask = ~self.valid_mask
         return np.ma.array(self.data, mask=mask)
+
+    @property
+    def raw_masked_data(self) -> np.ma.MaskedArray:
+        """
+        Same as :property:`raw_data`, but masked to the valid data, as a numpy
+        masked array.
+        """
+        # NOTE: using `self._valid_mask` instead of `self.valid_mask` to get the
+        # raw flat mask, not the one expanded to the full
+        mask = ~self._valid_mask
+        return np.ma.array(self.raw_data, mask=mask)
 
     @property
     def kind(self):

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -183,6 +183,14 @@ class ManagedBuffer:
 T = TypeVar('T', bound=np.generic)
 
 
+class InvalidMaskError(Exception):
+    """
+    The mask is not compatible, raised for example when the shape of
+    the mask doesn't match the data.
+    """
+    pass
+
+
 class ArrayWithMask(Generic[T]):
     """
     An opaque type representing an array together with a
@@ -200,7 +208,7 @@ class ArrayWithMask(Generic[T]):
         try:
             mask = np.broadcast_to(mask, arr.shape)
         except ValueError:
-            raise ValueError(
+            raise InvalidMaskError(
                 f"`arr` and `mask` must have compatible shapes "
                 f"(arr.shape={arr.shape} vs mask.shape={mask.shape})"
             )

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -356,8 +356,6 @@ class BufferWrapper:
 
         .. versionadded:: 0.7.0
 
-    valid_mask:
-        FIXME
     """
     def __init__(
         self,
@@ -366,7 +364,6 @@ class BufferWrapper:
         dtype="float32",
         where=None,
         use=None,
-        valid_mask: Optional[np.ndarray] = None,
     ) -> None:
         self._extra_shape = tuple(extra_shape)
         self._kind = kind
@@ -381,7 +378,6 @@ class BufferWrapper:
         self._roi = None
         self._roi_is_zero = None
         self._contiguous_cache = dict()
-        self._valid_mask = valid_mask
         self.use = use
 
     def set_roi(self, roi):
@@ -536,6 +532,10 @@ class BufferWrapper:
             return self._valid_mask.reshape(full_shape)
 
         return self._valid_mask
+
+    @valid_mask.setter
+    def valid_mask(self, valid_nask: np.ndarray):
+        self._valid_mask = valid_nask
 
     @property
     def valid_slice_bounding(self) -> tuple[slice, ...]:

--- a/src/libertem/executor/utils/dask_buffer.py
+++ b/src/libertem/executor/utils/dask_buffer.py
@@ -183,6 +183,7 @@ class DaskResultBufferWrapper(DaskPreallocBufferWrapper):
         result._ds_partitions = buffer._ds_partitions
         result._roi = buffer._roi
         result._roi_is_zero = buffer._roi_is_zero
+        result._valid_mask = buffer._valid_mask
         return result
 
     def __array__(self):

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1251,8 +1251,8 @@ class UDFBase(UDFProtocol):
                 kind=buf_decl.kind, extra_shape=buf_decl.extra_shape,
                 dtype=buf_decl.dtype,
                 data=arr,
-                valid_mask=mask,
             )
+            buf.valid_mask = mask
             buf.set_shape_ds(self.meta.dataset_shape, self.meta.roi)
             results[name] = buf
         return results

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1597,7 +1597,37 @@ class UDF(UDFBase):
         pass
 
     @staticmethod
-    def with_mask(data, mask: Union[np.ndarray, bool]) -> ArrayWithMask:
+    def with_mask(data: np.ndarray, mask: Union[np.ndarray, bool]) -> ArrayWithMask:
+        """
+        Add a mask to indicate the valid parts in a result. The mask
+        should be an array of bools, with a shape matching
+        the `data` array. The mask should have `True` in positions
+        that are valid, and `False` otherwise.
+
+        You can pass `mask=True` or `mask=False` as shortcuts for
+        all-valid or all-invalid, and also pass in masks that can
+        be broadcast to `data`.
+
+        This should be used in :meth:`get_results`.
+
+        See the :ref:`udf valid data masking` section in the
+        documentation for details and more examples.
+
+        Example
+        -------
+
+        >>> class SomeUDF(UDF):
+        ...     # ... other methods omitted for brevity ...
+        ...
+        ...     def get_results(self):
+        ...         return {
+        ...             'some_result': self.with_mask(
+        ...                 data=self.results.some_result,
+        ...                 mask=False,
+        ...             ),
+        ...         }
+        ...
+        """
         return ArrayWithMask(data, mask=mask)
 
     def buffer(

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -1233,12 +1233,10 @@ class UDFBase(UDFProtocol):
         # wrap numpy results into `ResultBuffer`s:
         results = {}
         for name, arr in results_tmp.items():
-            import dask.array.core
             mask = None
             if isinstance(arr, ArrayWithMask):
                 mask = arr.mask
                 arr = arr.arr
-            assert isinstance(arr, (np.ndarray, dask.array.core.Array))
             self._check_results(decl, arr, name)
             buf_decl = decl[name]
             if mask is None:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2270,10 +2270,8 @@ class UDFPartRunner:
             except TypeError:
                 raise TypeError("could not pickle partition")
             try:
-                # FIXME: validate state of the UDF here - need some values set
-                # for `_do_get_results`
                 cloudpickle.loads(cloudpickle.dumps(
-                    [u._do_get_results() for u in self._udfs]
+                    [u.results for u in self._udfs]
                 ))
             except TypeError:
                 raise TypeError("could not pickle results")

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2246,7 +2246,7 @@ class UDFRunner:
     @staticmethod
     def _apply_part_result(udfs, damage, part_results, task):
         for results, udf in zip(part_results, udfs):
-            udf.meta.valid_nav_mask = damage
+            udf.meta.valid_nav_mask = damage.raw_data
             udf.set_views_for_partition(task.partition)
             udf.merge(
                 dest=udf.results.get_proxy(),
@@ -2258,7 +2258,7 @@ class UDFRunner:
     @staticmethod
     def _make_udf_result(udfs: Iterable[UDF], damage: BufferWrapper) -> "UDFResults":
         for udf in udfs:
-            udf.meta.valid_nav_mask = damage
+            udf.meta.valid_nav_mask = damage.raw_data
             udf.clear_views()
         return UDFResults(
             buffers=tuple(

--- a/src/libertem/viz/base.py
+++ b/src/libertem/viz/base.py
@@ -207,7 +207,7 @@ class Live2DPlot:
         if self._extract is None:
             buffer = udf_results[self.channel]
             squeezed = buffer.masked_data.squeeze()
-            res_damage = buffer.valid_mask
+            res_damage = buffer.valid_mask.squeeze()
             return (squeezed, res_damage)
         else:
             return self._extract(udf_results, damage)

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -288,7 +288,7 @@ def test_com_regression_neutral(lt_ctx, use_roi, regression):
     udf = com.CoMUDF.with_params(cy=3, cx=3, regression=regression)
     for iter_res in lt_ctx.run_udf_iter(dataset=ds, udf=udf, roi=roi):
         res = iter_res.buffers[0]
-        assert_allclose(res['regression'], 0, atol=1e-14)
+        assert_allclose(res['regression'], 0, atol=1e-13)
         assert_allclose(res['field'].raw_data, 0, atol=1e-13)
         assert_allclose(res['field_y'].raw_data, 0, atol=1e-13)
         assert_allclose(res['field_x'].raw_data, 0, atol=1e-13)
@@ -319,7 +319,7 @@ def test_com_regression_offset(lt_ctx, use_roi, regression):
             [-2, 1],  # constant offset in y and x direction
             [0, 0],
             [0, 0]
-        ], atol=1e-14)
+        ], atol=1e-13)
         assert_allclose(res['field'].raw_data, 0, atol=1e-13)
         assert_allclose(res['field_y'].raw_data, 0, atol=1e-13)
         assert_allclose(res['field_x'].raw_data, 0, atol=1e-13)
@@ -346,7 +346,7 @@ def test_com_regression_linear(lt_ctx, use_roi, regression):
     for iter_res in lt_ctx.run_udf_iter(dataset=ds, udf=udf, roi=roi):
         res = iter_res.buffers[0]
         damage = iter_res.damage
-        assert_allclose(res['regression'].data, [[-2, 42], [2, 0], [0, -1]], atol=1e-14)
+        assert_allclose(res['regression'].data, [[-2, 42], [2, 0], [0, -1]], atol=1e-13)
         # The linear gradient is corrected in valid data
         assert_allclose(res['field'].data[damage], 0, atol=1e-12)
         # Regression only applied to valid data, other parts remain at their
@@ -378,7 +378,7 @@ def test_com_regression_linear_2(lt_ctx, use_roi, regression):
     udf = com.CoMUDF.with_params(cy=3, cx=3, regression=regression)
     for iter_res in lt_ctx.run_udf_iter(dataset=ds, udf=udf, roi=roi):
         res = iter_res.buffers[0]
-        assert_allclose(res['regression'].data, [[-2, 1], [2, 1], [3, 4]], atol=1e-14)
+        assert_allclose(res['regression'].data, [[-2, 1], [2, 1], [3, 4]], atol=1e-13)
         assert_allclose(res['field'].raw_data, 0, atol=1e-12)
         assert_allclose(res['field_y'].raw_data, 0, atol=1e-12)
         assert_allclose(res['field_x'].raw_data, 0, atol=1e-12)

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -336,7 +336,7 @@ def test_com_regression_linear(lt_ctx, use_roi, regression):
     for yy in range(23):
         for xx in range(42):
             data[yy, xx, 2*yy+1, 45-xx] = 1
-    ds = lt_ctx.load('memory', data=data, num_partitions=17)
+    ds = lt_ctx.load('memory', data=data, num_partitions=7)
     if use_roi:
         roi = np.random.choice([True, False], ds.shape.nav)
     else:
@@ -371,7 +371,8 @@ def test_com_regression_linear_2(lt_ctx, use_roi, regression):
             data[yy, xx, 1+2*yy+3*xx, 4+yy+4*xx] = 1
     ds = lt_ctx.load('memory', data=data, num_partitions=3)
     if use_roi:
-        roi = np.random.choice([True, False], ds.shape.nav)
+        roi = np.ones(ds.shape.nav, dtype=bool)
+        roi[2:4, 5:7] = False
     else:
         roi = None
 

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -310,7 +310,11 @@ def test_com_regression_offset(lt_ctx, use_roi, regression):
 
     udf = com.CoMUDF.with_params(cy=3, cx=3, regression=regression)
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
-    assert_allclose(res['regression'].data, [[-2, 1], [0, 0], [0, 0]], atol=1e-14)
+    assert_allclose(res['regression'].data, [
+        [-2, 1],  # constant offset in y and x direction
+        [0, 0],
+        [0, 0]
+    ], atol=1e-14)
     assert_allclose(res['field'].raw_data, 0, atol=1e-13)
     assert_allclose(res['field_y'].raw_data, 0, atol=1e-13)
     assert_allclose(res['field_x'].raw_data, 0, atol=1e-13)

--- a/tests/udf/test_valid_mask.py
+++ b/tests/udf/test_valid_mask.py
@@ -18,10 +18,10 @@ class ValidNavMaskUDF(UDF):
 
     def get_results(self):
         assert self.meta.valid_nav_mask is not None
-        assert self.meta.valid_nav_mask.data.sum() > 0, \
+        assert self.meta.valid_nav_mask.sum() > 0, \
             "get_results is not called with an empty valid nav mask"
         if self.params.debug:
-            print("get_results", self.meta.valid_nav_mask.data)
+            print("get_results", self.meta.valid_nav_mask)
         results = super().get_results()
         # import pdb; pdb.set_trace()
         return results
@@ -34,7 +34,7 @@ class ValidNavMaskUDF(UDF):
     def merge(self, dest, src):
         assert self.meta.valid_nav_mask is not None
         if self.params.debug:
-            print("merge", self.meta.valid_nav_mask.data)
+            print("merge", self.meta.valid_nav_mask)
         dest.buf_sig += src.buf_sig
         dest.buf_single += src.buf_single
         dest.buf_nav[:] = src.buf_nav

--- a/tests/udf/test_valid_mask.py
+++ b/tests/udf/test_valid_mask.py
@@ -41,6 +41,8 @@ class ValidNavMaskUDF(UDF):
         return results
 
     def process_frame(self, frame):
+        assert self.meta.get_valid_nav_mask() is None
+        assert self.meta.get_valid_nav_mask(full_nav=True) is None
         self.results.buf_sig += frame
         self.results.buf_nav[:] = frame.sum()
         self.results.buf_single[:] = frame.sum()

--- a/tests/udf/test_valid_mask.py
+++ b/tests/udf/test_valid_mask.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from libertem.api import Context
+from libertem.udf.base import UDF
+from libertem.io.dataset.memory import MemoryDataSet
+
+
+class ValidNavMaskUDF(UDF):
+    def __init__(self, debug=True):
+        super().__init__(debug=debug)
+
+    def get_result_buffers(self):
+        return {
+            'buf_sig': self.buffer(kind='sig', dtype=np.float32),
+            'buf_nav': self.buffer(kind='sig', dtype=np.float32),
+            'buf_single': self.buffer(kind='single', dtype=np.float32, extra_shape=(1,)),
+        }
+
+    def get_results(self):
+        assert self.meta.valid_nav_mask is not None
+        assert self.meta.valid_nav_mask.data.sum() > 0, \
+            "get_results is not called with an empty valid nav mask"
+        if self.params.debug:
+            print("get_results", self.meta.valid_nav_mask.data)
+        results = super().get_results()
+        # import pdb; pdb.set_trace()
+        return results
+
+    def process_frame(self, frame):
+        self.results.buf_sig += frame
+        self.results.buf_nav[:] = frame.sum()
+        self.results.buf_single[:] = frame.sum()
+
+    def merge(self, dest, src):
+        assert self.meta.valid_nav_mask is not None
+        if self.params.debug:
+            print("merge", self.meta.valid_nav_mask.data)
+        dest.buf_sig += src.buf_sig
+        dest.buf_single += src.buf_single
+        dest.buf_nav[:] = src.buf_nav
+
+
+def test_valid_nav_mask_available():
+    dataset = MemoryDataSet(datashape=[16, 16, 32, 32], num_partitions=4)
+    ctx = Context.make_with('inline')
+    for res in ctx.run_udf_iter(dataset=dataset, udf=ValidNavMaskUDF()):
+        # TODO: maybe compare damage we got in `get_results` with `res.damage` here?
+        pass
+
+
+def test_valid_nav_mask_available_roi():
+    dataset = MemoryDataSet(datashape=[16, 16, 32, 32], num_partitions=4)
+    ctx = Context.make_with('inline')
+    roi = np.zeros((16, 16), dtype=bool)
+    roi[4:-4, 4:-4] = True
+    for res in ctx.run_udf_iter(dataset=dataset, udf=ValidNavMaskUDF(debug=False), roi=roi):
+        print("damage", res.damage.data)
+        print("raw damage", res.damage.raw_data)

--- a/tests/udf/test_valid_mask.py
+++ b/tests/udf/test_valid_mask.py
@@ -47,6 +47,8 @@ class ValidNavMaskUDF(UDF):
 
     def merge(self, dest, src):
         assert self.meta.get_valid_nav_mask() is not None
+        assert not np.allclose(True, self.meta.get_valid_nav_mask()), \
+            "valid nav mask should be the already merged positions! can't be all-True"
         if self.params.debug:
             print("merge", self.meta.get_valid_nav_mask())
         dest.buf_sig += src.buf_sig

--- a/tests/viz/test_mpl.py
+++ b/tests/viz/test_mpl.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot
 
 from libertem.viz.mpl import MPLLive2DPlot
 from libertem.udf.sum import SumUDF
+from libertem.udf.raw import PickUDF
 from libertem.udf.sumsigudf import SumSigUDF
 
 
@@ -31,6 +32,23 @@ def test_mpl_nodisplay(monkeypatch, lt_ctx, default_raw):
     plots = [MPLLive2DPlot(dataset=default_raw, udf=udf)]
     with pytest.warns(UserWarning, match="Plot is not displayed, not plotting."):
         lt_ctx.run_udf(dataset=default_raw, udf=udf, plots=plots)
+
+
+@pytest.mark.parametrize("executor", ["dask", "inline"])
+def test_mpl_regression_pick_plot(monkeypatch, local_cluster_ctx, lt_ctx, default_raw, executor):
+    if executor == "dask":
+        ctx = local_cluster_ctx
+    elif executor == "inline":
+        ctx = lt_ctx
+    udf = PickUDF()
+    roi = np.zeros(default_raw.shape.nav, dtype=bool)
+    roi[0, 0] = True
+    monkeypatch.setattr(
+        matplotlib.pyplot,
+        'subplots',
+        mock.MagicMock(return_value=(mock.MagicMock(), mock.MagicMock()))
+    )
+    ctx.run_udf(dataset=default_raw, udf=udf, plots=True, roi=roi)
 
 
 def test_empty(monkeypatch, lt_ctx, default_raw):

--- a/tox.ini
+++ b/tox.ini
@@ -185,6 +185,7 @@ whitelist_externals=
     cat
 passenv=
     HOME
+    PYTHONWARNINGS
 
 [testenv:notebooks_gen]
 deps=


### PR DESCRIPTION
Makes the "valid nav mask" available in UDFs, and propagates it to results.

Closes #1473, closes #1449

## TODO

- [x] improve test cases
- [x] implement `BufferWrapper.masked_data` and friends
- [x] update plotting to use the per-buffer valid data mask instead of "global" damage
- [x] figure out how this fits best with `roi`s
- [x] add `raw_masked_data`
- [x] documentation

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
