### PR TITLE
Pin minimum numba versions for each Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     # for any future Python release, constrain numba to a recent version,
     # otherwise, version resolution might try to install an ancient version
     # that isn't constrained properly:
-    "numba>=0.61",  
+    "numba>=0.61;python_version >= '3.13'",  
     "numexpr!=2.8.6",
     "numpy",
     "opentelemetry-api",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,16 @@ dependencies = [
     "nbconvert",
     "nbformat",
     "ncempy>=1.10",
-    "numba>=0.51",
+    # Minimum constraints of numba for all Python versions we support
+    # See https://numba.readthedocs.io/en/stable/release-notes-overview.html
+    "numba>=0.53;python_version < '3.10'",
+    "numba>=0.55;python_version < '3.11'",
+    "numba>=0.57;python_version < '3.12'",
+    "numba>=0.59;python_version < '3.13'",
+    # for any future Python release, constrain numba to a recent version,
+    # otherwise, version resolution might try to install an ancient version
+    # that isn't constrained properly:
+    "numba>=0.61",  
     "numexpr!=2.8.6",
     "numpy",
     "opentelemetry-api",

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,8 @@ commands=
     pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=pyproject.toml --junitxml=junit.xml tests/io/datasets tests/executor/test_functional.py {posargs}
 
 [testenv:notebooks,notebooks-cuda{101,102,110,11x,12x}]
+# need to constrain package deps, as we support numpy 2.x, but pint on Python 3.9 doesn't
+constrain_package_deps=true
 deps=
     -rtest_requirements.txt
     nbval

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,13 @@ setenv=
 [testenv:py{39,310,311,312}-data,py{39,310,311,312}-data-cuda{101,102,110,11x,12x}]
 deps=
     -rtest_requirements.txt
+    # because tox first installs the dependencies listed here, without taking
+    # our package dependencies into account, we need to repeat the numbab
+    # version constraints here:
+    py{39}-data: numba>=0.53
+    py{310}-data: numba>=0.55
+    py{311}-data: numba>=0.57
+    py{312}-data: numba>=0.59
     hyperspy
     py{311,312}-data,py{311,312}-data-cuda{101,102,110,11x,12x}: orix
     stemtool
@@ -83,6 +90,10 @@ deps=
     nbval
     nbqa
     libertem-blobfinder[hdbscan]>=0.6
+    py{39}-data: numba>=0.53
+    py{310}-data: numba>=0.55
+    py{311}-data: numba>=0.57
+    py{312}-data: numba>=0.59
     hyperspy
     ipywidgets
     pyxem>=0.17


### PR DESCRIPTION
This should fix the `uv` dependency resolution issue, where `uv` picks `numpy==2.1.x` and a very old, incompatible `numba` version that wasn't yet constrained to `numpy` versions.

Also add an unconditional `numba` pin so installation on newer Python in the future won't try to pick an ancient `numba` version.

Closes #1672 

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
