### PR TITLE
Ensure liveness of executor for some utility endpoints

### DIFF
--- a/src/libertem/web/browse.py
+++ b/src/libertem/web/browse.py
@@ -19,7 +19,8 @@ class LocalFSBrowseHandler(tornado.web.RequestHandler):
         assert len(path) == 1
         path = path[0].decode("utf8")
         try:
-            listing = await executor.run_function(get_fs_listing, path)
+            with self.state.executor_state.keep_alive():
+                listing = await executor.run_function(get_fs_listing, path)
             msg = Message().directory_listing(
                 **listing
             )


### PR DESCRIPTION
Setting the snooze timeout very low, for example by starting with `libertem-server --snooze-timeout 0.001`, exposes some issues which this commit fixes, namely that the
executor snoozes before `get_fs_listing`/`detect` finish running.

It's not recommended to set the snooze timeout so small, but this change should increase stability in these cases - also possibly useful in cases where a lot of time passes between getting the executor and when the actual function is called, for example when the system is put to sleep, or possibly in case of forward jumps in time (?)

Refs #1576 - lower-level keep-alive would prevent this kind of issue completely.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
