### PR TITLE
scripts/release: use `packaging` instead of `pkg_resources`

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -11,8 +11,10 @@ import contextlib
 from os.path import join
 
 from github import Github, UnknownObjectException
-from pkg_resources import parse_version
-from pkg_resources.extern.packaging.version import LegacyVersion
+from packaging.version import (
+    parse as parse_version,
+    InvalidVersion,
+)
 import click
 import requests
 
@@ -143,16 +145,21 @@ def validate_version_tag():
         raise click.ClickException(
             "version tags need to have a 'v' prefix"
         )
-    v = parse_version(version_tag['full'])
-    if isinstance(v, LegacyVersion):
+    try:
+        v = parse_version(version_tag['full'])
+    except InvalidVersion as e:
         raise click.ClickException(
-            "The version tag %s could not be parsed as valid version" % v
+            f"The version tag {version_tag['full']} could not be parsed "
+            f"as valid version: {e}"
         )
 
-    version_from_file = parse_version(read_version(get_version_fn()))
-    if isinstance(version_from_file, LegacyVersion):
+    raw_version = read_version(get_version_fn())
+    try:
+        version_from_file = parse_version(raw_version)
+    except InvalidVersion as e:
         raise click.ClickException(
-            "__version__ %s could not be parsed as valid version" % version_from_file
+                f"__version__ {raw_version} could not be parsed "
+                f"as valid version: {e}"
         )
     if version_from_file != v:
         raise click.ClickException(

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,3 +8,4 @@ html5lib
 docutils
 bibtexparser
 ghp-import
+packaging


### PR DESCRIPTION
`pkg_resources` is deprecated, so we use the versioning utilities from `packaging` instead.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
