### PR TITLE
Fix deprecation warning on sparse.COO coords

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,5 @@ log_date_format = %Y-%m-%d %H:%M:%S
 env =
     D:NUMBA_NUM_THREADS = 4
 asyncio_mode = auto
+filterwarnings =
+    error:coords should be an ndarray:DeprecationWarning

--- a/src/libertem/analysis/clust.py
+++ b/src/libertem/analysis/clust.py
@@ -169,7 +169,7 @@ class ClusterAnalysis(BaseAnalysis, id_="CLUST"):
 
         mask = sparse.COO(
             shape=(len(y), ) + tuple(self.dataset.shape.sig),
-            coords=(z, y, x), data=1.
+            coords=np.stack((z, y, x), axis=0), data=1.
         )
 
         udf = ApplyMasksUDF(

--- a/src/libertem/analysis/point.py
+++ b/src/libertem/analysis/point.py
@@ -59,7 +59,7 @@ class PointMaskAnalysis(SingleMaskAnalysis, id_="APPLY_POINT_SELECTOR"):
         def _point_inner():
             a = sparse.COO(
                 data=np.array([1]),
-                coords=([int(cy)], [int(cx)]),
+                coords=np.array(([int(cy)], [int(cx)])),
                 shape=sig_shape
             )
             return a

--- a/src/libertem/common/sparse.py
+++ b/src/libertem/common/sparse.py
@@ -2,6 +2,8 @@ import numpy as np
 import scipy.sparse as sp
 import sparse
 from typing import Union, TYPE_CHECKING, Optional
+import sparseconverter
+
 
 if TYPE_CHECKING:
     from libertem.common.shape import Shape
@@ -17,13 +19,7 @@ def to_dense(a):
 
 
 def to_sparse(a, shape: Optional[Union['Shape', tuple[int, ...]]] = None):
-    if isinstance(a, sparse.COO):
-        return a
-    elif isinstance(a, sparse.SparseArray):
-        return sparse.COO(a)
-    elif sp.issparse(a):
-        return sparse.COO.from_scipy_sparse(a)
-    elif isinstance(a, (tuple, list)):
+    if isinstance(a, (tuple, list)):
         if all(isinstance(aa, int) for aa in a):
             a = ((a, True),)
         unique = {aa[-1] for aa in a}
@@ -34,7 +30,7 @@ def to_sparse(a, shape: Optional[Union['Shape', tuple[int, ...]]] = None):
         fill_val = not roi_val
         return sparse.COO.from_iter(a, shape=tuple(shape), fill_value=fill_val, dtype=bool)
     else:
-        return sparse.COO.from_numpy(np.array(a))
+        return sparseconverter.for_backend(a, sparseconverter.SPARSE_COO)
 
 
 def sparse_to_coo(a, shape: Optional[Union['Shape', tuple[int, ...]]] = None):

--- a/src/libertem/io/corrections/corrset.py
+++ b/src/libertem/io/corrections/corrset.py
@@ -4,6 +4,7 @@ from typing import Optional
 import numpy as np
 import numba
 import sparse
+import sparseconverter
 
 from libertem.common import Slice
 from libertem.io.corrections.detector import correct, RepairDescriptor
@@ -107,7 +108,9 @@ class CorrectionSet:
         self._dark = dark
         self._gain = gain
         if excluded_pixels is not None:
-            excluded_pixels = sparse.COO(excluded_pixels, prune=True)
+            excluded_pixels = sparseconverter.for_backend(
+                excluded_pixels, sparseconverter.SPARSE_COO
+            )
         self._excluded_pixels = excluded_pixels
         self._allow_empty = allow_empty
         if not allow_empty and excluded_pixels is not None:

--- a/src/libertem/io/corrections/detector.py
+++ b/src/libertem/io/corrections/detector.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numba
 import sparse
+import sparseconverter
 
 from libertem.common.math import prod
 from libertem.common.sparse import is_sparse
@@ -310,7 +311,7 @@ def correct_dot_masks(masks, gain_map, excluded_pixels=None, allow_empty=False):
                 for rr in r[:c]:
                     result[m, rr] = result[m, rr] + rep[m]
         if is_sparse(result):
-            result = sparse.COO(result)
+            result = sparseconverter.for_backend(result, sparseconverter.SPARSE_COO)
     else:
         result = masks
     result = result * gain_map.flatten()

--- a/src/libertem/masks.py
+++ b/src/libertem/masks.py
@@ -79,7 +79,7 @@ def sparse_template_multi_stack(mask_index, offsetX, offsetY, template, imageSiz
 
     return sparse.COO(
         data=data[selector],
-        coords=(coord_mask[selector], coord_y[selector], coord_x[selector]),
+        coords=np.stack((coord_mask[selector], coord_y[selector], coord_x[selector]), axis=0),
         shape=(int(max(mask_index) + 1), imageSizeY, imageSizeX)
     )
 
@@ -321,7 +321,13 @@ def radial_bins(centerX, centerY, imageSizeX, imageSizeY,
                 s = vals.sum()
                 if not np.isclose(s, 0):
                     vals /= s
-            slices.append(sparse.COO(shape=len(r), data=vals.astype(dtype), coords=(jjs[select],)))
+            slices.append(
+                sparse.COO(
+                    shape=(len(r), ),
+                    data=vals.astype(dtype),
+                    coords=(jjs[select])
+                )
+            )
         else:
             if normalize:  # Make sure each bin has a sum of 1
                 s = vals.sum()
@@ -336,7 +342,7 @@ def radial_bins(centerX, centerY, imageSizeX, imageSizeY,
             if use_sparse:
                 index = yy * imageSizeX + xx
                 diff = 1 - slices[0][index] - radius_inner
-                patch = sparse.COO(shape=len(r), data=[diff], coords=[index])
+                patch = sparse.COO(shape=len(r), data=np.array([diff]), coords=np.array([index]))
                 slices[0] += patch
             else:
                 slices[0][yy, xx] = 1 - radius_inner

--- a/tests/corrections/test_detector.py
+++ b/tests/corrections/test_detector.py
@@ -383,11 +383,11 @@ def test_mask_correction_sparse():
         print("Sig dims:", sig_dims)
         print("Exclude: ", exclude)
 
-        masks = sparse.DOK(sparse.zeros((20, ) + sig_dims, dtype=np.float64))
-        indices = [np.random.randint(low=0, high=s, size=s//2) for s in (20, ) + sig_dims]
-        for tup in zip(*indices):
-            masks[tup] = 1
-        masks = masks.to_coo()
+        shape = (20, ) + sig_dims
+        count = min(shape)//2
+        assert count > 0
+        indices = np.stack([np.random.randint(low=0, high=s, size=count) for s in shape], axis=0)
+        masks = sparse.COO(coords=indices, shape=shape, data=1)
 
         data_flat = data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
         damaged_flat = damaged_data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
@@ -481,11 +481,11 @@ def test_mask_patch_sparse():
         print("Sig dims:", sig_dims)
         print("Exclude: ", exclude)
 
-        masks = sparse.DOK(sparse.zeros((20, ) + sig_dims, dtype=np.float64))
-        indices = [np.random.randint(low=0, high=s, size=s//2) for s in (20, ) + sig_dims]
-        for tup in zip(*indices):
-            masks[tup] = 1
-        masks = masks.to_coo()
+        shape = (20, ) + sig_dims
+        count = min(shape)//2
+        assert count > 0
+        indices = np.stack([np.random.randint(low=0, high=s, size=count) for s in shape], axis=0)
+        masks = sparse.COO(coords=indices, shape=shape, data=1)
 
         data_flat = data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
         damaged_flat = damaged_data.reshape((np.prod(nav_dims), np.prod(sig_dims)))

--- a/tests/corrections/test_detector.py
+++ b/tests/corrections/test_detector.py
@@ -387,7 +387,7 @@ def test_mask_correction_sparse():
         count = min(shape)//2
         assert count > 0
         indices = np.stack([np.random.randint(low=0, high=s, size=count) for s in shape], axis=0)
-        masks = sparse.COO(coords=indices, shape=shape, data=1)
+        masks = sparse.COO(coords=indices, shape=shape, data=1).astype(np.float64)
 
         data_flat = data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
         damaged_flat = damaged_data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
@@ -485,7 +485,7 @@ def test_mask_patch_sparse():
         count = min(shape)//2
         assert count > 0
         indices = np.stack([np.random.randint(low=0, high=s, size=count) for s in shape], axis=0)
-        masks = sparse.COO(coords=indices, shape=shape, data=1)
+        masks = sparse.COO(coords=indices, shape=shape, data=1).astype(np.float64)
 
         data_flat = data.reshape((np.prod(nav_dims), np.prod(sig_dims)))
         damaged_flat = damaged_data.reshape((np.prod(nav_dims), np.prod(sig_dims)))

--- a/tests/io/test_tiling_negotiation.py
+++ b/tests/io/test_tiling_negotiation.py
@@ -452,7 +452,7 @@ def test_base_shape_adjustment_asis(lt_ctx_fast):
 
     corr = CorrectionSet(
         excluded_pixels=sparse.COO(
-            coords=(bad_y, bad_x),
+            coords=np.stack((bad_y, bad_x), axis=0),
             data=1,
             shape=ds.shape.sig
         )
@@ -487,7 +487,7 @@ def test_base_shape_adjustment_valid(lt_ctx_fast):
 
     corr = CorrectionSet(
         excluded_pixels=sparse.COO(
-            coords=(bad_y, bad_x),
+            coords=np.stack((bad_y, bad_x), axis=0),
             data=1,
             shape=ds.shape.sig
         )
@@ -517,7 +517,7 @@ def test_base_shape_adjustment_invalid(lt_ctx_fast):
 
     corr = CorrectionSet(
         excluded_pixels=sparse.COO(
-            coords=(bad_y, bad_x),
+            coords=np.stack((bad_y, bad_x), axis=0),
             data=1,
             shape=ds.shape.sig
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -274,7 +274,7 @@ def dataset_correction_verification(ds, roi, lt_ctx, exclude=None):
                 for s in tuple(ds.shape.sig)
             ]
 
-        exclude_coo = sparse.COO(coords=exclude, data=True, shape=ds.shape.sig)
+        exclude_coo = sparse.COO(coords=np.array(exclude), data=True, shape=ds.shape.sig)
         corrset = CorrectionSet(dark=dark, gain=gain, excluded_pixels=exclude_coo)
 
         # This one uses native input data


### PR DESCRIPTION
Convert to ndarray or use alternative methods.

Also include filter in pytest.ini that makes this deprecation warning an error during tests.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
