### PR TITLE
Fix #1612 - wrong MIME type for .js files

### DIFF
--- a/docs/source/changelog/bugfix/windows-js-mimetype.rst
+++ b/docs/source/changelog/bugfix/windows-js-mimetype.rst
@@ -1,0 +1,4 @@
+[Bugfix] Manually add MIME type for javascript on Windows
+=========================================================
+
+* This is needed to fix setups with an invalid registry entry (:issue:`1612` :pr:`1613`).

--- a/src/libertem/web/cli.py
+++ b/src/libertem/web/cli.py
@@ -66,6 +66,12 @@ def main(port, local_directory, browser, cpus, gpus, open_ds, log_level,
     if (open_ds and platform.system() == 'Windows' and open_ds[-1] == '"'
             and not os.path.exists(open_ds) and os.path.exists(open_ds[:-1])):
         open_ds = open_ds[:-1]
+    # Mitigation for https://github.com/python/cpython/issues/88141
+    if platform.system() == 'Windows':
+        # Replace the mimetype for .js, as there can be potentially broken
+        # entries in the windows registry:
+        import mimetypes
+        mimetypes.add_type('application/javascript', '.js', strict=True)
     is_custom_port = port is not None
     if port is None:
         port = 9000


### PR DESCRIPTION
Fixes #1612. To reproduce this: 

- Set `HKEY_CLASSES_ROOT\.js\Content Type` to `text/plain` instead of `application/javascript`
- Install LiberTEM without this PR
- Start `libertem-server`
- Note that chrome/firefox give you an error message in the developer tools console, and that the `.js` file is transferred as `text/plain` (see network tab, possibly needs a reload), and that the GUI does not load
- After applying this PR, and restarting `libertem-server`, the GUI should load properly
- Restore the registry key to the proper value

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
