### PR TITLE
Fix numerical instability

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -125,7 +125,7 @@ def empty_hdf5(tmpdir_factory):
 
 @pytest.fixture(scope='session')
 def hdf5_4d_data():
-    data = np.random.randn(2, 10, 26, 26).astype("float32")
+    data = np.random.random((2, 10, 26, 26)).astype("float32")
     yield data
 
 

--- a/tests/analysis/test_analysis_disk.py
+++ b/tests/analysis/test_analysis_disk.py
@@ -1,9 +1,7 @@
-import numpy as np
+from numpy.testing import assert_allclose
 from libertem.analysis.disk import DiskMaskAnalysis
-import pytest
 
 
-@pytest.mark.xfail
 def test_compare_hdf5_result_with_raw_result(
     lt_ctx, hdf5_same_data_4d, raw_same_dataset_4d
 ):
@@ -24,4 +22,4 @@ def test_compare_hdf5_result_with_raw_result(
     result_raw = lt_ctx.run(analysis_raw)
     result_raw = result_raw['intensity'].raw_data
 
-    assert not np.any(np.abs(result_hdf5 - result_raw))
+    assert_allclose(result_hdf5, result_raw, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
Closes #880

The random data from `np.random.randn` is centered around 0, meaning we amplify numerical errors when we sum up. Switching to `np.random.random` and setting usual error bounds fixes the issue.

Switching to float64 also fixed the instability in tests.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
