### PR TITLE
Fixup for malformed EMPAD data

### DIFF
--- a/docs/source/changelog/bugfix/empad-scan-params.rst
+++ b/docs/source/changelog/bugfix/empad-scan-params.rst
@@ -1,0 +1,7 @@
+[Bugfix] Fix loading of malformed EMPAD data
+============================================
+
+* For some data sets, the actual raw data acquired corresponds to the
+  :code:`mode="search"` scan parameters, and not :code:`mode="acquire"`. This
+  is probably a bug in the acquisition software, but we want to be able to load
+  these files anyways (:issue:`1617`, :pr:`1620`).

--- a/tests/io/datasets/test_empad.py
+++ b/tests/io/datasets/test_empad.py
@@ -29,6 +29,9 @@ EMPAD_XML_SERIES = os.path.join(EMPAD_TESTDATA_PATH, 'acquisition_series_pretty.
 EMPAD_XML_BROKEN_PARAMS = os.path.join(
     EMPAD_TESTDATA_PATH, 'Magical_DataSet/acquisition_1/acquisition_1.xml',
 )
+EMPAD_XML_BROKEN_PARAMS_BAD = os.path.join(
+    EMPAD_TESTDATA_PATH, 'Magical_DataSet/acquisition_1/acquisition_1_bad.xml',
+)
 HAVE_EMPAD_TESTDATA = os.path.exists(EMPAD_RAW) and os.path.exists(EMPAD_XML)
 
 pytestmark = pytest.mark.skipif(not HAVE_EMPAD_TESTDATA, reason="need EMPAD testdata")  # NOQA
@@ -83,6 +86,13 @@ def test_new_empad_xml(lt_ctx):
 def test_empad_broken_scan_parameters(lt_ctx):
     ds = lt_ctx.load("empad", path=EMPAD_XML_BROKEN_PARAMS)
     assert ds.shape.to_tuple() == (128, 16, 128, 128)
+
+
+def test_empad_broken_scan_parameters_bad(lt_ctx):
+    with pytest.raises(ValueError) as excinfo:
+        lt_ctx.load("empad", path=EMPAD_XML_BROKEN_PARAMS_BAD)
+    assert "(128, 17)" in str(excinfo.value)
+    assert "(256, 256)" in str(excinfo.value)
 
 
 def test_series_acquisition_xml():

--- a/tests/io/datasets/test_empad.py
+++ b/tests/io/datasets/test_empad.py
@@ -26,6 +26,9 @@ EMPAD_RAW = os.path.join(EMPAD_TESTDATA_PATH, 'scan_11_x4_y4.raw')
 EMPAD_XML = os.path.join(EMPAD_TESTDATA_PATH, 'acquisition_12_pretty.xml')
 EMPAD_XML_2 = os.path.join(EMPAD_TESTDATA_PATH, 'acquisition_12_pretty.xml')
 EMPAD_XML_SERIES = os.path.join(EMPAD_TESTDATA_PATH, 'acquisition_series_pretty.xml')
+EMPAD_XML_BROKEN_PARAMS = os.path.join(
+    EMPAD_TESTDATA_PATH, 'Magical_DataSet/acquisition_1/acquisition_1.xml',
+)
 HAVE_EMPAD_TESTDATA = os.path.exists(EMPAD_RAW) and os.path.exists(EMPAD_XML)
 
 pytestmark = pytest.mark.skipif(not HAVE_EMPAD_TESTDATA, reason="need EMPAD testdata")  # NOQA
@@ -72,12 +75,14 @@ def default_empad_raw():
     return raw_data[:, :, :128, :]
 
 
-def test_new_empad_xml():
-    executor = InlineJobExecutor()
-    ds = EMPADDataSet(
-        path=EMPAD_XML_2,
-    )
-    ds = ds.initialize(executor)
+def test_new_empad_xml(lt_ctx):
+    ds = lt_ctx.load("empad", path=EMPAD_XML_2)
+    assert ds.shape.to_tuple() == (4, 4, 128, 128)
+
+
+def test_empad_broken_scan_parameters(lt_ctx):
+    ds = lt_ctx.load("empad", path=EMPAD_XML_BROKEN_PARAMS)
+    assert ds.shape.to_tuple() == (128, 16, 128, 128)
 
 
 def test_series_acquisition_xml():


### PR DESCRIPTION
For some EMPAD data sets, the raw file corresponds to the shape of the scan parameters with `mode="search"`, not `mode="acquire"`. That means we were expecting more data than actually available.

Note that this means we are more strict in what we accept, in particular this checks (if we are opening via the XML file) that the raw file is exactly as large as specified in the XML file (one of the two `scan_parameters`). Previously, it was probably possible to have a raw file that is larger than the specified scan in the XML file, and we would have probably accepted that.

Fixes #1617 

@uellue is the `Magical_DataSet` going to stay in our test data, or should we extract an example file?

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
