### PR TITLE
Snooze at the executor level

### DIFF
--- a/src/libertem/common/executor.py
+++ b/src/libertem/common/executor.py
@@ -132,6 +132,12 @@ class JobExecutor:
     '''
     Interface to execute functions on workers.
     '''
+    def scale_up(self, n_workers: Optional[int]):
+        pass
+
+    def scale_down(self, n_workers: Optional[int]):
+        pass
+
     def run_function(self, fn: Callable[..., T], *args, **kwargs) -> T:
         """
         run a callable :code:`fn` on any worker

--- a/src/libertem/common/executor.py
+++ b/src/libertem/common/executor.py
@@ -141,7 +141,8 @@ class JobExecutor:
         """
         Adjust the executor state to the given number of workers
         If n_workers is None, return executor to its initial state
-        if not currently the case
+        if not currently the case. Block during scaling, raise
+        ExecutorError if scaling incomplete before timeout seconds.
         """
         pass
 

--- a/src/libertem/common/executor.py
+++ b/src/libertem/common/executor.py
@@ -137,7 +137,7 @@ class JobExecutor:
     '''
     Interface to execute functions on workers.
     '''
-    def scale(self, n_workers: Optional[int] = None):
+    def scale(self, n_workers: Optional[int] = None, timeout: float = 10.):
         """
         Adjust the executor state to the given number of workers
         If n_workers is None, return executor to its initial state

--- a/src/libertem/common/executor.py
+++ b/src/libertem/common/executor.py
@@ -1,11 +1,15 @@
 import queue
+import time
+import functools
 from typing import (
     Callable, Optional, Any, TYPE_CHECKING,
-    TypeVar,
+    TypeVar, Union
 )
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 import multiprocessing as mp
+import threading
+import contextlib
 
 import cloudpickle
 from opentelemetry import trace
@@ -132,10 +136,12 @@ class JobExecutor:
     '''
     Interface to execute functions on workers.
     '''
-    def scale_up(self, n_workers: Optional[int]):
-        pass
-
-    def scale_down(self, n_workers: Optional[int]):
+    def scale(self, n_workers: Optional[int] = None):
+        """
+        Adjust the executor state to the given number of workers
+        If n_workers is None, return executor to its initial state
+        if not currently the case
+        """
         pass
 
     def run_function(self, fn: Callable[..., T], *args, **kwargs) -> T:
@@ -711,3 +717,68 @@ class NoopCommHandler(TaskCommHandler):
 
     def done(self):
         pass
+
+
+class SnoozeMixin:
+    def setup_snooze(self, snooze_timeout: Union[float, int]):
+        self._keep_alive = 0
+        self._last_activity = time.monotonic()
+        self.is_snoozing = False
+        self._snooze_lock = threading.Lock()
+        self._snooze_timeout = snooze_timeout
+        self._snooze_check_interval = min(
+            30.0,
+            self._snooze_timeout and (self._snooze_timeout * 0.1) or 30.0,
+        )
+        self._snooze_task = threading.Thread(
+            target=self._snooze_check_task,
+            daemon=True,
+        )
+        self._snooze_task.start()
+
+    def _update_last_activity(self):
+        self._last_activity = time.monotonic()
+
+    @contextlib.contextmanager
+    def in_use(self):
+        self._update_last_activity()
+        self._keep_alive += 1
+        try:
+            yield
+        finally:
+            self._keep_alive -= 1
+            self._update_last_activity()
+
+    def snooze(self):
+        if self._keep_alive > 0:
+            return
+        with self._snooze_lock:
+            self.scale(1)
+            self.is_snoozing = True
+
+    def unsnooze(self):
+        with self._snooze_lock:
+            self.scale()
+            self.is_snoozing = False
+
+    def _snooze_check_task(self):
+        """
+        Periodically check if we need to snooze the executor
+        """
+        while True:
+            time.sleep(self._snooze_check_interval)
+            if self.is_snoozing or self._keep_alive > 0:
+                continue
+            since_last_activity = time.monotonic() - self._last_activity
+            if since_last_activity > self._snooze_timeout:
+                self.snooze()
+
+    @staticmethod
+    def keep_alive(fn):
+
+        @functools.wraps(fn)
+        def wrapped(self, *args, **kwargs):
+            with self.in_use():
+                return fn(self, *args, **kwargs)
+
+        return wrapped

--- a/src/libertem/executor/base.py
+++ b/src/libertem/executor/base.py
@@ -42,7 +42,7 @@ class AsyncAdapter(AsyncJobExecutor):
     Wrap a synchronous JobExecutor and allow to use it as AsyncJobExecutor. All methods are
     converted to async and executed in a separate thread.
     """
-    def __init__(self, wrapped, pool=None):
+    def __init__(self, wrapped: JobExecutor, pool=None):
         self._wrapped = wrapped
         if pool is None:
             pool = AsyncAdapter.make_pool()

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -453,6 +453,8 @@ class DaskJobExecutor(CommonDaskMixin, BaseJobExecutor, SnoozeMixin):
             )
 
     def scale(self, n_workers: Optional[int] = None):
+        if not self.is_local:
+            return
         if n_workers is None:
             n_workers = len(self._worker_spec)
         self.client.cluster.worker_spec = copy.copy(self._worker_spec)

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -426,7 +426,6 @@ def _dispatch_messages(subscribers: dict[str, list[Callable]], dask_message: tup
 
 class SnoozeMixin:
     def setup_snooze(self, snooze_timeout: Union[float, int]):
-        self._snooze_task = None
         self._keep_alive = 0
         self._last_activity = time.monotonic()
         self.is_snoozing = False
@@ -518,14 +517,16 @@ class DaskJobExecutor(CommonDaskMixin, BaseJobExecutor, SnoozeMixin):
             self._worker_spec = copy.copy(self.client.cluster.worker_spec)
             self.setup_snooze(10.)
 
-    def scale_up(self, n: Optional[int]):
-        if n is None:
-            n = len(self._worker_spec)
+    def scale_up(self, n_workers: Optional[int]):
+        if n_workers is None:
+            n_workers = len(self._worker_spec)
         self.client.cluster.worker_spec = copy.copy(self._worker_spec)
-        self.client.cluster.scale(n)
+        self.client.cluster.scale(n_workers)
 
-    def scale_down(self, n: int):
-        self.client.cluster.scale(n)
+    def scale_down(self, n_workers: Optional[int]):
+        if n_workers is None:
+            n_workers = 0
+        self.client.cluster.scale(n_workers)
 
     @contextlib.contextmanager
     def scatter(self, obj):

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -448,8 +448,9 @@ class DaskJobExecutor(CommonDaskMixin, BaseJobExecutor, SnoozeMixin):
         self._futures = {}
         self._scatter_map = {}
         if self.is_local:
-            self._worker_spec = copy.copy(self.client.cluster.worker_spec)
-            self.setup_snooze(10.)
+            self._worker_spec = copy.copy(
+                self.client.cluster.worker_spec
+            )
 
     def scale(self, n_workers: Optional[int] = None):
         if n_workers is None:

--- a/src/libertem/executor/dask.py
+++ b/src/libertem/executor/dask.py
@@ -424,7 +424,7 @@ def _dispatch_messages(subscribers: dict[str, list[Callable]], dask_message: tup
         handler(true_topic, message)
 
 
-class DaskJobExecutor(CommonDaskMixin, BaseJobExecutor, SnoozeMixin):
+class DaskJobExecutor(CommonDaskMixin, BaseJobExecutor):
     '''
     Default LiberTEM executor that uses `Dask futures
     <https://docs.dask.org/en/stable/futures.html>`_.

--- a/src/libertem/web/browse.py
+++ b/src/libertem/web/browse.py
@@ -19,8 +19,7 @@ class LocalFSBrowseHandler(tornado.web.RequestHandler):
         assert len(path) == 1
         path = path[0].decode("utf8")
         try:
-            with self.state.executor_state.keep_alive():
-                listing = await executor.run_function(get_fs_listing, path)
+            listing = await executor.run_function(get_fs_listing, path)
             msg = Message().directory_listing(
                 **listing
             )

--- a/src/libertem/web/dataset.py
+++ b/src/libertem/web/dataset.py
@@ -109,7 +109,7 @@ class DataSetDetailHandler(CORSMixin, tornado.web.RequestHandler):
             dataset_params = converter.to_python(params)
             executor = await self.state.executor_state.get_executor()
 
-            with self.state.executor_state.keep_alive():
+            with self.state.executor_state.executor.ensure_sync().in_use():
                 ds = await load(
                     filetype=cls, executor=executor, enable_async=True, **dataset_params
                 )
@@ -146,7 +146,7 @@ class DataSetDetectHandler(tornado.web.RequestHandler):
         path = self.request.arguments['path'][0].decode("utf8")
         executor = await self.state.executor_state.get_executor()
 
-        with self.state.executor_state.keep_alive():
+        with self.state.executor_state.executor.ensure_sync().in_use():
             detected_params = await sync_to_async(
                 detect, path=path, executor=executor.ensure_sync()
             )

--- a/src/libertem/web/engine.py
+++ b/src/libertem/web/engine.py
@@ -142,16 +142,15 @@ class JobEngine:
         analysis_id: str,
         details: AnalysisDetails,
     ) -> AnalysisResultSet:
-        with self.state.executor_state.keep_alive():
-            with tracer.start_as_current_span("JobEngine.run_udf"):
-                return await self._run_udf(
-                    job_id,
-                    dataset,
-                    dataset_id,
-                    analysis,
-                    analysis_id,
-                    details,
-                )
+        with tracer.start_as_current_span("JobEngine.run_udf"):
+            return await self._run_udf(
+                job_id,
+                dataset,
+                dataset_id,
+                analysis,
+                analysis_id,
+                details,
+            )
 
     async def _run_udf(
         self,

--- a/src/libertem/web/state.py
+++ b/src/libertem/web/state.py
@@ -119,7 +119,7 @@ class ExecutorState:
             )
 
     async def get_executor(self):
-        self.executor.ensure_sync().unsnooze()
+        await self.executor.ensure_async().unsnooze()
         return self.executor
 
     def have_executor(self):


### PR DESCRIPTION
Possible implementation of executor-level snoozing, using `distributed.SpecCluster.scale` for the normal executor.

Only implemented for `DaskJobExecutor` though if we implement a similar scaling mechanism for the other multi-worker executors then the mixin should be reusable.

The approach of course is slightly different to what we did with the web client, here the executor is kept around even while snoozed, it is just the workers which are spun down/up as needed. I do wondew how this would interact with data already scattered to the cluster (presumably would have to re-scatter any data to he new workers after snoozing).

Would close #1576.


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] No import of GPL code from MIT code