### PR TITLE
Make sure live plots work with the widget backend

### DIFF
--- a/examples/live-plotting.ipynb
+++ b/examples/live-plotting.ipynb
@@ -64,18 +64,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\weber\\miniconda3\\envs\\lt312\\Lib\\site-packages\\distributed\\node.py:182: UserWarning: Port 8787 is already in use.\n",
-      "Perhaps you already have a cluster running?\n",
-      "Hosting the HTTP server on port 62496 instead\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We set the Context to use BQLive2DPlot for live plotting\n",
     "ctx = lt.Context(plot_class=BQLive2DPlot)\n",
@@ -201,7 +190,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f791b59ad3224adcb59a6f3dcb2b0852",
+       "model_id": "2f0c865008604989b9142b814c9eed08",
        "version_major": 2,
        "version_minor": 0
       },
@@ -226,7 +215,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f44bd1608ad9411292a6dc6860a3abb0",
+       "model_id": "217fb056f6e040e3a03682873249cf7b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -251,7 +240,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2c1d12eb9b641879d40bc7cc3be5ef5",
+       "model_id": "2ad7bad29337471ca0391df0fc89d4ba",
        "version_major": 2,
        "version_minor": 0
       },
@@ -276,7 +265,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4928ce2ab8fa403db4362cd2d6fb0b4f",
+       "model_id": "897e126627834da69ed97ff591507c52",
        "version_major": 2,
        "version_minor": 0
       },
@@ -300,6 +289,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "res = ctx.run_udf(dataset=ds, udf=udfs, plots=True)"
    ]
   },
@@ -320,7 +311,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d1a568731ff746d282d9cc94dac7ca95",
+       "model_id": "b8e332cfe6084393863570e0e6e3232c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -345,7 +336,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5430a60f27c44bd9be3a4227f4480f5f",
+       "model_id": "9889cd19af7747ed98dd203d12573752",
        "version_major": 2,
        "version_minor": 0
       },
@@ -370,7 +361,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a4062cd2e12e40f68fbc414aaa20735d",
+       "model_id": "691f91808b2c435e9591dcdf8a49ace7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -394,6 +385,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "res = ctx.run_udf(dataset=ds, udf=udfs, plots=[['nav_sum'], ['sig_sum', 'sig_max']])"
    ]
   },
@@ -430,7 +423,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "efef6e28e93e4f7484e73e24eb1afe55",
+       "model_id": "55c37c8559a249749c2f7f29d9abca04",
        "version_major": 2,
        "version_minor": 0
       },
@@ -455,7 +448,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9980fe8fba5c4bf686a4a5b0db22e262",
+       "model_id": "a4d5cf822e2a4316ab85d4d951e67c07",
        "version_major": 2,
        "version_minor": 0
       },
@@ -480,7 +473,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "08f2a223bccd4489985b6d6f882b4495",
+       "model_id": "8d37bb99cfca480da8ba4589856af84f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -505,7 +498,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "43f5082e60f74905b243361b8e72e43b",
+       "model_id": "5f9870c1a5824284a3600c8f1c4df22f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -529,6 +522,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "plot_list=[\n",
     "    ['nav_sum', ('nav_sum', larger), ('nav_sum', smaller)],\n",
     "    [],\n",
@@ -575,7 +570,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "938bcc1c7bf04361885d26ff1a6cd6b6",
+       "model_id": "23fcc52a5bd641aab39456a87b97fed3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -600,7 +595,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x269085611c0>"
+       "<matplotlib.colorbar.Colorbar at 0x1c8bdca9220>"
       ]
      },
      "execution_count": 12,
@@ -609,6 +604,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "live_plot.display()\n",
     "# We can access and modify the matplotlib objects, in this case to add a color bar\n",
     "live_plot.fig.colorbar(live_plot.im_obj)"
@@ -674,7 +671,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1d9d8fed6c21455c915a6e1d18dacc91",
+       "model_id": "cdc87451e6d64b9fb943d0b0462de2c3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -765,7 +762,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "112c5011814a4633b582cc26e2d40a1f",
+       "model_id": "55fca9011e03430090b5c08bb87ee42a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -790,7 +787,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f9ce180fbea7425ebb48ed3195713766",
+       "model_id": "fb76bd75d0f0469cb14133a1c30a265d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -814,6 +811,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "live_plots = [\n",
     "    MPLLive2DPlot(dataset=ds, udf=udfs[0], channel=nav_ratio),\n",
     "    MPLLive2DPlot(dataset=ds, udf=udfs[1], channel=sig_ratio),\n",
@@ -861,7 +860,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3bc1777338534dd2bc82461b26c3c26c",
+       "model_id": "835c4feeeac649bbac9c3a048a08446e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -895,6 +894,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "# This just works, the ROI is handled correctly internally\n",
     "ctx.run_udf(dataset=ds, udf=pick_udf, roi=roi, plots=True)"
    ]
@@ -907,7 +908,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "689cde48c29c45f6a1cda1bc281ee894",
+       "model_id": "b64d2c7ba99d4eb19e3529bbf575838e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -931,6 +932,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "# Here we have to pass the ROI\n",
     "# If this was omitted, the PickUDF would allocate memory for the entire dataset and the plot would try to display that!\n",
     "live_plot_pick = MPLLive2DPlot(dataset=ds, udf=pick_udf, roi=roi, channel='intensity')\n",
@@ -980,7 +983,7 @@
       "File \u001b[1;32m~\\Documents\\src\\LiberTEM\\src\\libertem\\api.py:984\u001b[0m, in \u001b[0;36mContext.run_udf\u001b[1;34m(self, dataset, udf, roi, corrections, progress, backends, plots, sync)\u001b[0m\n\u001b[0;32m    982\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m tracer\u001b[38;5;241m.\u001b[39mstart_as_current_span(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mContext.run_udf\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n\u001b[0;32m    983\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m sync:\n\u001b[1;32m--> 984\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_run_sync\u001b[49m\u001b[43m(\u001b[49m\n\u001b[0;32m    985\u001b[0m \u001b[43m            \u001b[49m\u001b[43mdataset\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdataset\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    986\u001b[0m \u001b[43m            \u001b[49m\u001b[43mudf\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mudf\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    987\u001b[0m \u001b[43m            \u001b[49m\u001b[43mroi\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mroi\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    988\u001b[0m \u001b[43m            \u001b[49m\u001b[43mcorrections\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcorrections\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    989\u001b[0m \u001b[43m            \u001b[49m\u001b[43mprogress\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mprogress\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    990\u001b[0m \u001b[43m            \u001b[49m\u001b[43mbackends\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbackends\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    991\u001b[0m \u001b[43m            \u001b[49m\u001b[43mplots\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mplots\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    992\u001b[0m \u001b[43m            \u001b[49m\u001b[43miterate\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[0;32m    993\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m    994\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m    995\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_run_async(\n\u001b[0;32m    996\u001b[0m             dataset\u001b[38;5;241m=\u001b[39mdataset,\n\u001b[0;32m    997\u001b[0m             udf\u001b[38;5;241m=\u001b[39mudf,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m   1003\u001b[0m             iterate\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[0;32m   1004\u001b[0m         )\n",
       "File \u001b[1;32m~\\Documents\\src\\LiberTEM\\src\\libertem\\api.py:1227\u001b[0m, in \u001b[0;36mContext._run_sync\u001b[1;34m(self, dataset, udf, roi, corrections, progress, backends, plots, iterate)\u001b[0m\n\u001b[0;32m   1225\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m enable_plotting:\n\u001b[0;32m   1226\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m tracer\u001b[38;5;241m.\u001b[39mstart_as_current_span(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mprepare_plots\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n\u001b[1;32m-> 1227\u001b[0m         plots \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_prepare_plots\u001b[49m\u001b[43m(\u001b[49m\u001b[43mudfs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdataset\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroi\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mplots\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   1229\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m corrections \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m   1230\u001b[0m     corrections \u001b[38;5;241m=\u001b[39m dataset\u001b[38;5;241m.\u001b[39mget_correction_data()\n",
       "File \u001b[1;32m~\\Documents\\src\\LiberTEM\\src\\libertem\\api.py:1466\u001b[0m, in \u001b[0;36mContext._prepare_plots\u001b[1;34m(self, udfs, dataset, roi, plots)\u001b[0m\n\u001b[0;32m   1454\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m channel \u001b[38;5;129;01min\u001b[39;00m udf_channels:\n\u001b[0;32m   1455\u001b[0m         p0 \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mplot_class(\n\u001b[0;32m   1456\u001b[0m             dataset,\n\u001b[0;32m   1457\u001b[0m             udf\u001b[38;5;241m=\u001b[39mudf,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m   1464\u001b[0m             ),\n\u001b[0;32m   1465\u001b[0m         )\n\u001b[1;32m-> 1466\u001b[0m         \u001b[43mp0\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdisplay\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   1467\u001b[0m         plots\u001b[38;5;241m.\u001b[39mappend(p0)\n\u001b[0;32m   1468\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m plots\n",
-      "File \u001b[1;32m~\\Documents\\src\\LiberTEM\\src\\libertem\\viz\\mpl.py:77\u001b[0m, in \u001b[0;36mMPLLive2DPlot.display\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     75\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m ui_events() \u001b[38;5;28;01mas\u001b[39;00m poll:\n\u001b[0;32m     76\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfig, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39maxes \u001b[38;5;241m=\u001b[39m plt\u001b[38;5;241m.\u001b[39msubplots()\n\u001b[1;32m---> 77\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mim_obj \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43maxes\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mimshow\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     78\u001b[0m     \u001b[38;5;66;03m# Set values compatible with log norm\u001b[39;00m\n\u001b[0;32m     79\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mim_obj\u001b[38;5;241m.\u001b[39mnorm\u001b[38;5;241m.\u001b[39mvmin \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n",
+      "File \u001b[1;32m~\\Documents\\src\\LiberTEM\\src\\libertem\\viz\\mpl.py:93\u001b[0m, in \u001b[0;36mMPLLive2DPlot.display\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     91\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m ui_events() \u001b[38;5;28;01mas\u001b[39;00m poll:\n\u001b[0;32m     92\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfig, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39maxes \u001b[38;5;241m=\u001b[39m plt\u001b[38;5;241m.\u001b[39msubplots()\n\u001b[1;32m---> 93\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mim_obj \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43maxes\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mimshow\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     94\u001b[0m     \u001b[38;5;66;03m# Set values compatible with log norm\u001b[39;00m\n\u001b[0;32m     95\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mim_obj\u001b[38;5;241m.\u001b[39mnorm\u001b[38;5;241m.\u001b[39mvmin \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n",
       "File \u001b[1;32m~\\miniconda3\\envs\\lt312\\Lib\\site-packages\\matplotlib\\__init__.py:1478\u001b[0m, in \u001b[0;36m_preprocess_data.<locals>.inner\u001b[1;34m(ax, data, *args, **kwargs)\u001b[0m\n\u001b[0;32m   1475\u001b[0m \u001b[38;5;129m@functools\u001b[39m\u001b[38;5;241m.\u001b[39mwraps(func)\n\u001b[0;32m   1476\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21minner\u001b[39m(ax, \u001b[38;5;241m*\u001b[39margs, data\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[0;32m   1477\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m data \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m-> 1478\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[43max\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43mmap\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43msanitize_sequence\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   1480\u001b[0m     bound \u001b[38;5;241m=\u001b[39m new_sig\u001b[38;5;241m.\u001b[39mbind(ax, \u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[0;32m   1481\u001b[0m     auto_label \u001b[38;5;241m=\u001b[39m (bound\u001b[38;5;241m.\u001b[39marguments\u001b[38;5;241m.\u001b[39mget(label_namer)\n\u001b[0;32m   1482\u001b[0m                   \u001b[38;5;129;01mor\u001b[39;00m bound\u001b[38;5;241m.\u001b[39mkwargs\u001b[38;5;241m.\u001b[39mget(label_namer))\n",
       "File \u001b[1;32m~\\miniconda3\\envs\\lt312\\Lib\\site-packages\\matplotlib\\axes\\_axes.py:5759\u001b[0m, in \u001b[0;36mAxes.imshow\u001b[1;34m(self, X, cmap, norm, aspect, interpolation, alpha, vmin, vmax, origin, extent, interpolation_stage, filternorm, filterrad, resample, url, **kwargs)\u001b[0m\n\u001b[0;32m   5756\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m aspect \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m   5757\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_aspect(aspect)\n\u001b[1;32m-> 5759\u001b[0m \u001b[43mim\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mset_data\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   5760\u001b[0m im\u001b[38;5;241m.\u001b[39mset_alpha(alpha)\n\u001b[0;32m   5761\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m im\u001b[38;5;241m.\u001b[39mget_clip_path() \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m   5762\u001b[0m     \u001b[38;5;66;03m# image does not already have clipping set, clip to axes patch\u001b[39;00m\n",
       "File \u001b[1;32m~\\miniconda3\\envs\\lt312\\Lib\\site-packages\\matplotlib\\image.py:723\u001b[0m, in \u001b[0;36m_ImageBase.set_data\u001b[1;34m(self, A)\u001b[0m\n\u001b[0;32m    721\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(A, PIL\u001b[38;5;241m.\u001b[39mImage\u001b[38;5;241m.\u001b[39mImage):\n\u001b[0;32m    722\u001b[0m     A \u001b[38;5;241m=\u001b[39m pil_to_array(A)  \u001b[38;5;66;03m# Needed e.g. to apply png palette.\u001b[39;00m\n\u001b[1;32m--> 723\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_A \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_normalize_image_array\u001b[49m\u001b[43m(\u001b[49m\u001b[43mA\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m    724\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_imcache \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m    725\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstale \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n",
@@ -991,7 +994,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "47a00db00ecd41b5a41548771b217719",
+       "model_id": "8a01a93b29b14444a5849bc28965b470",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1028,7 +1031,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "97dcbc5192c141d78fc3ed7500f6988f",
+       "model_id": "601e8ab44c7f44c590eb2ff93e7f670f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1062,6 +1065,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# (output is ignored in nbval run because it somehow doesn't work with widgets)\n",
     "# Works, we squeeze the extra axis out\n",
     "ctx.run_udf(dataset=ds, udf=pick_udf, roi=roi, plots=[[('intensity', lambda x: x.squeeze())]])"
    ]

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,8 @@ setup(
         'tomli',
         'sparseconverter>=0.3.3',
         'numexpr!=2.8.6',  # work around broken sanitization, remove this line when fixed
+        'jupyter_ui_poll',  # Make live matplotlib plots work with the widget backend
+        'ipympl',  # Support the widget backend
     ],
     extras_require={
         # NumPy interfacing issue on Win 11, Python 3.10

--- a/src/libertem/viz/mpl.py
+++ b/src/libertem/viz/mpl.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from contextlib import contextmanager
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -9,6 +10,21 @@ from .base import Live2DPlot
 
 
 logger = logging.getLogger(__name__)
+
+try:
+    with ui_events() as poll:
+        pass
+except Exception:
+    logger.info(
+            'Deactivating Jupyter UI event polling, '
+            'possibly not running in IPython?',
+            exc_info=True
+        )
+
+    # Replacing jupyter_ui_poll with a dummy
+    @contextmanager
+    def ui_events():
+        yield lambda x: None
 
 
 class MPLLive2DPlot(Live2DPlot):

--- a/src/libertem/viz/mpl.py
+++ b/src/libertem/viz/mpl.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 import matplotlib.pyplot as plt
+from jupyter_ui_poll import ui_events
 
 from .base import Live2DPlot
 
@@ -71,12 +72,15 @@ class MPLLive2DPlot(Live2DPlot):
         self.im_obj = None
 
     def display(self):
-        self.fig, self.axes = plt.subplots()
-        self.im_obj = self.axes.imshow(self.data, **self.kwargs)
-        # Set values compatible with log norm
-        self.im_obj.norm.vmin = 1
-        self.im_obj.norm.vmax = 1 + 1e-12
-        self.axes.set_title(self.title)
+        with ui_events() as poll:
+            self.fig, self.axes = plt.subplots()
+            self.im_obj = self.axes.imshow(self.data, **self.kwargs)
+            # Set values compatible with log norm
+            self.im_obj.norm.vmin = 1
+            self.im_obj.norm.vmax = 1 + 1e-12
+            self.axes.set_title(self.title)
+            self.fig.show()
+            poll(1000)
 
     def update(self, damage, force=False):
         """
@@ -104,5 +108,8 @@ class MPLLive2DPlot(Live2DPlot):
         if len(valid_data) > 0:
             i_o.norm.vmin = np.min(valid_data)
             i_o.norm.vmax = np.max(valid_data)
-        i_o.changed()
-        self.fig.canvas.draw()
+        with ui_events() as poll:
+            i_o.changed()
+            self.fig.canvas.draw_idle()
+            self.fig.canvas.flush_events()
+            poll(1000)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist = py{37,38,39,310,311,312}{,-data}{,-nogpu}, notebooks
 
 [testenv]
-allowlist_externals=
-    pip
 commands=
     pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg --junitxml=junit.xml {posargs:tests/}
     # win_tweaks.py depends on modules that are only available on Windows

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = py{37,38,39,310,311,312}{,-data}{,-nogpu}, notebooks
 
 [testenv]
+allowlist_externals=
+    pip
 commands=
     pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=setup.cfg --junitxml=junit.xml {posargs:tests/}
     # win_tweaks.py depends on modules that are only available on Windows


### PR DESCRIPTION
The newest versions of jupyterlab and notebook don't support the `nbagg` backend anymore. Instead the `widget` backend is supposed to be used: https://matplotlib.org/stable/users/explain/figure/interactive.html#jupyter-notebooks-jupyterlab

With this change the `widget` backend shows and updates the plots live as it is supposed to. It also uses the recommended live drawing functions for matplotlib:
https://matplotlib.org/stable/users/explain/figure/interactive_guide.html#explicitly-spinning-the-event-loop

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
