### PR TITLE
Missing File / Bad `DataSet` parameters exception messages

### DIFF
--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -126,9 +126,9 @@ When planning a release, create a new issue with the following checklist:
         * [ ] Use the GUI while a long-running analysis is running
             * [ ] Still usable, decent response times?
     * [ ] Check what happens when trying to open non-existent files by scripting.
-        * [ ] Proper understandable error message? TODO automate?
+        * [ ] Run `pytest -rA tests/io/datasets/test_missing.py` and check output
     * [ ] Check what happens when opening all file types with bad parameters by scripting
-        * [ ] Proper understandable error message? TODO automate?
+        * [ ] Run `pytest -rA tests/io/datasets/ -k "test_bad_params"` and check output
 
     ## Step 3: bump version and let release pipeline run
 

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -365,3 +365,9 @@ def test_compare_backends_sparse(lt_ctx, default_blo, buffered_blo, as_sparse):
     buffered_f0 = lt_ctx.run_udf(dataset=buffered_blo, udf=PickUDF(), roi=roi)['intensity']
 
     assert np.allclose(mm_f0, buffered_f0)
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("blo", BLO_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_dm.py
+++ b/tests/io/datasets/test_dm.py
@@ -507,3 +507,8 @@ def test_load_stack_dd(local_cluster_ctx, dm_stack_glob):
     files = dm_stack_glob
     ds = local_cluster_ctx.load("dm", files=files, same_offset=True)
     ds.check_valid()
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params, dm_3d_glob):
+    for params in standard_bad_ds_params:
+        ds_params_tester("dm", files=dm_3d_glob, **params)

--- a/tests/io/datasets/test_empad.py
+++ b/tests/io/datasets/test_empad.py
@@ -499,3 +499,9 @@ def test_compare_backends_sparse(lt_ctx, default_empad, buffered_empad, as_spars
     buffered_f0 = lt_ctx.run_udf(dataset=buffered_empad, udf=PickUDF(), roi=roi)['intensity']
 
     assert np.allclose(mm_f0, buffered_f0)
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("empad", EMPAD_XML)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_frms6.py
+++ b/tests/io/datasets/test_frms6.py
@@ -631,3 +631,9 @@ def test_compare_backends_sparse(lt_ctx, default_frms6, buffered_frms6, as_spars
     buffered_f0 = lt_ctx.run_udf(dataset=buffered_frms6, udf=PickUDF(), roi=roi)['intensity']
 
     assert np.allclose(mm_f0, buffered_f0)
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("frms6", FRMS6_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -708,3 +708,9 @@ def test_incorrect_sig_shape(lt_ctx):
     assert e.match(
         r"sig_shape must be of size: 3809280"
     )
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("k2is", K2IS_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -596,3 +596,11 @@ def test_run_many_files(lt_ctx):
     hdr_path = out_dir / 'w_140 h_139-2map.hdr'
     nav_shape = (139, 141)
     lt_ctx.load('mib', path=hdr_path, nav_shape=nav_shape)
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("mib", MIB_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        if 'nav_shape' not in params:
+            params['nav_shape'] = (1, 1)
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_missing.py
+++ b/tests/io/datasets/test_missing.py
@@ -1,0 +1,32 @@
+import inspect
+import pytest
+
+
+from libertem.io.dataset import filetypes, get_dataset_cls
+
+
+@pytest.mark.parametrize(
+    "ds_key", tuple(filetypes.keys())
+)
+def test_missing(lt_ctx, ds_key):
+    ds_class = get_dataset_cls(ds_key)
+    classname = ds_class.__name__
+    params = inspect.signature(ds_class.__init__).parameters
+    for extension in ds_class.get_supported_extensions():
+        filename = f"not_a_file.{extension}"
+        with pytest.raises(Exception) as e:
+            lt_ctx.load(
+                ds_key, filename,
+            )
+        e_msg = str(e.value)
+
+        print(f'{classname} + {filename} => {e.typename}("{e_msg}")')
+
+        if "nav_shape" in e_msg and "nav_shape" in params:
+            nav_shape = (8, 8)
+            with pytest.raises(Exception) as e:
+                lt_ctx.load(
+                    ds_key, filename, nav_shape=nav_shape
+                )
+            e_msg = str(e.value)
+            print(f'{classname} + {filename} + nav_shape={nav_shape} => {e.typename}("{e_msg}")')

--- a/tests/io/datasets/test_mrc.py
+++ b/tests/io/datasets/test_mrc.py
@@ -260,3 +260,9 @@ def test_scheme_too_large(default_mrc):
 
 def test_diagnostics(default_mrc):
     assert {"name": "dtype", "value": "float32"} in default_mrc.get_diagnostics()
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("mrc", MRC_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_npy.py
+++ b/tests/io/datasets/test_npy.py
@@ -465,3 +465,9 @@ def test_correction_default(default_npy, lt_ctx, with_roi):
 
 def test_diagnostics(default_npy):
     assert {"name": "dtype", "value": "float32"} in default_npy.get_diagnostics()
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params, default_npy):
+    args = ("npy", default_npy._path)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_raw.py
+++ b/tests/io/datasets/test_raw.py
@@ -869,3 +869,14 @@ def test_compare_backends_sparse(lt_ctx, default_raw, buffered_raw, as_sparse):
 
 def test_diagnostics(default_raw):
     assert {"name": "dtype", "value": "float32"} in default_raw.get_diagnostics()
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params, raw_dataset_8x8x8x8):
+    args = ("raw", raw_dataset_8x8x8x8._path)
+    for params in standard_bad_ds_params:
+        params['dtype'] = raw_dataset_8x8x8x8.meta.raw_dtype
+        if 'nav_shape' not in params:
+            params['nav_shape'] = raw_dataset_8x8x8x8.meta.shape.nav
+        if 'sig_shape' not in params:
+            params['sig_shape'] = raw_dataset_8x8x8x8.meta.shape.sig
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -834,3 +834,11 @@ def test_scheme_too_large(default_seq):
     assert tuple(t.tile_slice.shape) == tuple((depth,) + default_seq.shape.sig)
     for _ in tiles:
         pass
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("seq", SEQ_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        if "nav_shape" not in params:
+            params['nav_shape'] = (8, 8)
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -401,3 +401,9 @@ def test_scheme_too_large(default_ser):
     tiles = p.get_tiles(tiling_scheme=tiling_scheme)
     t = next(tiles)
     assert tuple(t.tile_slice.shape)[0] <= depth
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("ser", SER_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)

--- a/tests/io/datasets/test_tvips.py
+++ b/tests/io/datasets/test_tvips.py
@@ -456,3 +456,9 @@ def test_compare_backends_sparse(lt_ctx, default_tvips, buffered_tvips, as_spars
     buffered_f0 = lt_ctx.run_udf(dataset=buffered_tvips, udf=PickUDF(), roi=roi)['intensity']
 
     assert np.allclose(mm_f0, buffered_f0)
+
+
+def test_bad_params(ds_params_tester, standard_bad_ds_params):
+    args = ("tvips", TVIPS_TESTDATA_PATH)
+    for params in standard_bad_ds_params:
+        ds_params_tester(*args, **params)


### PR DESCRIPTION
Adds test cases to display a range of error messages from datasets when supplied with bad parameters. Responds to this comment https://github.com/LiberTEM/LiberTEM/pull/1625#pullrequestreview-2024548062

The bad parameter tests don't actually assert that exceptions are or are not raised, the simply store and echo the output for a human to verify (as they would do with the release checklist). The output can be generated with something like:
```
pytest -rA tests/io/datasets/test_missing.py
```
for missing files, and:
```
pytest -rA tests/io/datasets/ -k "test_bad_params"
```
for bad params.

As a result these tests could essentially be marked as "release tests" and only run manually when needed with the "-rA" option.

There is some `pytest` abuse involved, namely the interception of exceptions so that I can "successfully" report if there was an error or not, and also accumulating log messages into a fixture which gets emitted at teardown. The good news is that each dataset can define its own sets of bad params to test, but the majority of the cases are a re-used fixture.

The outputs are like the following - I think the display of the bad params log can be easily improved with a bit of accumulation:

```
==================================================================================================== PASSES =====================================================================================================
______________________________________________________________________________________________ test_missing[hdf5] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
H5DataSet + not_a_file.nxs => FileNotFoundError("[Errno 2] Unable to open file (unable to open file: name = 'not_a_file.nxs', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)")
H5DataSet + not_a_file.hspy => FileNotFoundError("[Errno 2] Unable to open file (unable to open file: name = 'not_a_file.hspy', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)")
H5DataSet + not_a_file.h5 => FileNotFoundError("[Errno 2] Unable to open file (unable to open file: name = 'not_a_file.h5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)")
H5DataSet + not_a_file.hdf5 => FileNotFoundError("[Errno 2] Unable to open file (unable to open file: name = 'not_a_file.hdf5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)")
_____________________________________________________________________________________________ test_missing[raw_csr] _____________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
RawCSRDataSet + not_a_file.toml => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.toml'")
_______________________________________________________________________________________________ test_missing[mib] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
MIBDataSet + not_a_file.hdr => DataSetException("no files found")
MIBDataSet + not_a_file.mib => ValueError("either nav_shape needs to be passed, or path needs to point to a .hdr file")
MIBDataSet + not_a_file.mib + nav_shape=(8, 8) => DataSetException("no files found")
_______________________________________________________________________________________________ test_missing[blo] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
BloDataSet + not_a_file.blo => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.blo'")
______________________________________________________________________________________________ test_missing[k2is] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
K2ISDataSet + not_a_file.gtg => DataSetException("expected 8 files at not_a_file*.bin, found 0")
K2ISDataSet + not_a_file.bin => DataSetException("expected 8 files at not_a_file*.bin, found 0")
_______________________________________________________________________________________________ test_missing[ser] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
SERDataSet + not_a_file.ser => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.ser'")
______________________________________________________________________________________________ test_missing[frms6] ______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
FRMS6DataSet + not_a_file.frms6 => DataSetException("Could not find .hdr file not_a_file.hdr")
FRMS6DataSet + not_a_file.hdr => DataSetException("Could not find .hdr file not_a_file.hdr")
______________________________________________________________________________________________ test_missing[empad] ______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
EMPADDataSet + not_a_file.xml => DataSetException("could not initialize EMPAD file; error: [Errno 2] No such file or directory: 'not_a_file.xml'")
EMPADDataSet + not_a_file.raw => DataSetException("need to set or detect nav_shape!")
EMPADDataSet + not_a_file.raw + nav_shape=(8, 8) => DataSetException("could not open file not_a_file.raw: [Errno 2] No such file or directory: 'not_a_file.raw'")
_______________________________________________________________________________________________ test_missing[dm] ________________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
DMDataSet + not_a_file.dm4 => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.dm4'")
DMDataSet + not_a_file.dm3 => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.dm3'")
_______________________________________________________________________________________________ test_missing[seq] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
SEQDataSet + not_a_file.seq => TypeError("missing 1 required argument: 'nav_shape'")
SEQDataSet + not_a_file.seq + nav_shape=(8, 8) => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.seq'")
_______________________________________________________________________________________________ test_missing[mrc] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
MRCDataSet + not_a_file.mrc => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.mrc'")
______________________________________________________________________________________________ test_missing[tvips] ______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
TVIPSDataSet + not_a_file.tvips => IndexError("list index out of range")
_______________________________________________________________________________________________ test_missing[npy] _______________________________________________________________________________________________
--------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------
NPYDataSet + not_a_file.npy => FileNotFoundError("[Errno 2] No such file or directory: 'not_a_file.npy'")
```

and

```
BloDataSet(..., nav_shape=(-1, 2))
  DID NOT raise
BloDataSet(..., nav_shape=4)
  RAISED TypeError("'int' object is not iterable")
BloDataSet(..., sig_shape=(3, 17))
  RAISED DataSetException("sig_shape must be of size: 20736")
BloDataSet(..., sig_shape=(103, -83))
  RAISED DataSetException("sig_shape must be of size: 20736")
BloDataSet(..., sync_offset=180000000)
  RAISED DataSetException("sync_offset should be in (-10890, 10890), which is (-image_count, image_count)")
BloDataSet(..., io_backend="doesn't exist")
  DID NOT raise
DMDataSet(..., files=['/storage/er-c-..., nav_shape=(-1, 2))
  DID NOT raise
DMDataSet(..., files=['/storage/er-c-..., nav_shape=4)
  RAISED TypeError("'int' object is not iterable")
DMDataSet(..., files=['/storage/er-c-..., sig_shape=(3, 17))
  RAISED DataSetException("sig_shape must be of size: 14238980")
DMDataSet(..., files=['/storage/er-c-..., sig_shape=(103, -83))
  RAISED DataSetException("sig_shape must be of size: 14238980")
DMDataSet(..., files=['/storage/er-c-..., sync_offset=180000000)
  RAISED DataSetException("sync_offset should be in (-40, 40), which is (-image_count, image_count)")
DMDataSet(..., files=['/storage/er-c-..., io_backend="doesn't exist")
  DID NOT raise
EMPADDataSet(..., nav_shape=(-1, 2))
  DID NOT raise
EMPADDataSet(..., nav_shape=4)
  RAISED TypeError("'int' object is not iterable")
EMPADDataSet(..., sig_shape=(3, 17))
  RAISED DataSetException("sig_shape must be of size: 16384")
....
```

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code