### PR TITLE
Make zenodo upload verbose

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -328,6 +328,7 @@ def upload_to_zenodo(verbose, parent, token):
     with get_archive(tag) as repo_archive:
         out = subprocess.check_output([
             "python", join(HERE, "zenodo_upload"),
+            "-v",
             "--url=%s" % url,
             "--parent=%s" % parent,
             "--mask-zenodo-exception",


### PR DESCRIPTION
As it was often flaky in the past, we might be able to better debug it with the verbose log output.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
