### PR TITLE
Add a helper for generating ROIs from slices

### DIFF
--- a/docs/source/changelog/features/roi-helper.rst
+++ b/docs/source/changelog/features/roi-helper.rst
@@ -1,0 +1,4 @@
+[Feature] Add a helper for making ROIs from slices
+==================================================
+* This is a shortcut to generate ROIs from any numpy-supported slicing (:pr:`1704`).
+

--- a/docs/source/udf/basic.rst
+++ b/docs/source/udf/basic.rst
@@ -542,9 +542,9 @@ run your UDF on a selected subset of data. :code:`roi` can be specified in sever
   This allows quick specification of a small number of pixels to include or exclude
   from the analysis.
 - a NumPy array containing a bool mask, having the shape of the navigation
-  axes of the dataset.
+  axes of the dataset. This can also be created from a slice using :attr:`~libertem.io.dataset.DataSet.roi`.
 - any :code:`scipy.sparse` matrix or array or :code:`pydata.sparse.SparseArray` format,
-  again having the same shape as the naivgation axes of the dataset
+  again having the same shape as the navigation axes of the dataset
 
 For example, to process a random subset of a 4D-STEM dataset:
    
@@ -556,6 +556,13 @@ For example, to process a random subset of a 4D-STEM dataset:
    # and two navigation dimensions, `dataset.shape.nav`
    # translates to `(14, 14)`.
    roi = np.random.choice(a=[False, True], size=dataset.shape.nav)
+   ctx.run_udf(udf=udf, dataset=dataset, roi=roi)
+
+Or, to select a specific slice:
+
+.. testcode:: run
+
+   roi = dataset.roi[3:7, 9:12]
    ctx.run_udf(udf=udf, dataset=dataset, roi=roi)
 
 Note that the result array only contains values for the selected indices, all

--- a/src/libertem/api.py
+++ b/src/libertem/api.py
@@ -966,8 +966,7 @@ class Context:
         Running a UDF on a subset of data:
 
         >>> from libertem.udf.sumsigudf import SumSigUDF
-        >>> roi = np.zeros(dataset.shape.nav, dtype=bool)
-        >>> roi[0, 0] = True
+        >>> roi = dataset.roi[0, 0]
         >>> result = ctx.run_udf(dataset=dataset, udf=SumSigUDF(), roi=roi)
         >>> # to get the full navigation-shaped results, with NaNs where the `roi` was False:
         >>> np.array(result["intensity"]).shape

--- a/src/libertem/io/dataset/base/dataset.py
+++ b/src/libertem/io/dataset/base/dataset.py
@@ -19,6 +19,16 @@ if typing.TYPE_CHECKING:
     from numpy import typing as nt
 
 
+class RoiHelper:
+    def __init__(self, ds):
+        self._ds = ds
+
+    def __getitem__(self, k):
+        roi = np.zeros(self._ds.shape.nav, dtype=bool)
+        roi[k] = True
+        return roi
+
+
 class DataSet:
     # The default partition size in bytes
     MAX_PARTITION_SIZE = 512*1024*1024
@@ -31,6 +41,7 @@ class DataSet:
         self._nav_shape_product = 0
         self._io_backend = io_backend
         self._meta: Optional[DataSetMeta] = None
+        self._roi_helper = RoiHelper(ds=self)
 
     def initialize(self, executor) -> "DataSet":
         """
@@ -183,6 +194,10 @@ class DataSet:
         a list of dicts itself. Subclasses should override this method.
         """
         return []
+
+    @property
+    def roi(self):
+        return self._roi_helper
 
     def partition_shape(
         self,

--- a/src/libertem/udf/raw.py
+++ b/src/libertem/udf/raw.py
@@ -20,8 +20,7 @@ class PickUDF(UDF):
     Examples
     --------
     >>> udf = PickUDF()
-    >>> roi = np.zeros(dataset.shape.nav, dtype=bool)
-    >>> roi[0] = True
+    >>> roi = dataset.roi[0]
     >>> result = ctx.run_udf(dataset=dataset, udf=udf, roi=roi)
     >>> result["intensity"].raw_data[0].shape
     (32, 32)

--- a/tests/io/datasets/test_helpers.py
+++ b/tests/io/datasets/test_helpers.py
@@ -1,0 +1,18 @@
+import pytest
+import numpy as np
+
+@pytest.mark.parametrize(
+    "slice_", [
+        np.s_[0],
+        np.s_[5, 5],
+        np.s_[0:5],
+        np.s_[0:5, 2:7],
+    ]
+)
+def test_roi_helper(default_raw, slice_):
+    ref_roi = np.zeros(default_raw.shape.nav, dtype=bool)
+    ref_roi[slice_] = True
+    assert np.allclose(
+        default_raw.roi[slice_],
+        ref_roi,
+    )

--- a/tests/io/datasets/test_helpers.py
+++ b/tests/io/datasets/test_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 
+
 @pytest.mark.parametrize(
     "slice_", [
         np.s_[0],


### PR DESCRIPTION
Usage:

```python
ctx.run_udf(dataset=ds, udf=SumUDF(), roi=ds.roi[0:7, 12:25])  # or any other numpy-supported slicing
```

Means you don't need to manually make a bool array etc. anymore if you want to slice nav in any of the numpy-supported slicing ways.

Feel free to bikeshed the name, haven't put much thought into it.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
