### PR TITLE
Make `get_results` lazy

### DIFF
--- a/docs/source/changelog/features/get_results_improvements.rst
+++ b/docs/source/changelog/features/get_results_improvements.rst
@@ -1,0 +1,7 @@
+[Feature] Consistent access to results
+======================================
+* In case of async iteration over results, we now make sure the merge function
+  is not running concurrently with accessing and using the results. Also, the
+  :meth:`~libertem.udf.base.UDF.get_results` method is called lazily, reducing
+  overheads (:pr:`1632`).
+

--- a/docs/source/udf/advanced.rst
+++ b/docs/source/udf/advanced.rst
@@ -240,6 +240,10 @@ access to a version of the result that is suitable for visualization using
 a :code:`roi` was used, but still allow access to the raw result using
 :attr:`~libertem.common.buffers.BufferWrapper.raw_data` attribute.
 
+Implementations of :meth:`~libertem.udf.base.UDF.get_results` should not
+have side-effects you rely on, as in some situations, it will be called lazily,
+i.e. only when accessing the :code:`buffers` attribute of the results object.
+
 The detailed rules for buffer declarations, :code:`get_result_buffers` and :code:`get_results` are:
 
 1) All buffers are declared in :code:`get_result_buffers`

--- a/docs/source/udf/basic.rst
+++ b/docs/source/udf/basic.rst
@@ -634,6 +634,11 @@ that leads to undefined behavior. In particular, nested or concurrent execution
 of the same UDF objects must be avoided since it modifies the buffers that are
 allocated internally while a UDF is running.
 
+With :meth:`~libertem.api.Context.run_udf_iter`, for performance reasons, the
+:meth:`~libertem.udf.base.UDF.get_results` method will only be called when
+accessing the :code:`.buffers` attribute. Make sure there are no side effects
+that you rely on!
+
 Asynchronous execution
 ----------------------
 
@@ -651,6 +656,11 @@ passing :code:`sync=False` to :meth:`~libertem.api.Context.run_udf_iter` or
 
     # or the version without intermediate results:
     udf_results = await ctx.run_udf(dataset=dataset, udf=udf, sync=False)
+
+Note that, in case you are using the async mode of
+:meth:`~libertem.api.Context.run_udf_iter`, a copy of the results will be
+performed on accessing the :code:`buffers` attribute, to make sure that
+concurrent access does not result in inconsistent views of results.
 
 See the items below for a more comprehensive demonstration and documentation:
 

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -1253,6 +1253,7 @@ class Context:
         backends,
         plots,
         iterate: bool,
+        copy_needed: bool = False,
     ):
         """
         Run the given UDF(s), either returning the final result (when
@@ -1307,6 +1308,7 @@ class Context:
                 corrections=corrections,
                 backends=backends,
                 iterate=(iterate or enable_plotting),
+                copy_needed=iterate and copy_needed,
             )
 
             def _inner():
@@ -1446,6 +1448,7 @@ class Context:
             backends=backends,
             plots=plots,
             iterate=True,
+            copy_needed=True,
         )
 
         async def _run_async_wrap() -> UDFResultDict:

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2811,7 +2811,7 @@ class UDFResultsLazy:
     '''
     Lazy version of :class:`UDFResults`
 
-    .. versionadded:: 0.7.0
+    .. versionadded:: 0.15.0
 
     Parameters
     ----------

--- a/src/libertem/udf/base.py
+++ b/src/libertem/udf/base.py
@@ -2692,7 +2692,6 @@ class UDFRunner:
         def _inner(environment: Environment):
             num_results = 0
             try:
-<<<<<<< HEAD
                 with environment.enter():
                     for part_results, task in result_iter:
                         num_results += 1
@@ -2707,7 +2706,9 @@ class UDFRunner:
                         if iterate:
                             yield self._make_udf_result(
                                 udfs=self._udfs,
-                                damage=damage
+                                damage=damage,
+                                make_copy=copy_needed,
+                                results_lock=self._results_lock,
                             )
                     if num_results == 0 or not iterate:
                         yield self._make_udf_result(

--- a/tests/udf/test_simple_udf.py
+++ b/tests/udf/test_simple_udf.py
@@ -15,6 +15,7 @@ from libertem.common.backend import set_use_cpu, set_use_cuda
 from libertem.common.buffers import reshaped_view
 from libertem.udf.sumsigudf import SumSigUDF
 from libertem.udf.sum import SumUDF
+from libertem.api import Context
 
 from utils import _mk_random, ValidationUDF
 
@@ -855,3 +856,39 @@ def test_copy_roi(lt_ctx):
     assert res['intensity']._roi.sum() == 1
     roi[:] = ds.roi[:, :]
     assert res['intensity']._roi.sum() == 1
+
+
+class GetResultsCalledError(Exception):
+    pass
+
+
+class GetResultsNotCalledUDF(UDF):
+    def get_result_buffers(self):
+        return {}
+
+    def process_frame(self, frame):
+        pass
+
+    def get_results(self):
+        raise GetResultsCalledError("should not be called")
+
+
+def test_lazy_get_results_not_called(lt_ctx: Context, default_raw):
+    results = lt_ctx.run_udf_iter(
+        dataset=default_raw,
+        udf=GetResultsNotCalledUDF()
+    )
+
+    for res in results:
+        pass
+        # if we accessed `res.buffers`, `get_results` would be called and the
+        # `RuntimeError` would be thrown; see below:
+
+    results = lt_ctx.run_udf_iter(
+        dataset=default_raw,
+        udf=GetResultsNotCalledUDF()
+    )
+
+    with pytest.raises(GetResultsCalledError):
+        for res in results:
+            res.buffers

--- a/tests/udf/test_valid_mask.py
+++ b/tests/udf/test_valid_mask.py
@@ -227,7 +227,7 @@ def test_custom_mask_invalid_shape(mask_shape, lt_ctx):
 
     with pytest.raises(InvalidMaskError):
         for res in lt_ctx.run_udf_iter(dataset=dataset, udf=CustomMaskFromParams(mask=mask)):
-            pass
+            res.buffers
 
 
 @pytest.mark.parametrize("mask_dtype", [
@@ -242,7 +242,7 @@ def test_custom_mask_invalid_dtype(mask_dtype, lt_ctx):
 
     with pytest.raises(InvalidMaskError):
         for res in lt_ctx.run_udf_iter(dataset=dataset, udf=CustomMaskFromParams(mask=mask)):
-            pass
+            res.buffers
 
 
 @pytest.mark.parametrize("mask_shape", [
@@ -263,7 +263,7 @@ def test_custom_mask_valid(mask_shape, lt_ctx):
     mask = np.zeros(mask_shape, dtype=bool)
 
     for res in lt_ctx.run_udf_iter(dataset=dataset, udf=CustomMaskFromParams(mask=mask)):
-        pass
+        res.buffers
 
 
 def test_valid_mask_slice_bounding(lt_ctx):


### PR DESCRIPTION
In case `UDF.get_results` does any significant amount of work (like CoM with `regression=1`), it's wasteful to call it for every partial result, especially in the live case, and when using smaller partitions.

With this PR, if the downstream visualization doesn't access the `buffers` attribute on the results object, calling `get_results` is skipped and the overheads should be reduced significantly.

Another aspect is, in case of async iteration, we need to make sure that access to results is happening in a consistent way. This PR introduces a lock that is taken around both `merge` and `get_results` (actually the functions around them, such that we get consistent results across multiple UDFs), and in the async case, a copy is performed such that we don't get a reference to the buffers that will be modified with the next `merge` call.

## TODOs:

- [x] How to make this thread-safe - we need to prevent the delayed `get_results` and the `merge` function from running concurrently on the same data / buffers, basically.
- [x] Needs documentation on how to safely access the results of `run_udf_iter`
- [x] This slightly changes the observed behavior, as seen in the failing test cases. I think this should be OK and the tests and the docs need to be updated, but some input would be welcome! This is mostly an issue if `get_results` has observable side-effects

Fixes #1596

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
