### PR TITLE
Exposed Y and X field shifts in CoMUDF

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,12 +18,6 @@ Changelog
   :glob:
 
   changelog/*/*
-  
-Misc
-----
-
-- In :class:`~libertem.udf.com.CoMUDF`, added `field_y` and `field_x` to results, 
-  which are slices of their respective components in the `field` result.
 
 .. _latest:
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,12 @@ Changelog
   :glob:
 
   changelog/*/*
+  
+Misc
+----
+
+- In :class:`~libertem.udf.com.CoMUDF`, added `field_y` and `field_x` to results, 
+  which are slices of their respective components in the `field` result.
 
 .. _latest:
 

--- a/docs/source/changelog/misc/field-components.rst
+++ b/docs/source/changelog/misc/field-components.rst
@@ -2,4 +2,4 @@
 ==============================================
 
 * In :class:`~libertem.udf.com.CoMUDF`, added `field_y` and `field_x` to results, 
-  which are slices of their respective components in the `field` result.
+  which are slices of their respective components in the `field` result (:pr:`1608`).

--- a/docs/source/changelog/misc/field-components.rst
+++ b/docs/source/changelog/misc/field-components.rst
@@ -1,0 +1,5 @@
+[Feature] Expose y- and x-components in CoMUDF
+==============================================
+
+* In :class:`~libertem.udf.com.CoMUDF`, added `field_y` and `field_x` to results, 
+  which are slices of their respective components in the `field` result.

--- a/packaging/creators.json
+++ b/packaging/creators.json
@@ -40,6 +40,14 @@
         "orcid": "0000-0002-6296-4492"
     },
     {
+        "displayname": "Sivert J.V. Dagenborg",
+        "authorname": "Dagenborg, Sivert",
+        "affiliation": "Norwegian University of Science and Technology",
+        "github": "sivborg",
+        "contribution": "Code, tests, code in related projects",
+        "orcid": "0009-0000-8753-9698"
+    },
+    {
         "displayname": "Anand Baburajan",
         "authorname": "Baburajan, Anand",
         "affiliation": "Government Engineering College Sreekrishnapuram",
@@ -173,13 +181,5 @@
         "affiliation": "Jülich Research Centre, Ernst Ruska Centre",
         "contribution": "Scientific advisory, resources, discussion, publications",
         "orcid": "0000-0001-8082-0647"
-    },
-    {
-        "displayname": "Sivert J.V. Dagenborg",
-        "authorname": "Dagenborg, Sivert",
-        "affiliation": "Norwegian University of Science and Technology",
-        "github": "sivborg",
-        "contribution": "Code, tests, code in related projects",
-        "orcid": "0009-0000-8753-9698"
     }
 ]

--- a/packaging/creators.json
+++ b/packaging/creators.json
@@ -173,5 +173,13 @@
         "affiliation": "Jülich Research Centre, Ernst Ruska Centre",
         "contribution": "Scientific advisory, resources, discussion, publications",
         "orcid": "0000-0001-8082-0647"
+    },
+    {
+        "displayname": "Sivert J.V. Dagenborg",
+        "authorname": "Dagenborg, Sivert",
+        "affiliation": "Norwegian University of Science and Technology",
+        "github": "sivborg",
+        "contribution": "Code, tests, code in related projects",
+        "orcid": "0009-0000-8753-9698"
     }
 ]

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -481,6 +481,12 @@ class CoMUDF(UDF):
             'field': self.buffer(
                 kind='nav', dtype=dtype, extra_shape=(2, ), use='result_only'
             ),
+            'field_y': self.buffer(
+                kind='nav', dtype=dtype, use='result_only'
+            ),
+            'field_x': self.buffer(
+                kind='nav', dtype=dtype, use='result_only'
+            ),
             'magnitude': self.buffer(
                 kind='nav', dtype=dtype, use='result_only'
             ),
@@ -678,6 +684,8 @@ class CoMUDF(UDF):
             'raw_shifts': raw_shifts,
             'raw_com': raw_com,
             'field': field,
+            'field_y': field[..., 0],
+            'field_x': field[..., 1],
             'regression': regression.astype(np.float64),
         }
 

--- a/src/libertem/udf/com.py
+++ b/src/libertem/udf/com.py
@@ -322,6 +322,12 @@ class CoMUDF(UDF):
         The transformed shift in the centre-of-mass in pixels, subject
         to any corrections (scan rotation, detector flip)
 
+    * field_y, scalar
+        y-component of field, as given above.
+
+    * field_x, scalar
+        x-component of field, as given above.
+
     * magnitude, scalar
         The magnitude of the field buffer, equivalent to ||raw_shifts||_2
 

--- a/tests/udf/test_com.py
+++ b/tests/udf/test_com.py
@@ -48,6 +48,18 @@ def test_com(lt_ctx, delayed_ctx, backend):
             np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
         )
         assert_allclose(
+            com_result['field_y'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 0],
+        )
+        assert_allclose(
+            com_result['field_x'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 1],
+        )
+        assert_allclose(
+            com_result['field'],
+            np.stack((com_result['field_y'], com_result['field_x']), axis=-1),
+        )
+        assert_allclose(
             com_result['magnitude'],
             analysis_result.magnitude.raw_data,
         )
@@ -63,6 +75,18 @@ def test_com(lt_ctx, delayed_ctx, backend):
         assert_allclose(
             com_delayed['field'],
             np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+        )
+        assert_allclose(
+            com_delayed['field_y'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 0],
+        )
+        assert_allclose(
+            com_delayed['field_x'],
+            np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 1],
+        )
+        assert_allclose(
+            com_delayed['field'],
+            np.stack((com_delayed['field_y'], com_delayed['field_x']), axis=-1),
         )
         assert_allclose(
             com_delayed['magnitude'],
@@ -126,6 +150,18 @@ def test_com_params(lt_ctx, repeat):
     assert_allclose(
         com_result['field'],
         np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
+    )
+    assert_allclose(
+        com_result['field_y'],
+        np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 0],
+    )
+    assert_allclose(
+        com_result['field_x'],
+        np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 1],
+    )
+    assert_allclose(
+        com_result['field'],
+        np.stack((com_result['field_y'], com_result['field_x']), axis=-1),
     )
     assert_allclose(
         com_result['magnitude'],
@@ -193,6 +229,18 @@ def test_com_roi(lt_ctx, repeat):
         np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1),
     )
     assert_allclose(
+        com_result['field_y'],
+        np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 0],
+    )
+    assert_allclose(
+        com_result['field_x'],
+        np.flip(np.moveaxis(analysis_result.field.raw_data, 0, -1), axis=-1)[..., 1],
+    )
+    assert_allclose(
+        com_result['field'],
+        np.stack((com_result['field_y'], com_result['field_x']), axis=-1),
+    )
+    assert_allclose(
         com_result['magnitude'],
         analysis_result.magnitude.raw_data,
     )
@@ -239,6 +287,8 @@ def test_com_regression_neutral(lt_ctx, use_roi, regression):
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
     assert_allclose(res['regression'], 0, atol=1e-14)
     assert_allclose(res['field'].raw_data, 0, atol=1e-13)
+    assert_allclose(res['field_y'].raw_data, 0, atol=1e-13)
+    assert_allclose(res['field_x'].raw_data, 0, atol=1e-13)
 
 
 @pytest.mark.parametrize(
@@ -262,6 +312,8 @@ def test_com_regression_offset(lt_ctx, use_roi, regression):
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
     assert_allclose(res['regression'].data, [[-2, 1], [0, 0], [0, 0]], atol=1e-14)
     assert_allclose(res['field'].raw_data, 0, atol=1e-13)
+    assert_allclose(res['field_y'].raw_data, 0, atol=1e-13)
+    assert_allclose(res['field_x'].raw_data, 0, atol=1e-13)
 
 
 @pytest.mark.parametrize(
@@ -285,6 +337,8 @@ def test_com_regression_linear(lt_ctx, use_roi, regression):
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
     assert_allclose(res['regression'].data, [[-2, 42], [2, 0], [0, -1]], atol=1e-14)
     assert_allclose(res['field'].raw_data, 0, atol=1e-12)
+    assert_allclose(res['field_y'].raw_data, 0, atol=1e-12)
+    assert_allclose(res['field_x'].raw_data, 0, atol=1e-12)
 
 
 @pytest.mark.parametrize(
@@ -310,6 +364,8 @@ def test_com_regression_linear_2(lt_ctx, use_roi, regression):
     res = lt_ctx.run_udf(dataset=ds, udf=udf, roi=roi)
     assert_allclose(res['regression'].data, [[-2, 1], [2, 1], [3, 4]], atol=1e-14)
     assert_allclose(res['field'].raw_data, 0, atol=1e-12)
+    assert_allclose(res['field_y'].raw_data, 0, atol=1e-12)
+    assert_allclose(res['field_x'].raw_data, 0, atol=1e-12)
 
 
 def test_invalid_regression_val(lt_ctx, npy_8x8x8x8_ds):


### PR DESCRIPTION
This is only a small change in the :class:`~libertem.udf.com.CoMUDF` class. It exposes the y- and x-components of the `field` result. The reason is so that they are more easy to plot and access, which is already shown to be useful in cases where the other results do not give good information. For example in my case where the entire dataset is magnetized with same magnitude, but different orientation.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code