### PR TITLE
Update code_template.py: widget instead of nbagg

### DIFF
--- a/src/libertem/web/notebook_generator/code_template.py
+++ b/src/libertem/web/notebook_generator/code_template.py
@@ -89,7 +89,7 @@ class CodeTemplate(TemplateBase):
         return self.code_formatter('\n'.join(dep))
 
     def initial_setup(self):
-        return "%matplotlib nbagg"
+        return "%matplotlib widget"
 
     def connection(self):
         docs = ["# Connection"]


### PR DESCRIPTION
Follow-up to https://github.com/LiberTEM/LiberTEM/pull/1599

nbagg is not supported anymore in current jupyter versions

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] No import of GPL code from MIT code

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
