### PR TITLE
Add `libertem-server` `test_cli.py` GET

### DIFF
--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -37,10 +37,6 @@ async def test_libertem_server_cli_startup(http_client):
         if 'LiberTEM listening on' in line:
             break
 
-    addr = line[line.find("http"):].strip()
-    async with http_client.get(addr, timeout=30.0) as response:
-        assert response.status == 200, "Failed to GET from libertem-server"
-
     async def _debug():
         while True:
             line = await asyncio.wait_for(p.stderr.readline(), 5)
@@ -52,6 +48,10 @@ async def test_libertem_server_cli_startup(http_client):
     debug_task = asyncio.ensure_future(_debug())
 
     try:
+        addr = line[line.find("http"):].strip()
+        async with http_client.get(addr, timeout=30.0) as response:
+            assert response.status == 200, "Failed to GET from libertem-server"
+
         # windows likes to be special, so we just kill the subprocess instead:
         if sys.platform.startswith("win"):
             if p.returncode is None:


### PR DESCRIPTION
Followup to #1618 by checking we get a 200 response to a GET request to `libertem-server`. Basic but is an improvement on no check. Could go further by checking the response content for some likely strings.

I don't know if we'd like to have a shorter timeout? The `http_client` fixture seems to have a default 120 second timeout.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code