### PR TITLE
Adjust event loop on Windows when launching libertem-server

### DIFF
--- a/src/libertem/web/server.py
+++ b/src/libertem/web/server.py
@@ -22,6 +22,7 @@ import tornado.ioloop
 import tornado.escape
 from tornado import httputil
 
+from ..common.async_utils import adjust_event_loop_policy
 from .shutdown import ShutdownHandler
 from .state import SharedState, ExecutorState
 from .config import ConfigHandler, ClusterDetailHandler
@@ -221,6 +222,7 @@ def run(
         format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
     )
 
+    adjust_event_loop_policy()
     loop = asyncio.get_event_loop()
 
     # shared state:


### PR DESCRIPTION
Closes #1616 

Seems like the web server also needs coaxing into using `WindowsSelectorEventLoopPolicy`. Without this change we had a `ProactorEventLoop` despite the `Selector` policy being returned from `asyncio.get_event_loop_policy()` (??).

Probably needs more thought later, but if you can check on your Windows 11 machine @uellue we could merge as a quick fix? I've checked this now works on Windows 10, Windows Server 2016 and a Ubuntu Server 20.

This was not caught by the smoke `test_cli.py` case because it only checks for a synchronous `log.info`, we could make it actually `curl` the server address to check if we actually get a response!


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code
