### PR TITLE
Allow small partitions; add manual override

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -242,15 +242,20 @@ def default_raw_data():
 
 
 @pytest.fixture(scope='session')
-def default_raw(tmpdir_factory, default_raw_data):
-    lt_ctx = lt.Context(executor=InlineJobExecutor())
+def default_raw_file(tmpdir_factory, default_raw_data):
     datadir = tmpdir_factory.mktemp('data')
     filename = datadir + '/raw-test-default'
     default_raw_data.tofile(str(filename))
     del default_raw_data
+    return filename
+
+
+@pytest.fixture(scope='session')
+def default_raw(default_raw_file):
+    lt_ctx = lt.Context(executor=InlineJobExecutor())
     ds = lt_ctx.load(
         "raw",
-        path=str(filename),
+        path=str(default_raw_file),
         dtype="float32",
         nav_shape=(16, 16),
         sig_shape=(128, 128),

--- a/docs/source/changelog/features/num-partitions.rst
+++ b/docs/source/changelog/features/num-partitions.rst
@@ -4,7 +4,7 @@
   implementations. This means (expert) users can override the number of
   partitions when loading data, in cases where the default heuristic doesn't
   work well. Also changes the number of partitions in case there are fewer
-  frames than workers, where it is an advantage to more have small (1-frame)
+  frames than workers, where it is an overall advantage to have small (1-frame)
   partitions instead of aggregating all frames into a single partition,
   especially if there is a lot of processing done per frame (:issue:`1701`
   :pr:`1702`).

--- a/docs/source/changelog/features/num-partitions.rst
+++ b/docs/source/changelog/features/num-partitions.rst
@@ -1,0 +1,10 @@
+[Feature] Allow overriding the number of partitions
+===================================================
+* Adds a parameter :code:`num_partitions` to most :code:`DataSet`
+  implementations. This means (export) users can override the number of
+  partitions when loading data, in cases where the default heuristic doesn't
+  work well. Also changes the number of partitions in case there are fewer
+  frames than workers, where it is an advantage to more have small (1-frame)
+  partitions instead of aggregating all frames into a single partition,
+  especially if there is a lot of processing done per frame (:issue:`1701`
+  :pr:`1702`).

--- a/docs/source/changelog/features/num-partitions.rst
+++ b/docs/source/changelog/features/num-partitions.rst
@@ -1,7 +1,7 @@
 [Feature] Allow overriding the number of partitions
 ===================================================
 * Adds a parameter :code:`num_partitions` to most :code:`DataSet`
-  implementations. This means (export) users can override the number of
+  implementations. This means (expert) users can override the number of
   partitions when loading data, in cases where the default heuristic doesn't
   work well. Also changes the number of partitions in case there are fewer
   frames than workers, where it is an advantage to more have small (1-frame)

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,4 @@ env =
 asyncio_mode = auto
 filterwarnings =
     error:coords should be an ndarray:DeprecationWarning
+    error:overflow encountered in scalar negative:RuntimeWarning

--- a/src/libertem/io/dataset/base/dataset.py
+++ b/src/libertem/io/dataset/base/dataset.py
@@ -87,7 +87,7 @@ class DataSet:
         are created.
         """
         if self._user_num_partitions is not None:
-            return self._user_num_partitions
+            return max(1, self._user_num_partitions)
         partition_size_float_px = self.MAX_PARTITION_SIZE // 4
         dataset_size_px = prod(self.shape)
         num: int = max(self._cores, dataset_size_px // partition_size_float_px)

--- a/src/libertem/io/dataset/base/dataset.py
+++ b/src/libertem/io/dataset/base/dataset.py
@@ -23,13 +23,18 @@ class DataSet:
     # The default partition size in bytes
     MAX_PARTITION_SIZE = 512*1024*1024
 
-    def __init__(self, io_backend: Optional["IOBackend"] = None):
+    def __init__(
+        self,
+        io_backend: Optional["IOBackend"] = None,
+        num_partitions: Optional[int] = None,
+    ):
         self._cores = 1
         self._sync_offset: Optional[int] = 0
         self._sync_offset_info = None
         self._image_count = 0
         self._nav_shape_product = 0
         self._io_backend = io_backend
+        self._user_num_partitions = num_partitions
         self._meta: Optional[DataSetMeta] = None
 
     def initialize(self, executor) -> "DataSet":
@@ -81,6 +86,8 @@ class DataSet:
         native dtype. At least :code:`self._cores` partitions
         are created.
         """
+        if self._user_num_partitions is not None:
+            return self._user_num_partitions
         partition_size_float_px = self.MAX_PARTITION_SIZE // 4
         dataset_size_px = prod(self.shape)
         num: int = max(self._cores, dataset_size_px // partition_size_float_px)

--- a/src/libertem/io/dataset/base/file.py
+++ b/src/libertem/io/dataset/base/file.py
@@ -59,8 +59,8 @@ class File:
     def __init__(self, path, start_idx, end_idx,
                 native_dtype, sig_shape,
                 frame_footer=0, frame_header=0, file_header=0):
-        self._start_idx = start_idx
-        self._end_idx = end_idx
+        self._start_idx = int(start_idx)
+        self._end_idx = int(end_idx)
         self._native_dtype = native_dtype
         self._path = path
         self._file_header = file_header

--- a/src/libertem/io/dataset/base/partition.py
+++ b/src/libertem/io/dataset/base/partition.py
@@ -77,7 +77,7 @@ class Partition:
                 "setting num_part to 1 to allow processing (use fewer workers?)",
                 RuntimeWarning
             )
-            num_partitions = 1
+            num_partitions = num_frames
         boundaries = np.linspace(
             0,
             num_frames,

--- a/src/libertem/io/dataset/base/partition.py
+++ b/src/libertem/io/dataset/base/partition.py
@@ -73,8 +73,8 @@ class Partition:
         num_frames = shape.nav.size
         if num_partitions > num_frames:
             warnings.warn(
-                "dataset contains fewer frames than partitions, "
-                "setting num_part to 1 to allow processing (use fewer workers?)",
+                f"dataset contains fewer frames than partitions, "
+                f"setting num_partitions to {num_frames} to allow processing",
                 RuntimeWarning
             )
             num_partitions = num_frames

--- a/src/libertem/io/dataset/base/partition.py
+++ b/src/libertem/io/dataset/base/partition.py
@@ -73,8 +73,9 @@ class Partition:
         num_frames = shape.nav.size
         if num_partitions > num_frames:
             warnings.warn(
-                f"dataset contains fewer frames than partitions, "
-                f"setting num_partitions to {num_frames} to allow processing",
+                "dataset contains fewer frames than specified partitions, "
+                f"setting num_partitions == num_frames == {num_frames} "
+                "to avoid creating empty partitions",
                 RuntimeWarning
             )
             num_partitions = num_frames

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -123,7 +123,9 @@ class BloDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(
         self,

--- a/src/libertem/io/dataset/blo.py
+++ b/src/libertem/io/dataset/blo.py
@@ -120,10 +120,26 @@ class BloDataSet(DataSet):
     sync_offset: int, optional
         If positive, number of frames to skip from start
         If negative, number of blank frames to insert at start
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
     """
-    def __init__(self, path, tileshape=None, endianess='<', nav_shape=None,
-                 sig_shape=None, sync_offset=0, io_backend=None):
-        super().__init__(io_backend=io_backend)
+    def __init__(
+        self,
+        path,
+        tileshape=None,
+        endianess='<',
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=0,
+        io_backend=None,
+        num_partitions=None,
+    ):
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         # handle backwards-compatability:
         if tileshape is not None:
             warnings.warn(

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -206,8 +206,8 @@ class StackedDMDataSet(DMDataSet):
         the one from the first file.
     """
     def __init__(self, files=None, scan_size=None, same_offset=False, nav_shape=None,
-                 sig_shape=None, sync_offset=0, io_backend=None):
-        super().__init__(io_backend=io_backend)
+                 sig_shape=None, sync_offset=0, io_backend=None, num_partitions=None):
+        super().__init__(io_backend=io_backend, num_partitions=num_partitions)
         self._meta = None
         self._same_offset = same_offset
         self._nav_shape = tuple(nav_shape) if nav_shape else nav_shape

--- a/src/libertem/io/dataset/dm.py
+++ b/src/libertem/io/dataset/dm.py
@@ -204,6 +204,12 @@ class StackedDMDataSet(DMDataSet):
         absolutely know that the offsets and sizes are the same for all files,
         you can set this parameter and we will skip reading all metadata but
         the one from the first file.
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(self, files=None, scan_size=None, same_offset=False, nav_shape=None,
                  sig_shape=None, sync_offset=0, io_backend=None, num_partitions=None):

--- a/src/libertem/io/dataset/dm_single.py
+++ b/src/libertem/io/dataset/dm_single.py
@@ -92,7 +92,9 @@ class SingleDMDataSet(DMDataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(
         self,

--- a/src/libertem/io/dataset/dm_single.py
+++ b/src/libertem/io/dataset/dm_single.py
@@ -89,6 +89,10 @@ class SingleDMDataSet(DMDataSet):
         the datasets in a DM-file often begin with a thumbnail
         which occupies the 0 dataset index. If not provided the
         first compatible dataset found in the file is used.
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
     """
     def __init__(
         self,
@@ -98,9 +102,13 @@ class SingleDMDataSet(DMDataSet):
         sync_offset: int = 0,
         io_backend: Optional[IOBackend] = None,
         force_c_order: bool = False,
-        dataset_index: Optional[int] = None
+        dataset_index: Optional[int] = None,
+        num_partitions: Optional[int] = None,
     ):
-        super().__init__(io_backend=io_backend)
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._filesize = None
 
         self._path = path

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -135,14 +135,29 @@ class EMPADDataSet(DataSet):
         If positive, number of frames to skip from start
         If negative, number of blank frames to insert at start
 
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
+
     Examples
     --------
 
     >>> ds = ctx.load("empad", path='./path_to_file.xml', ...)  # doctest: +SKIP
     """
-    def __init__(self, path, scan_size=None, nav_shape=None,
-                 sig_shape=None, sync_offset=0, io_backend=None):
-        super().__init__(io_backend=io_backend)
+    def __init__(
+        self,
+        path,
+        scan_size=None,
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=0,
+        io_backend=None,
+        num_partitions=None,
+    ):
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._path = path
         self._nav_shape = tuple(nav_shape) if nav_shape else nav_shape
         self._sig_shape = tuple(sig_shape) if sig_shape else sig_shape

--- a/src/libertem/io/dataset/empad.py
+++ b/src/libertem/io/dataset/empad.py
@@ -137,7 +137,9 @@ class EMPADDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
 
     Examples
     --------

--- a/src/libertem/io/dataset/frms6.py
+++ b/src/libertem/io/dataset/frms6.py
@@ -436,7 +436,9 @@ class FRMS6DataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
 
     Examples
     --------

--- a/src/libertem/io/dataset/frms6.py
+++ b/src/libertem/io/dataset/frms6.py
@@ -434,15 +434,32 @@ class FRMS6DataSet(DataSet):
         If positive, number of frames to skip from start
         If negative, number of blank frames to insert at start
 
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
+
     Examples
     --------
 
     >>> ds = ctx.load("frms6", path='./path_to_file.hdr', ...)  # doctest: +SKIP
     """
 
-    def __init__(self, path, enable_offset_correction=True, gain_map_path=None, dest_dtype=None,
-                 nav_shape=None, sig_shape=None, sync_offset=0, io_backend=None):
-        super().__init__(io_backend=io_backend)
+    def __init__(
+        self,
+        path,
+        enable_offset_correction=True,
+        gain_map_path=None,
+        dest_dtype=None,
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=0,
+        io_backend=None,
+        num_partitions=None,
+    ):
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._path = path
         self._gain_map_path = gain_map_path
         self._dark_frame = None

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -750,7 +750,9 @@ class K2ISDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
 
     Examples
     --------

--- a/src/libertem/io/dataset/k2is.py
+++ b/src/libertem/io/dataset/k2is.py
@@ -748,14 +748,29 @@ class K2ISDataSet(DataSet):
         If positive, number of frames to skip from start
         If negative, number of blank frames to insert at start
 
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
+
     Examples
     --------
 
     >>> ds = ctx.load("k2is", path='./path_to_file.bin', ...)  # doctest: +SKIP
     """
 
-    def __init__(self, path, nav_shape=None, sig_shape=None, sync_offset=None, io_backend=None):
-        super().__init__(io_backend=io_backend)
+    def __init__(
+        self,
+        path,
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=None,
+        io_backend=None,
+        num_partitions=None,
+    ):
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._path = path
         self._start_offsets = None
         self._last_offsets = None

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1044,10 +1044,27 @@ class MIBDataSet(DataSet):
         (for example, a.mib, a1.mib and a2.mib), loading a.mib would include a1.mib and a2.mib
         in the data set. Setting :code:`disable_glob` to :code:`True` will only load the single
         .mib file specified as :code:`path`.
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
     """
-    def __init__(self, path, tileshape=None, scan_size=None, disable_glob=False,
-                 nav_shape=None, sig_shape=None, sync_offset=0, io_backend=None):
-        super().__init__(io_backend=io_backend)
+    def __init__(
+        self,
+        path,
+        tileshape=None,
+        scan_size=None,
+        disable_glob=False,
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=0,
+        io_backend=None,
+        num_partitions=None,
+    ):
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._sig_dims = 2
         self._path = str(path)
         self._nav_shape = tuple(nav_shape) if nav_shape else nav_shape

--- a/src/libertem/io/dataset/mib.py
+++ b/src/libertem/io/dataset/mib.py
@@ -1047,7 +1047,9 @@ class MIBDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(
         self,

--- a/src/libertem/io/dataset/mrc.py
+++ b/src/libertem/io/dataset/mrc.py
@@ -115,7 +115,9 @@ class MRCDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(
         self,

--- a/src/libertem/io/dataset/mrc.py
+++ b/src/libertem/io/dataset/mrc.py
@@ -112,9 +112,24 @@ class MRCDataSet(DataSet):
     sync_offset: int, optional
         If positive, number of frames to skip from start
         If negative, number of blank frames to insert at start
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
     """
-    def __init__(self, path, nav_shape=None, sig_shape=None, sync_offset=0, io_backend=None):
-        super().__init__(io_backend=io_backend)
+    def __init__(
+        self,
+        path,
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=0,
+        io_backend=None,
+        num_partitions=None,
+    ):
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         if io_backend is not None:
             raise ValueError("MRCDataSet currently doesn't support alternative I/O backends")
         self._path = path

--- a/src/libertem/io/dataset/npy.py
+++ b/src/libertem/io/dataset/npy.py
@@ -119,7 +119,9 @@ class NPYDataSet(DataSet):
         The I/O backend to use, see :ref:`io backends`, by default None.
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
 
     Raises
     ------

--- a/src/libertem/io/dataset/npy.py
+++ b/src/libertem/io/dataset/npy.py
@@ -117,6 +117,9 @@ class NPYDataSet(DataSet):
         If negative, number of blank frames to insert at start
     io_backend : IOBackend, optional
         The I/O backend to use, see :ref:`io backends`, by default None.
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
 
     Raises
     ------
@@ -141,8 +144,12 @@ class NPYDataSet(DataSet):
         sig_shape: Optional[tuple[int, int]] = None,
         sync_offset: int = 0,
         io_backend: Optional[IOBackend] = None,
+        num_partitions: Optional[int] = None,
     ):
-        super().__init__(io_backend=io_backend)
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._meta = None
         self._nav_shape = tuple(nav_shape) if nav_shape else nav_shape
         self._sig_shape = tuple(sig_shape) if sig_shape else sig_shape

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -95,10 +95,27 @@ class RawFileDataSet(DataSet):
     dtype: numpy dtype
         The dtype of the data as it is on disk. Can contain endian indicator, for
         example >u2 for big-endian 16bit data.
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
     """
-    def __init__(self, path, dtype, scan_size=None, detector_size=None, enable_direct=False,
-                 detector_size_raw=None, crop_detector_to=None, tileshape=None,
-                 nav_shape=None, sig_shape=None, sync_offset=0, io_backend=None):
+    def __init__(
+        self,
+        path,
+        dtype,
+        scan_size=None,
+        detector_size=None,
+        enable_direct=False,
+        detector_size_raw=None,
+        crop_detector_to=None,
+        tileshape=None,
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=0,
+        io_backend=None,
+        num_partitions=None,
+    ):
         if enable_direct and io_backend is not None:
             raise ValueError("can't specify io_backend and enable_direct at the same time")
         if enable_direct:
@@ -108,7 +125,10 @@ class RawFileDataSet(DataSet):
                 FutureWarning
             )
             io_backend = DirectBackend()
-        super().__init__(io_backend=io_backend)
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         # handle backwards-compatability:
         if tileshape is not None:
             warnings.warn(

--- a/src/libertem/io/dataset/raw.py
+++ b/src/libertem/io/dataset/raw.py
@@ -98,7 +98,9 @@ class RawFileDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(
         self,

--- a/src/libertem/io/dataset/raw_csr.py
+++ b/src/libertem/io/dataset/raw_csr.py
@@ -138,7 +138,9 @@ class RawCSRDataSet(DataSet):
         The I/O backend to use, see :ref:`io backends`, by default None.
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
 
     Examples
     --------

--- a/src/libertem/io/dataset/raw_csr.py
+++ b/src/libertem/io/dataset/raw_csr.py
@@ -136,6 +136,9 @@ class RawCSRDataSet(DataSet):
         If negative, number of blank frames to insert at start
     io_backend : IOBackend, optional
         The I/O backend to use, see :ref:`io backends`, by default None.
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
 
     Examples
     --------
@@ -149,11 +152,15 @@ class RawCSRDataSet(DataSet):
         nav_shape: typing.Optional[tuple[int, ...]] = None,
         sig_shape: typing.Optional[tuple[int, ...]] = None,
         sync_offset: int = 0,
-        io_backend: typing.Optional["IOBackend"] = None
+        io_backend: typing.Optional["IOBackend"] = None,
+        num_partitions: typing.Optional[int] = None,
     ):
         if io_backend is not None:
             raise NotImplementedError()
-        super().__init__(io_backend=io_backend)
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._path = path
         if nav_shape is not None:
             nav_shape = tuple(nav_shape)

--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -438,7 +438,9 @@ class SEQDataSet(DataSet):
         If negative, number of blank frames to insert at start.
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
 
     Note
     ----

--- a/src/libertem/io/dataset/seq.py
+++ b/src/libertem/io/dataset/seq.py
@@ -436,6 +436,9 @@ class SEQDataSet(DataSet):
     sync_offset: int, optional
         If positive, number of frames to skip from start.
         If negative, number of blank frames to insert at start.
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
 
     Note
     ----
@@ -464,8 +467,12 @@ class SEQDataSet(DataSet):
         sig_shape: Optional[tuple[int, ...]] = None,
         sync_offset: int = 0,
         io_backend=None,
+        num_partitions=None,
     ):
-        super().__init__(io_backend=io_backend)
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._path = path
         # There might be '.seq.seq' and '.seq' in the wild
         # See https://github.com/LiberTEM/LiberTEM/issues/1120

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -118,7 +118,9 @@ class SERDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(
         self,

--- a/src/libertem/io/dataset/ser.py
+++ b/src/libertem/io/dataset/ser.py
@@ -115,10 +115,25 @@ class SERDataSet(DataSet):
     sync_offset: int, optional
         If positive, number of frames to skip from start
         If negative, number of blank frames to insert at start
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
     """
-    def __init__(self, path, emipath=None, nav_shape=None,
-                 sig_shape=None, sync_offset=0, io_backend=None):
-        super().__init__(io_backend=io_backend)
+    def __init__(
+        self,
+        path,
+        emipath=None,
+        nav_shape=None,
+        sig_shape=None,
+        sync_offset=0,
+        io_backend=None,
+        num_partitions=None,
+    ):
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         if io_backend is not None:
             raise ValueError("SERDataSet currently doesn't support alternative I/O backends")
         self._path = path

--- a/src/libertem/io/dataset/tvips.py
+++ b/src/libertem/io/dataset/tvips.py
@@ -316,6 +316,10 @@ class TVIPSDataSet(DataSet):
         If negative, number of blank frames to insert at start
         If not given, we try to automatically determine the sync_offset from
         the scan metadata in the image headers.
+
+    num_partitions: int, optional
+        Override the number of partitions. This is useful if the
+        default heuristic doesn't work well.
     """
     def __init__(
         self,
@@ -324,8 +328,12 @@ class TVIPSDataSet(DataSet):
         sig_shape: Optional[tuple[int, ...]] = None,
         sync_offset: Optional[int] = None,
         io_backend: Optional[IOBackend] = None,
+        num_partitions: Optional[int] = None,
     ):
-        super().__init__(io_backend=io_backend)
+        super().__init__(
+            io_backend=io_backend,
+            num_partitions=num_partitions,
+        )
         self._nav_shape = tuple(nav_shape) if nav_shape else nav_shape
         self._sig_shape = tuple(sig_shape) if sig_shape else sig_shape
         self._sync_offset = sync_offset

--- a/src/libertem/io/dataset/tvips.py
+++ b/src/libertem/io/dataset/tvips.py
@@ -319,7 +319,9 @@ class TVIPSDataSet(DataSet):
 
     num_partitions: int, optional
         Override the number of partitions. This is useful if the
-        default heuristic doesn't work well.
+        default number of partitions, chosen based on common workloads,
+        creates partitions which are too large (or small) for the UDFs
+        being run on this dataset.
     """
     def __init__(
         self,

--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -329,6 +329,15 @@ def test_incorrect_sig_shape(lt_ctx):
     )
 
 
+def test_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "blo",
+        path=BLO_TESTDATA_PATH,
+        num_partitions=129,
+    )
+    assert len(list(ds.get_partitions())) == 129
+
+
 def test_compare_backends(lt_ctx, default_blo, buffered_blo):
     y = random.choice(range(default_blo.shape.nav[0]))
     x = random.choice(range(default_blo.shape.nav[1]))

--- a/tests/io/datasets/test_dm.py
+++ b/tests/io/datasets/test_dm.py
@@ -317,9 +317,8 @@ def test_missing_frames(lt_ctx, io_backend, dm_stack_glob):
         files=list(sorted(dm_stack_glob)),
         nav_shape=nav_shape,
         io_backend=io_backend,
+        num_partitions=4,
     )
-
-    ds.set_num_cores(4)
 
     tileshape = Shape(
         (1,) + tuple(ds.shape.sig),

--- a/tests/io/datasets/test_dm_single.py
+++ b/tests/io/datasets/test_dm_single.py
@@ -553,6 +553,7 @@ def test_convert_f_ordered(monkeypatch, dm4_mockfile_f, lt_ctx, tmpdir_factory):
     assert np.allclose(pick_frame, array[3, 4, :, :])
 
 
+@pytest.mark.skipif(not HAVE_DM_TESTDATA, reason="No DM4 test data")
 def test_num_partitions(lt_ctx, dm3_3dstack_path):
     ds = lt_ctx.load(
         "dm",

--- a/tests/io/datasets/test_dm_single.py
+++ b/tests/io/datasets/test_dm_single.py
@@ -551,3 +551,12 @@ def test_convert_f_ordered(monkeypatch, dm4_mockfile_f, lt_ctx, tmpdir_factory):
     pick_frame = lt_ctx.run(pick_a).intensity.raw_data
     # flipped coords because pick_a takes x, y arguments
     assert np.allclose(pick_frame, array[3, 4, :, :])
+
+
+def test_num_partitions(lt_ctx, dm3_3dstack_path):
+    ds = lt_ctx.load(
+        "dm",
+        path=dm3_3dstack_path,
+        num_partitions=2,
+    )
+    assert len(list(ds.get_partitions())) == 2

--- a/tests/io/datasets/test_dm_single.py
+++ b/tests/io/datasets/test_dm_single.py
@@ -276,8 +276,7 @@ def test_many_tiles(monkeypatch, dm4_mockfile_c, lt_ctx_fast):
     (array, filename), mock_fileDM = dm4_mockfile_c
     _patch_filedm(monkeypatch, mock_fileDM)
 
-    ds = lt_ctx_fast.load('dm', filename)
-    ds.set_num_cores(8)
+    ds = lt_ctx_fast.load('dm', filename, num_partitions=8)
     _, _, sy, sx = array.shape
     flat_data = array.reshape(-1, sy, sx)
     # depth 5, height 3, divides neither flat_nav or sy evenly
@@ -347,8 +346,7 @@ def test_macrotile_normal(monkeypatch, dm4_mockfile_c, lt_ctx_fast):
     (array, filename), mock_fileDM = dm4_mockfile_c
     _patch_filedm(monkeypatch, mock_fileDM)
 
-    ds = lt_ctx_fast.load('dm', filename)
-    ds.set_num_cores(4)
+    ds = lt_ctx_fast.load('dm', filename, num_partitions=4)
 
     ps = ds.get_partitions()
     _ = next(ps)
@@ -383,8 +381,8 @@ def test_positive_sync_offset(monkeypatch, dm4_mockfile_c, lt_ctx):
     ds_with_offset = SingleDMDataSet(
         path=filename,
         sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -434,8 +432,8 @@ def test_negative_sync_offset(monkeypatch, dm4_mockfile_c, lt_ctx):
     ds_with_offset = SingleDMDataSet(
         path=filename,
         sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 

--- a/tests/io/datasets/test_empad.py
+++ b/tests/io/datasets/test_empad.py
@@ -505,3 +505,12 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
     args = ("empad", EMPAD_XML)
     for params in standard_bad_ds_params:
         ds_params_tester(*args, **params)
+
+
+def test_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "empad",
+        path=EMPAD_XML,
+        num_partitions=5,
+    )
+    assert len(list(ds.get_partitions())) == 5

--- a/tests/io/datasets/test_frms6.py
+++ b/tests/io/datasets/test_frms6.py
@@ -637,3 +637,12 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
     args = ("frms6", FRMS6_TESTDATA_PATH)
     for params in standard_bad_ds_params:
         ds_params_tester(*args, **params)
+
+
+def test_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "frms6",
+        path=FRMS6_TESTDATA_PATH,
+        num_partitions=129,
+    )
+    assert len(list(ds.get_partitions())) == 129

--- a/tests/io/datasets/test_frms6.py
+++ b/tests/io/datasets/test_frms6.py
@@ -639,6 +639,7 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
         ds_params_tester(*args, **params)
 
 
+@needsdata
 def test_num_partitions(lt_ctx):
     ds = lt_ctx.load(
         "frms6",

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -716,6 +716,7 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
         ds_params_tester(*args, **params)
 
 
+@needsdata
 def test_num_partitions(lt_ctx):
     ds = lt_ctx.load(
         "k2is",

--- a/tests/io/datasets/test_k2is.py
+++ b/tests/io/datasets/test_k2is.py
@@ -714,3 +714,12 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
     args = ("k2is", K2IS_TESTDATA_PATH)
     for params in standard_bad_ds_params:
         ds_params_tester(*args, **params)
+
+
+def test_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "k2is",
+        path=K2IS_TESTDATA_PATH,
+        num_partitions=129,
+    )
+    assert len(list(ds.get_partitions())) == 129

--- a/tests/io/datasets/test_mem.py
+++ b/tests/io/datasets/test_mem.py
@@ -384,3 +384,13 @@ def test_sig_nav_dims_sync(nav_shape, sig_shape, sync_offset, sig_dims, prime_ra
 def test_exception_no_datashape(lt_ctx_fast):
     with pytest.raises(DataSetException):
         lt_ctx_fast.load('memory', tileshape=(5, 6, 7))
+
+
+def test_num_partitions(lt_ctx):
+    data = _mk_random(size=(8, 8, 8, 8))
+    ds = lt_ctx.load(
+        "memory",
+        num_partitions=7,
+        data=data,
+    )
+    assert len(list(ds.get_partitions())) == 7

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -619,3 +619,13 @@ def test_read_scan_shape_header(lt_ctx):
     ds = lt_ctx.load('mib', path=hdr_path)
     assert ds.shape.nav.to_tuple() == (20, 28)
     assert ds.shape.sig.to_tuple() == (514, 514)
+
+
+@needsdata
+def test_no_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "mib",
+        path=MIB_TESTDATA_PATH,
+        nav_shape=(32, 32),
+    )
+    lt_ctx.run_udf(dataset=ds, udf=SumSigUDF())

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -46,8 +46,8 @@ def default_mib(lt_ctx):
         path=MIB_TESTDATA_PATH,
         nav_shape=nav_shape,
         io_backend=MMapBackend(),
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     return ds
 
 
@@ -59,8 +59,8 @@ def default_mib_readahead(lt_ctx):
         path=MIB_TESTDATA_PATH,
         nav_shape=nav_shape,
         io_backend=MMapBackend(enable_readahead_hints=True),
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     return ds
 
 
@@ -138,9 +138,9 @@ def test_positive_sync_offset(default_mib, lt_ctx):
     sync_offset = 2
 
     ds_with_offset = MIBDataSet(
-        path=MIB_TESTDATA_PATH, nav_shape=(32, 32), sync_offset=sync_offset
+        path=MIB_TESTDATA_PATH, nav_shape=(32, 32), sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -187,9 +187,9 @@ def test_negative_sync_offset(default_mib, lt_ctx):
     sync_offset = -2
 
     ds_with_offset = MIBDataSet(
-        path=MIB_TESTDATA_PATH, nav_shape=(32, 32), sync_offset=sync_offset
+        path=MIB_TESTDATA_PATH, nav_shape=(32, 32), sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 

--- a/tests/io/datasets/test_mrc.py
+++ b/tests/io/datasets/test_mrc.py
@@ -266,3 +266,12 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
     args = ("mrc", MRC_TESTDATA_PATH)
     for params in standard_bad_ds_params:
         ds_params_tester(*args, **params)
+
+
+def test_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "mrc",
+        path=MRC_TESTDATA_PATH,
+        num_partitions=3,
+    )
+    assert len(list(ds.get_partitions())) == 3

--- a/tests/io/datasets/test_npy.py
+++ b/tests/io/datasets/test_npy.py
@@ -258,8 +258,8 @@ def test_positive_sync_offset(lt_ctx, npy_8x8x8x8_ds, npy_8x8x8x8_path, io_backe
         path=npy_8x8x8x8_path,
         sync_offset=sync_offset,
         io_backend=io_backend,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -314,8 +314,8 @@ def test_negative_sync_offset(lt_ctx, npy_8x8x8x8_ds, npy_8x8x8x8_path, io_backe
         path=npy_8x8x8x8_path,
         sync_offset=sync_offset,
         io_backend=io_backend,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 

--- a/tests/io/datasets/test_npy.py
+++ b/tests/io/datasets/test_npy.py
@@ -368,6 +368,14 @@ def test_load_direct(lt_ctx, npy_8x8x8x8_path):
     lt_ctx.run(analysis)
 
 
+def test_no_num_partitions(lt_ctx, npy_8x8x8x8_path):
+    ds = lt_ctx.load(
+        "npy",
+        path=npy_8x8x8x8_path,
+    )
+    lt_ctx.run_udf(dataset=ds, udf=SumSigUDF())
+
+
 @pytest.mark.parametrize(
     "io_backend", (
         BufferedBackend(),

--- a/tests/io/datasets/test_raw.py
+++ b/tests/io/datasets/test_raw.py
@@ -29,8 +29,8 @@ def raw_dataset_8x8x8x8(lt_ctx, raw_data_8x8x8x8_path):
         nav_shape=(8, 8),
         sig_shape=(8, 8),
         dtype="float32",
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     ds = ds.initialize(lt_ctx.executor)
 
     return ds
@@ -508,8 +508,8 @@ def test_positive_sync_offset(lt_ctx, raw_dataset_8x8x8x8, raw_data_8x8x8x8_path
         dtype="float32",
         sync_offset=sync_offset,
         io_backend=io_backend,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -567,8 +567,8 @@ def test_negative_sync_offset(lt_ctx, raw_dataset_8x8x8x8, raw_data_8x8x8x8_path
         dtype="float32",
         sync_offset=sync_offset,
         io_backend=io_backend,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -620,8 +620,8 @@ def test_missing_frames(lt_ctx, raw_data_8x8x8x8_path, io_backend):
         sig_shape=(8, 8),
         dtype="float32",
         io_backend=io_backend,
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     ds = ds.initialize(lt_ctx.executor)
 
     tileshape = Shape(
@@ -658,8 +658,8 @@ def test_too_many_frames(lt_ctx, raw_data_8x8x8x8_path, io_backend):
         sig_shape=(8, 8),
         dtype="float32",
         io_backend=io_backend,
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     ds = ds.initialize(lt_ctx.executor)
 
     tileshape = Shape(

--- a/tests/io/datasets/test_raw_csr.py
+++ b/tests/io/datasets/test_raw_csr.py
@@ -466,6 +466,7 @@ def test_large_file_detect(monkeypatch, default_raw, inline_executor_fast):
     assert not load_called
 
 
+@pytest.mark.skipif(not HAVE_CSR_TESTDATA, reason="need raw CSR testdata")
 def test_num_partitions(lt_ctx):
     ds = lt_ctx.load(
         "raw_csr",

--- a/tests/io/datasets/test_raw_csr.py
+++ b/tests/io/datasets/test_raw_csr.py
@@ -464,3 +464,12 @@ def test_large_file_detect(monkeypatch, default_raw, inline_executor_fast):
     detects = RawCSRDataSet.detect_params(filepath, inline_executor_fast)
     assert not detects
     assert not load_called
+
+
+def test_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "raw_csr",
+        path=RAW_CSR_TESTDATA_PATH,
+        num_partitions=129,
+    )
+    assert len(list(ds.get_partitions())) == 129

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -43,9 +43,9 @@ def default_seq(lt_ctx):
         path=SEQ_TESTDATA_PATH,
         nav_shape=nav_shape,
         io_backend=MMapBackend(),
+        num_partitions=4,
     )
 
-    ds.set_num_cores(4)
     assert tuple(ds.shape) == (8, 8, 128, 128)
     return ds
 
@@ -59,9 +59,9 @@ def buffered_seq(lt_ctx):
         path=SEQ_TESTDATA_PATH,
         nav_shape=nav_shape,
         io_backend=BufferedBackend(),
+        num_partitions=4,
     )
 
-    ds.set_num_cores(4)
     return ds
 
 
@@ -74,9 +74,9 @@ def direct_seq(lt_ctx):
         path=SEQ_TESTDATA_PATH,
         nav_shape=nav_shape,
         io_backend=DirectBackend(),
+        num_partitions=4,
     )
 
-    ds.set_num_cores(4)
     return ds
 
 
@@ -114,9 +114,9 @@ def test_positive_sync_offset(default_seq, lt_ctx):
     sync_offset = 2
 
     ds_with_offset = SEQDataSet(
-        path=SEQ_TESTDATA_PATH, nav_shape=(8, 8), sync_offset=sync_offset
+        path=SEQ_TESTDATA_PATH, nav_shape=(8, 8), sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -448,9 +448,9 @@ def test_negative_sync_offset(default_seq, lt_ctx):
     sync_offset = -2
 
     ds_with_offset = SEQDataSet(
-        path=SEQ_TESTDATA_PATH, nav_shape=(8, 8), sync_offset=sync_offset
+        path=SEQ_TESTDATA_PATH, nav_shape=(8, 8), sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -493,8 +493,11 @@ def test_negative_sync_offset(default_seq, lt_ctx):
 def test_missing_frames(lt_ctx):
     nav_shape = (16, 8)
 
-    ds = SEQDataSet(path=SEQ_TESTDATA_PATH, nav_shape=nav_shape)
-    ds.set_num_cores(4)
+    ds = SEQDataSet(
+        path=SEQ_TESTDATA_PATH,
+        nav_shape=nav_shape,
+        num_partitions=4,
+    )
     ds = ds.initialize(lt_ctx.executor)
     ds.check_valid()
 
@@ -525,9 +528,11 @@ def test_missing_data_with_positive_sync_offset(lt_ctx):
     sync_offset = 8
 
     ds = SEQDataSet(
-        path=SEQ_TESTDATA_PATH, nav_shape=nav_shape, sync_offset=sync_offset
+        path=SEQ_TESTDATA_PATH,
+        nav_shape=nav_shape,
+        sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     ds = ds.initialize(lt_ctx.executor)
 
     tileshape = Shape(
@@ -555,9 +560,11 @@ def test_missing_data_with_negative_sync_offset(lt_ctx):
     sync_offset = -8
 
     ds = SEQDataSet(
-        path=SEQ_TESTDATA_PATH, nav_shape=nav_shape, sync_offset=sync_offset
+        path=SEQ_TESTDATA_PATH,
+        nav_shape=nav_shape,
+        sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     ds = ds.initialize(lt_ctx.executor)
 
     tileshape = Shape(
@@ -583,8 +590,11 @@ def test_missing_data_with_negative_sync_offset(lt_ctx):
 def test_too_many_frames(lt_ctx):
     nav_shape = (4, 8)
 
-    ds = SEQDataSet(path=SEQ_TESTDATA_PATH, nav_shape=nav_shape)
-    ds.set_num_cores(4)
+    ds = SEQDataSet(
+        path=SEQ_TESTDATA_PATH,
+        nav_shape=nav_shape,
+        num_partitions=4,
+    )
     ds = ds.initialize(lt_ctx.executor)
     ds.check_valid()
 

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -858,6 +858,7 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
         ds_params_tester(*args, **params)
 
 
+@needsdata
 def test_no_num_partitions(lt_ctx):
     nav_shape = (8, 8)
     ds = lt_ctx.load(

--- a/tests/io/datasets/test_seq.py
+++ b/tests/io/datasets/test_seq.py
@@ -856,3 +856,13 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
         if "nav_shape" not in params:
             params['nav_shape'] = (8, 8)
         ds_params_tester(*args, **params)
+
+
+def test_no_num_partitions(lt_ctx):
+    nav_shape = (8, 8)
+    ds = lt_ctx.load(
+        "seq",
+        path=SEQ_TESTDATA_PATH,
+        nav_shape=nav_shape,
+    )
+    lt_ctx.run_udf(dataset=ds, udf=SumSigUDF())

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -415,3 +415,11 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
     args = ("ser", SER_TESTDATA_PATH)
     for params in standard_bad_ds_params:
         ds_params_tester(*args, **params)
+
+
+def test_no_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "ser",
+        path=SER_TESTDATA_PATH,
+    )
+    lt_ctx.run_udf(dataset=ds, udf=SumSigUDF())

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -30,8 +30,7 @@ pytestmark = pytest.mark.skipif(not HAVE_SER_TESTDATA, reason="need SER testdata
 
 @pytest.fixture
 def default_ser(lt_ctx):
-    ds = SERDataSet(path=SER_TESTDATA_PATH)
-    ds.set_num_cores(4)
+    ds = SERDataSet(path=SER_TESTDATA_PATH, num_partitions=4)
     ds = ds.initialize(lt_ctx.executor)
     assert tuple(ds.shape) == (8, 35, 512, 512)
     return ds
@@ -84,11 +83,10 @@ def test_comparison_roi(default_ser, default_ser_raw, lt_ctx_fast):
     ),
 )
 def test_roi(lt_ctx, as_sparse):
-    ds = lt_ctx.load("ser", path=SER_TESTDATA_PATH)
+    ds = lt_ctx.load("ser", path=SER_TESTDATA_PATH, num_partitions=2)
     roi = np.zeros(ds.shape.nav, dtype=bool)
     roi[0, 1] = True
 
-    ds.set_num_cores(2)
     parts = ds.get_partitions()
 
     p = next(parts)
@@ -155,9 +153,9 @@ def test_positive_sync_offset(default_ser, lt_ctx):
     sync_offset = 2
 
     ds_with_offset = SERDataSet(
-        path=SER_TESTDATA_PATH, sync_offset=sync_offset
+        path=SER_TESTDATA_PATH, sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -200,9 +198,9 @@ def test_negative_sync_offset(default_ser, lt_ctx):
     sync_offset = -2
 
     ds_with_offset = SERDataSet(
-        path=SER_TESTDATA_PATH, sync_offset=sync_offset
+        path=SER_TESTDATA_PATH, sync_offset=sync_offset,
+        num_partitions=4,
     )
-    ds_with_offset.set_num_cores(4)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -279,8 +277,11 @@ def test_negative_sync_offset_with_roi(default_ser, lt_ctx):
 def test_missing_frames(lt_ctx):
     nav_shape = (10, 35)
 
-    ds = SERDataSet(path=SER_TESTDATA_PATH, nav_shape=nav_shape)
-    ds.set_num_cores(4)
+    ds = SERDataSet(
+        path=SER_TESTDATA_PATH,
+        nav_shape=nav_shape,
+        num_partitions=4,
+    )
     ds = ds.initialize(lt_ctx.executor)
 
     tileshape = Shape(
@@ -307,8 +308,11 @@ def test_missing_frames(lt_ctx):
 def test_too_many_frames(lt_ctx):
     nav_shape = (7, 35)
 
-    ds = SERDataSet(path=SER_TESTDATA_PATH, nav_shape=nav_shape)
-    ds.set_num_cores(4)
+    ds = SERDataSet(
+        path=SER_TESTDATA_PATH,
+        nav_shape=nav_shape,
+        num_partitions=4,
+    )
     ds = ds.initialize(lt_ctx.executor)
 
     tileshape = Shape(

--- a/tests/io/datasets/test_tvips.py
+++ b/tests/io/datasets/test_tvips.py
@@ -76,8 +76,8 @@ def default_tvips(lt_ctx):
         path=TVIPS_TESTDATA_PATH,
         nav_shape=nav_shape,
         io_backend=MMapBackend(),
+        num_partitions=4,
     )
-    ds.set_num_cores(4)
     return ds
 
 
@@ -142,9 +142,9 @@ def test_positive_sync_offset(default_tvips, lt_ctx):
     sync_offset = 2
 
     ds_with_offset = TVIPSDataSet(
-        path=TVIPS_TESTDATA_PATH, sync_offset=sync_offset
+        path=TVIPS_TESTDATA_PATH, sync_offset=sync_offset,
+        num_partitions=2,
     )
-    ds_with_offset.set_num_cores(2)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 
@@ -191,9 +191,9 @@ def test_negative_sync_offset(default_tvips, lt_ctx):
     sync_offset = -2
 
     ds_with_offset = TVIPSDataSet(
-        path=TVIPS_TESTDATA_PATH, sync_offset=sync_offset
+        path=TVIPS_TESTDATA_PATH, sync_offset=sync_offset,
+        num_partitions=2,
     )
-    ds_with_offset.set_num_cores(2)
     ds_with_offset = ds_with_offset.initialize(lt_ctx.executor)
     ds_with_offset.check_valid()
 

--- a/tests/io/datasets/test_tvips.py
+++ b/tests/io/datasets/test_tvips.py
@@ -462,3 +462,11 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
     args = ("tvips", TVIPS_TESTDATA_PATH)
     for params in standard_bad_ds_params:
         ds_params_tester(*args, **params)
+
+
+def test_no_num_partitions(lt_ctx):
+    ds = lt_ctx.load(
+        "tvips",
+        path=TVIPS_TESTDATA_PATH,
+    )
+    lt_ctx.run_udf(dataset=ds, udf=SumSigUDF())

--- a/tests/io/datasets/test_tvips.py
+++ b/tests/io/datasets/test_tvips.py
@@ -464,6 +464,7 @@ def test_bad_params(ds_params_tester, standard_bad_ds_params):
         ds_params_tester(*args, **params)
 
 
+@needsdata
 def test_no_num_partitions(lt_ctx):
     ds = lt_ctx.load(
         "tvips",

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -35,10 +35,12 @@ def test_sweep_stackheight():
 
 def test_num_part_larger_than_num_frames():
     shape = Shape((1, 1, 256, 256), sig_dims=2)
-    slice_iter = Partition.make_slices(shape=shape, num_partitions=2)
-    next(slice_iter)
-    with pytest.raises(StopIteration):
+
+    with pytest.warns(RuntimeWarning):
+        slice_iter = Partition.make_slices(shape=shape, num_partitions=2)
         next(slice_iter)
+        with pytest.raises(StopIteration):
+            next(slice_iter)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In case a `DataSet` has less frames than partitions (i.e. workers), we previously combined the frames into a single partition. This is a performance issue if there is a lot of work per-frame. Instead, create one partition per frame so we get more parallelization.

Also add a manual override in case the automatically chosen number of partition is inappropriate.

See #1701 for some initial discussion and other options.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
