### PR TITLE
Fix compatibility with numpy>=2.0.0

### DIFF
--- a/docs/source/changelog/features/numpy2.rst
+++ b/docs/source/changelog/features/numpy2.rst
@@ -1,0 +1,6 @@
+[Feature] numpy 2 compatibility
+===============================
+
+* Support for numpy 2.x. Note that some examples may not yet run, as the
+  dependencies might not be numpy 2 compatible. For these cases, please
+  downgrade to :code:`numpy<2` (:pr:`1656`, :issue:`1653`).

--- a/src/libertem/io/dataset/base/decode.py
+++ b/src/libertem/io/dataset/base/decode.py
@@ -14,8 +14,8 @@ def byteswap_2_straight(inp, out):
 @numba.njit(inline='always', cache=True)
 def byteswap_2_decode(inp, out):
     for i in range(inp.shape[0] // 2):
-        o0 = inp[i * 2 + 0] << 8
-        o1 = inp[i * 2 + 1] << 0
+        o0 = np.uint16(inp[i * 2 + 0]) << 8
+        o1 = np.uint16(inp[i * 2 + 1]) << 0
         out[i] = o0 | o1
 
 
@@ -31,10 +31,10 @@ def byteswap_4_straight(inp, out):
 @numba.njit(inline='always', cache=True)
 def byteswap_4_decode(inp, out):
     for i in range(inp.shape[0] // 4):
-        o0 = inp[i * 4 + 0] << 24
-        o1 = inp[i * 4 + 1] << 16
-        o2 = inp[i * 4 + 2] << 8
-        o3 = inp[i * 4 + 3] << 0
+        o0 = np.uint32(inp[i * 4 + 0]) << 24
+        o1 = np.uint32(inp[i * 4 + 1]) << 16
+        o2 = np.uint32(inp[i * 4 + 2]) << 8
+        o3 = np.uint32(inp[i * 4 + 3]) << 0
         out[i] = o0 + o1 + o2 + o3
 
 

--- a/src/libertem/io/dataset/base/decode.py
+++ b/src/libertem/io/dataset/base/decode.py
@@ -54,14 +54,14 @@ def byteswap_8_straight(inp, out):
 @numba.njit(inline='always', cache=True)
 def byteswap_8_decode(inp, out):
     for i in range(inp.shape[0] // 8):
-        o0 = inp[i * 8 + 0] << 56
-        o1 = inp[i * 8 + 1] << 48
-        o2 = inp[i * 8 + 2] << 40
-        o3 = inp[i * 8 + 3] << 32
-        o4 = inp[i * 8 + 4] << 24
-        o5 = inp[i * 8 + 5] << 16
-        o6 = inp[i * 8 + 6] << 8
-        o7 = inp[i * 8 + 7] << 0
+        o0 = np.uint64(inp[i * 8 + 0]) << 56
+        o1 = np.uint64(inp[i * 8 + 1]) << 48
+        o2 = np.uint64(inp[i * 8 + 2]) << 40
+        o3 = np.uint64(inp[i * 8 + 3]) << 32
+        o4 = np.uint64(inp[i * 8 + 4]) << 24
+        o5 = np.uint64(inp[i * 8 + 5]) << 16
+        o6 = np.uint64(inp[i * 8 + 6]) << 8
+        o7 = np.uint64(inp[i * 8 + 7]) << 0
         out[i] = o0 + o1 + o2 + o3 + o4 + o5 + o6 + o7
 
 

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -314,7 +314,7 @@ class StackedDMDataSet(DMDataSet):
                 fn: metadata[fn]['zsize']
                 for fn in self._get_files()
             }
-        self._image_count = sum(self._z_sizes.values())
+        self._image_count = int(sum(self._z_sizes.values()))
         if self._nav_shape is None:
             self._nav_shape = (sum(self._z_sizes.values()),)
         native_sig_shape, native_dtype = executor.run_function(self._get_sig_shape_and_native_dtype)

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -167,8 +167,8 @@ def encode_u2(inp, out):
         row_in = inp[y]
         for i in range(row_in.shape[0]):
             in_value = row_in[i]
-            row_out[i * 2] = (0xFF00 & in_value) >> 8
-            row_out[i * 2 + 1] = 0xFF & in_value
+            row_out[i * 2] = (0xFF00 & np.uint16(in_value)) >> 8
+            row_out[i * 2 + 1] = 0xFF & np.uint16(in_value)
 
 
 @numba.njit(cache=True)
@@ -181,7 +181,7 @@ def encode_r1(inp, out):
                 out_byte = 0
                 for bitpos in range(8):
                     value = row_in[64 * stripe + 8 * byte + bitpos] & 1
-                    out_byte |= (value << bitpos)
+                    out_byte |= (np.uint64(value) << bitpos)
                 row_out[(stripe + 1) * 8 - (byte + 1)] = out_byte
 
 
@@ -636,7 +636,7 @@ def decode_r12_swap(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
         col = i % 4
         pos = i // 4
         out_pos = (pos + 1) * 4 - col - 1
-        out[idx, out_pos] = (inp[i * 2] << 8) + (inp[i * 2 + 1] << 0)
+        out[idx, out_pos] = (np.uint16(inp[i * 2]) << 8) + (np.uint16(inp[i * 2 + 1]) << 0)
 
 
 @numba.njit(inline='always', cache=True)
@@ -655,7 +655,7 @@ def decode_r24_swap(inp, out, idx, native_dtype, rr, origin, shape, ds_shape):
         col = i % 4
         pos = i // 4
         out_pos = (pos + 1) * 4 - col - 1
-        out_val = np.uint32((inp[i * 2] << 8) + (inp[i * 2 + 1] << 0))
+        out_val = np.uint32((np.uint32(inp[i * 2]) << 8) + (np.uint32(inp[i * 2 + 1]) << 0))
         if idx % 2 == 0:  # from first frame: most significant bits
             out_val = out_val << 12
         out[idx // 2, out_pos] += out_val

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -578,14 +578,16 @@ def decode_r12_swap_2x2(inp, out, idx, native_dtype, rr, origin, shape, ds_shape
             col = i % 4
             pos = i // 4
             out_pos = (pos + 1) * 4 - col - 1
-            out_cut[out_pos] = (inp[i * 2] << 8) + (inp[i * 2 + 1] << 0)
+            out_cut[out_pos] = (np.uint16(inp[i * 2]) << 8) + (inp[i * 2 + 1] << 0)
     else:
         # flip in x direction:
         for i in range(out_cut.shape[0]):
             col = i % 4
             pos = i // 4
             out_pos = (pos + 1) * 4 - col - 1
-            out_cut[out_cut.shape[0] - out_pos - 1] = (inp[i * 2] << 8) + (inp[i * 2 + 1] << 0)
+            out_cut[out_cut.shape[0] - out_pos - 1] = (
+                (np.uint16(inp[i * 2]) << 8) + (inp[i * 2 + 1] << 0)
+            )
 
     # reference non-quad impl:
     # for i in range(out.shape[1]):

--- a/src/libertem/io/dataset/npy.py
+++ b/src/libertem/io/dataset/npy.py
@@ -6,7 +6,7 @@ from typing import Optional
 import logging
 
 import numpy as np
-from numpy.lib.utils import safe_eval
+from ast import literal_eval
 from numpy.lib.format import read_magic
 from numpy.compat import long, asstr
 from libertem.common.messageconverter import MessageConverter
@@ -128,7 +128,7 @@ def _read_array_header(fp, version):
     #   "descr" : dtype.descr
     header = _filter_header(header)
     try:
-        d = safe_eval(header)
+        d = literal_eval(header)
     except SyntaxError as e:
         msg = "Cannot parse header: %r\nException: %r"
         raise ValueError(msg % (header, e))

--- a/src/libertem/udf/masks.py
+++ b/src/libertem/udf/masks.py
@@ -235,13 +235,14 @@ class ApplyMasksUDF(UDF):
     or a per-frame shift supplied using an :class:`~libertem.common.buffers.AuxBufferWrapper`
     created using :meth:`~libertem.udf.base.UDF.aux_data`:
 
+    >>> shifts = np.random.randint(-8, 8, size=(16, 16, 2)).ravel()
     >>> udf = ApplyMasksUDF(
     ...         mask_factories=my_masks,
     ...         shifts=ApplyMasksUDF.aux_data(
-    ...             np.random.randint(-8, 8, size=(16, 16, 2)).ravel(),
+    ...             shifts,
     ...             kind='nav',
     ...             extra_shape=(2,),
-    ...             dtype=int,
+    ...             dtype=shifts.dtype,
     ...         )
     ...     )
     >>> res_shift_aux = ctx.run_udf(dataset=dataset, udf=udf)['intensity']

--- a/tests/common/test_bufferwrapper.py
+++ b/tests/common/test_bufferwrapper.py
@@ -32,7 +32,7 @@ def test_new_for_partition():
         ps = partition.slice.get(nav_only=True)
         roi_part = roi.reshape(-1)[ps]
 
-        assert np.product(new_buf._data.shape) == roi_part.sum()
+        assert np.prod(new_buf._data.shape) == roi_part.sum()
 
         # old buffer stays the same:
         assert np.allclose(buf._data, auxdata.reshape(-1))

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -19,8 +19,12 @@ from libertem.udf.raw import PickUDF
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    import rsciio
-    import rsciio.blockfile
+    # FIXME: rsciio/pint is not numpy2 compatible yet
+    if int(np.version.version.split('.')[0]) < 2:
+        import rsciio
+        import rsciio.blockfile
+    else:
+        rsciio = None
 except ModuleNotFoundError:
     rsciio = None
 

--- a/tests/io/datasets/test_dm.py
+++ b/tests/io/datasets/test_dm.py
@@ -18,7 +18,11 @@ from libertem.io.dataset.base import (
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    import hyperspy.api as hs
+    # FIXME: rsciio/pint is not numpy2 compatible yet
+    if int(np.version.version.split('.')[0]) < 2:
+        import hyperspy.api as hs
+    else:
+        hs = None
 except ModuleNotFoundError:
     hs = None
 

--- a/tests/io/datasets/test_k2is_uint12.py
+++ b/tests/io/datasets/test_k2is_uint12.py
@@ -3,14 +3,35 @@ import math
 import pytest
 import numpy as np
 import numba
+from numpy.testing import assert_allclose
 
 from libertem.io.dataset.k2is import decode_uint12_le
+
+
+def test_foo():
+    inp = np.zeros(2, dtype=np.uint16)
+    inp[0] = 0xABC
+    inp[1] = 0xDEF
+    out = np.zeros(int(math.ceil(len(inp) * 12 / 8)), dtype=np.uint8)
+    print(list(map(hex, inp)))
+    encode_uint12_alt(inp, out)
+    print(list(map(hex, out)))
+    assert_allclose(out, np.array([0xbc, 0xfa, 0xde]))
 
 
 @numba.njit
 def decode_uint12_le_ref(inp, out):
     """
-    decode bytes from bytestring ``inp`` as 12 bit into ``out``
+    Decode bytes from bytestring ``inp`` as 12 bit into ``out``
+
+    The mapping looks like this (where a_i and b_i are nibbles):
+
+    Input (12bit "packed" integers)
+    |a_2|a_3|b_3|a_1|b_1|b_2|
+
+    Output (16bit integers):
+    |0_0|a_1|a_2|a_3|0_0|b_1|b_2|b_3|
+
     """
     o = 0
     for i in range(0, len(inp), 3):
@@ -22,105 +43,28 @@ def decode_uint12_le_ref(inp, out):
         o += 2
 
 
-def encode_12_little_little(inp, out):
-    bytebits = 8
-    bits = 12
-    out = out.view(np.uint8)
-    encoded_type = np.dtype('<u4')
-    decoded_words = len(inp)
-    assert len(out)*bytebits >= decoded_words*bits
+def encode_uint12_alt(inp, out):
+    """
+    Encode 12bit values from uint16 `inp` into a uint8 array `out`.
 
-    encoded_bytes = encoded_type.itemsize
+    Input (16bit integers):
+    |0_0|a_1|a_2|a_3|0_0|b_1|b_2|b_3|
 
-    # how many words of encoded_type an encoded block
-    encoded_stride = 3
-    # how many words of "bits" bits in an encoded block
-    decoded_stride = 8
+    Output (12bit "packed" integers)
+    |a_2|a_3|b_3|a_1|b_1|b_2|
+    """
+    o = 0
+    for i in range(0, len(inp), 2):
+        # two input values, truncated to 12 bit:
+        a = inp[i] & 0xFFF
+        b = inp[i + 1] & 0xFFF
 
-    mask = 0xfff
+        j = o
+        out[j] = a & 0x0FF
+        out[j + 1] = (a & 0xF00) >> 8 | ((b & 0x00F) << 4)
+        out[j + 2] = (b & 0xFF0) >> 4
 
-    # How many blocks are encoded in one loop
-    middle_loops = 8
-    # How many decoded words processed in one middle loop
-    middle_decoded_words = middle_loops * decoded_stride
-    middle_encoded_words = middle_loops * encoded_stride
-    middle_encoded_bytes = middle_encoded_words * encoded_bytes
-
-    blocks = decoded_words // middle_decoded_words
-
-    rest = decoded_words % middle_decoded_words
-
-    def decoded_start_index(block):
-        return block*middle_decoded_words
-
-    def encoded_start_index(block):
-        return block*middle_encoded_words
-
-    def decoded_loopbuffer_index(middle):
-        return middle*decoded_stride
-
-    def encoded_loopbuffer_index(middle):
-        return middle*encoded_stride
-
-    def char_start_index(block):
-        return block*middle_encoded_words*encoded_bytes
-
-    def encode_pair(k, m):
-        a = np.uint8(k & 0xff)
-        b = np.uint8(((k & 0xf00) >> 8) | ((m & 0xf) << 4))
-        c = np.uint8((m & 0xff0) >> 4)
-        return (a, b, c)
-
-    loopbuffer_in = np.zeros(middle_decoded_words, dtype=inp.dtype)
-    loopbuffer_out = np.zeros(middle_encoded_words, dtype=encoded_type)
-    loopbuffer_out_chars = loopbuffer_out.view(np.uint8)
-
-    for block in range(blocks):
-        decoded_start = decoded_start_index(block)
-        for i in range(middle_decoded_words):
-            loopbuffer_in[i] = inp[decoded_start + i]
-
-        for middle in range(middle_loops):
-            decoded_base = decoded_loopbuffer_index(middle)
-            encoded_base = encoded_loopbuffer_index(middle)
-            loopbuffer_out[encoded_base + 0] = (
-                (loopbuffer_in[decoded_base + 0] & mask)
-                | ((loopbuffer_in[decoded_base + 1] & mask) << 12)
-                | ((loopbuffer_in[decoded_base + 2] & mask) << 24)
-            )
-
-            loopbuffer_out[encoded_base + 1] = (
-                ((loopbuffer_in[decoded_base + 2] & mask) >> 8)
-                | ((loopbuffer_in[decoded_base + 3] & mask) << 4)
-                | ((loopbuffer_in[decoded_base + 4] & mask) << 16)
-                | ((loopbuffer_in[decoded_base + 5] & mask) << 28)
-            )
-
-            loopbuffer_out[encoded_base + 2] = (
-                ((loopbuffer_in[decoded_base + 5] & mask) >> 4)
-                | ((loopbuffer_in[decoded_base + 6] & mask) << 8)
-                | ((loopbuffer_in[decoded_base + 7] & mask) << 20)
-            )
-        char_start = char_start_index(block)
-        for i in range(middle_encoded_bytes):
-            out[char_start + i] = loopbuffer_out_chars[i]
-    decoded_remainder_offset = decoded_start_index(blocks)
-    encoded_remainder_offset = char_start_index(blocks)
-    if (rest > 1):
-        for r in range(0, rest - 1, 2):
-            k = inp[decoded_remainder_offset + r]
-            m = inp[decoded_remainder_offset + r + 1]
-            (a, b, c) = encode_pair(k, m)
-            out[encoded_remainder_offset] = a
-            out[encoded_remainder_offset + 1] = b
-            out[encoded_remainder_offset + 2] = c
-            encoded_remainder_offset += 3
-    if (rest % 2):
-        k = inp[decoded_remainder_offset + rest - 1]
-        m = 0
-        (a, b, c) = encode_pair(k, m)
-        out[encoded_remainder_offset] = a
-        out[encoded_remainder_offset + 1] = b
+        o += 3
 
 
 @pytest.mark.with_numba
@@ -131,12 +75,12 @@ def test_encode_decode_uint12_ref():
     result = np.zeros(int(math.ceil(len(out) * 2 / 3)), dtype=np.uint16)
 
     print(list(map(hex, inp)))
-    encode_12_little_little(inp, out)
+    encode_uint12_alt(inp, out)
 
     print(list(map(hex, out.view(np.uint8))))
     decode_uint12_le_ref(inp=out, out=result)
 
-    assert np.allclose(inp, result)
+    assert_allclose(inp, result)
 
 
 @pytest.mark.with_numba
@@ -149,11 +93,11 @@ def test_encode_decode_uint12():
 
     print(list(map(hex, inp)))
 
-    encode_12_little_little(inp, out)
+    encode_uint12_alt(inp, out)
     print(list(map(hex, out.view(np.uint8))))
 
     decode_uint12_le(inp=out, out=result)
-    assert np.allclose(inp, result)
+    assert_allclose(inp, result)
 
     decode_uint12_le_ref(inp=out, out=result_ref)
-    assert np.allclose(result_ref, result)
+    assert_allclose(result_ref, result)

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -23,7 +23,11 @@ from libertem.io.dataset.base import (
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    import rsciio
+    # FIXME: rsciio/pint is not numpy2 compatible yet
+    if int(np.version.version.split('.')[0]) < 2:
+        import rsciio
+    else:
+        rsciio = None
 except ModuleNotFoundError:
     rsciio = None
 

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -21,7 +21,11 @@ from utils import get_testdata_path, ValidationUDF, roi_as_sparse
 import defusedxml.ElementTree as ET
 
 try:
-    import pims
+    # FIXME: pims/skimage can't deal with numpy2 on python 3.9
+    if int(np.version.version.split('.')[0]) < 2 or sys.version_info >= (3, 10):
+        import pims
+    else:
+        pims = None
 except ModuleNotFoundError:
     pims = None
 

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -13,7 +13,11 @@ from libertem.common.buffers import reshaped_view
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    import hyperspy.api as hs
+    # FIXME: rsciio/pint is not numpy2 compatible yet
+    if int(np.version.version.split('.')[0]) < 2:
+        import hyperspy.api as hs
+    else:
+        hs = None
 except ModuleNotFoundError:
     hs = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ deps=
     rosettasciio
     scikit-image
     pint<0.20
+    numpy<2
     notebooks-cuda101: cupy-cuda101
     notebooks-cuda102: cupy-cuda102
     notebooks-cuda110: cupy-cuda110

--- a/tox.ini
+++ b/tox.ini
@@ -178,6 +178,7 @@ commands=
     # cat docs/build/html/output.txt
 deps=
     setuptools
+    numpy<2
     -rdocs_requirements.txt
 skipsdist=True
 whitelist_externals=

--- a/tox.ini
+++ b/tox.ini
@@ -164,7 +164,6 @@ passenv=
 
 [testenv:docs-check]
 changedir={toxinidir}
-basepython=python3
 setenv=
     PYTHONPATH={toxinidir}
 commands=


### PR DESCRIPTION
Fixes #1653

 * npy: use `ast.literal_eval` instead of `numpy.lib.utils.safe_eval`
 * k2is: fix encode test case; simplify encoder function
 * dm: convert image count from `np.uint32` to Python integer, as it is used in arithmetics which might not fit into the original dtype
 * mib,raw: update decoders/encoders to explicitly use fitting dtypes for shifted `uint8`s

Note that the notebook tests and the docs checks don't currently run with numpy 2 because of incompatibilities in dependencies (hyperspy->pint and scikit-image), so I've constrained these to `numpy<2` for now.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
