### PR TITLE
Fix `test_raw.csr.py::test_reshape_sync_offset` w/ pytest-xdist

### DIFF
--- a/tests/io/datasets/test_raw_csr.py
+++ b/tests/io/datasets/test_raw_csr.py
@@ -329,6 +329,24 @@ def test_sig_nav_shape(raw_csr_generated, lt_ctx):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
+    'nav_shape', (
+        None,
+        (14, 14),
+        (47, 13),
+        "random1d",
+        "random2d",
+        "random3d",
+    ),
+)
+@pytest.mark.parametrize(
+    'sync_offset', (
+        0, 1, -1, -10, 13, 13*15, -13*14,
+        "random",
+        -13*17+1,
+        13*17-1,
+    ),
+)
+@pytest.mark.parametrize(
     'sig_shape', (
         None, (24, 19), (24*19, )
     ),
@@ -337,93 +355,93 @@ def test_sig_nav_shape(raw_csr_generated, lt_ctx):
     'use_roi', (False, True)
 )
 def test_reshape_sync_offset(
-        raw_csr_generated, mock_sparse_data, lt_ctx, sig_shape, use_roi):
-    for sync_offset in (
-        0, 1, -1, -10, 13, 13*15, -13*14,
-        np.random.randint(low=-13*17+1, high=13*17),
-        -13*17+1,
-        13*17-1,
-    ):
-        for nav_shape in (
-            None, (14, 14), (47, 13),
-            (np.random.randint(low=1, high=13*18), ),
-            (np.random.randint(low=1, high=13*18), np.random.randint(low=1, high=13*18)),
-            (
-                np.random.randint(low=1, high=13*18),
-                np.random.randint(low=1, high=13*18),
-                np.random.randint(low=1, high=13*18)
-            ),
-        ):
-            orig, data_flat = mock_sparse_data
-            data = data_flat.reshape(raw_csr_generated.shape)
-            # Otherwise memory and raw_csr use different approach to determine shape
-            # that yields different results
-            if nav_shape is None and sig_shape is not None:
-                mem_nav_shape = raw_csr_generated.shape.nav
-            else:
-                mem_nav_shape = nav_shape
-            if sig_shape is None and nav_shape is not None:
-                mem_sig_shape = raw_csr_generated.shape.sig
-            else:
-                mem_sig_shape = sig_shape
-            ref_ds = lt_ctx.load(
-                'memory',
-                data=data,
-                nav_shape=mem_nav_shape,
-                sig_shape=mem_sig_shape,
-                sync_offset=sync_offset,
-            )
+        raw_csr_generated, mock_sparse_data, lt_ctx, sync_offset, nav_shape, sig_shape, use_roi):
+    if sync_offset == 'random':
+        sync_offset = np.random.randint(low=-13*17+1, high=13*17)
+    if nav_shape == 'random1d':
+        nav_shape = (np.random.randint(low=1, high=13*18),)
+    elif nav_shape == 'random2d':
+        nav_shape = (
+            np.random.randint(low=1, high=13*18),
+            np.random.randint(low=1, high=13*18),
+        )
+    elif nav_shape == 'random3d':
+        nav_shape = (
+            np.random.randint(low=1, high=13*18),
+            np.random.randint(low=1, high=13*18),
+            np.random.randint(low=1, high=13*18),
+        )
 
-            if use_roi:
-                roi = np.random.choice([True, False], size=ref_ds.shape.nav)
-            else:
-                roi = None
+    orig, data_flat = mock_sparse_data
+    data = data_flat.reshape(raw_csr_generated.shape)
+    # Otherwise memory and raw_csr use different approach to determine shape
+    # that yields different results
+    if nav_shape is None and sig_shape is not None:
+        mem_nav_shape = raw_csr_generated.shape.nav
+    else:
+        mem_nav_shape = nav_shape
+    if sig_shape is None and nav_shape is not None:
+        mem_sig_shape = raw_csr_generated.shape.sig
+    else:
+        mem_sig_shape = sig_shape
+    ref_ds = lt_ctx.load(
+        'memory',
+        data=data,
+        nav_shape=mem_nav_shape,
+        sig_shape=mem_sig_shape,
+        sync_offset=sync_offset,
+    )
 
-            print('nav_shape', nav_shape)
-            print('sig_shape', sig_shape)
-            print('sync_offset', sync_offset)
-            print('roi', roi)
+    if use_roi:
+        roi = np.random.choice([True, False], size=ref_ds.shape.nav)
+    else:
+        roi = None
 
-            ds = lt_ctx.load(
-                'raw_csr', path=raw_csr_generated._path,
-                sync_offset=sync_offset, nav_shape=nav_shape, sig_shape=sig_shape
-            )
+    print('nav_shape', nav_shape)
+    print('sig_shape', sig_shape)
+    print('sync_offset', sync_offset)
+    print('roi', roi)
 
-            assert tuple(ref_ds.shape.sig) == tuple(ds.shape.sig)
-            assert tuple(ref_ds.shape.nav) == tuple(ds.shape.nav)
+    ds = lt_ctx.load(
+        'raw_csr', path=raw_csr_generated._path,
+        sync_offset=sync_offset, nav_shape=nav_shape, sig_shape=sig_shape
+    )
 
-            masks = np.random.random(size=(3, *ref_ds.shape.sig))
-            udf_masks = ApplyMasksUDF(mask_factories=lambda: masks)
-            udf_std = StdDevUDF()
+    assert tuple(ref_ds.shape.sig) == tuple(ds.shape.sig)
+    assert tuple(ref_ds.shape.nav) == tuple(ds.shape.nav)
 
-            ref_result = lt_ctx.run_udf(udf=(udf_masks, udf_std), dataset=ref_ds)
-            result = lt_ctx.run_udf(udf=(udf_masks, udf_std), dataset=ds)
+    masks = np.random.random(size=(3, *ref_ds.shape.sig))
+    udf_masks = ApplyMasksUDF(mask_factories=lambda: masks)
+    udf_std = StdDevUDF()
 
-            r1 = ref_result[0]['intensity'].raw_data
-            r2 = result[0]['intensity'].raw_data
+    ref_result = lt_ctx.run_udf(udf=(udf_masks, udf_std), dataset=ref_ds)
+    result = lt_ctx.run_udf(udf=(udf_masks, udf_std), dataset=ds)
 
-            print(
-                np.max((r1 - r2) / np.maximum(0.00001, (np.abs(r1) + np.abs(r2))))
-            )
+    r1 = ref_result[0]['intensity'].raw_data
+    r2 = result[0]['intensity'].raw_data
 
-            assert_allclose(
-                ref_result[0]['intensity'].raw_data,
-                result[0]['intensity'].raw_data,
-                rtol=1e-5,
-                atol=1e-8,
-            )
-            assert_allclose(
-                ref_result[1]['std'].raw_data,
-                result[1]['std'].raw_data,
-                rtol=1e-5,
-                atol=1e-8,
-            )
-            assert_allclose(
-                ref_result[1]['num_frames'].raw_data,
-                result[1]['num_frames'].raw_data,
-                rtol=1e-5,
-                atol=1e-8,
-            )
+    print(
+        np.max((r1 - r2) / np.maximum(0.00001, (np.abs(r1) + np.abs(r2))))
+    )
+
+    assert_allclose(
+        ref_result[0]['intensity'].raw_data,
+        result[0]['intensity'].raw_data,
+        rtol=1e-5,
+        atol=1e-8,
+    )
+    assert_allclose(
+        ref_result[1]['std'].raw_data,
+        result[1]['std'].raw_data,
+        rtol=1e-5,
+        atol=1e-8,
+    )
+    assert_allclose(
+        ref_result[1]['num_frames'].raw_data,
+        result[1]['num_frames'].raw_data,
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
 
 def test_uint64ptr(lt_ctx_fast, raw_csr_generated_uint64):


### PR DESCRIPTION
Can't have randomly generated parametrize values, as that influences the test names, which have to be consistent across pytest-xdist workers.

This fixes things like `pytest tests/ -m "slow and not dist" -n 12`

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
