### PR TITLE
Codecov needs the token in azure, too

### DIFF
--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -78,8 +78,9 @@ stages:
 
       - bash: ./scripts/codecov.sh -f ./coverage.xml
         displayName: 'Submit coverage to codecov.io'
-        env:
-          CODECOV_TOKEN: $(CODECOV_TOKEN)
+        ${{ if and(not(eq(variables['Build.Reason'], 'PullRequest')), eq(variables['Build.SourceBranch'], 'refs/heads/master')) }}:
+          env:
+            CODECOV_TOKEN: $(CODECOV_TOKEN)
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()
@@ -152,8 +153,9 @@ stages:
 
       - bash: ./scripts/codecov.sh -f ./coverage.xml
         displayName: 'Submit coverage to codecov.io'
-        env:
-          CODECOV_TOKEN: $(CODECOV_TOKEN)
+        ${{ if and(not(eq(variables['Build.Reason'], 'PullRequest')), eq(variables['Build.SourceBranch'], 'refs/heads/master')) }}:
+          env:
+            CODECOV_TOKEN: $(CODECOV_TOKEN)
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()
@@ -200,8 +202,9 @@ stages:
 
       - bash: ./scripts/codecov.sh -f ./coverage.xml
         displayName: 'Submit coverage to codecov.io'
-        env:
-          CODECOV_TOKEN: $(CODECOV_TOKEN)
+        ${{ if and(not(eq(variables['Build.Reason'], 'PullRequest')), eq(variables['Build.SourceBranch'], 'refs/heads/master')) }}:
+          env:
+            CODECOV_TOKEN: $(CODECOV_TOKEN)
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -15,6 +15,7 @@ variables:
   - name: PIP_CACHE_DIR
     value: $(Pipeline.Workspace)/.pip
   - group: Packaging
+  - group: Coverage
   - name: npm_config_cache
     value: $(Pipeline.Workspace)/.npm
   - name: tox_dir
@@ -77,6 +78,8 @@ stages:
 
       - bash: ./scripts/codecov.sh -f ./coverage.xml
         displayName: 'Submit coverage to codecov.io'
+        env:
+          CODECOV_TOKEN: $(CODECOV_TOKEN)
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()
@@ -149,6 +152,8 @@ stages:
 
       - bash: ./scripts/codecov.sh -f ./coverage.xml
         displayName: 'Submit coverage to codecov.io'
+        env:
+          CODECOV_TOKEN: $(CODECOV_TOKEN)
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()
@@ -195,6 +200,8 @@ stages:
 
       - bash: ./scripts/codecov.sh -f ./coverage.xml
         displayName: 'Submit coverage to codecov.io'
+        env:
+          CODECOV_TOKEN: $(CODECOV_TOKEN)
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()


### PR DESCRIPTION
Otherwise, builds for `master` won't properly submit their coverage.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
