### PR TITLE
Use more sparseconverter

### DIFF
--- a/src/libertem/common/sparse.py
+++ b/src/libertem/common/sparse.py
@@ -10,12 +10,11 @@ if TYPE_CHECKING:
 
 
 def to_dense(a):
-    if isinstance(a, sparse.SparseArray):
-        return a.todense()
-    elif sp.issparse(a):
-        return a.toarray()
-    else:
+    # If unsupported by sparseconverter
+    if sparseconverter.get_backend(a) is None:
         return np.array(a)
+    else:
+        return sparseconverter.for_backend(a, sparseconverter.NUMPY)
 
 
 def to_sparse(a, shape: Optional[Union['Shape', tuple[int, ...]]] = None):


### PR DESCRIPTION
Closes #1373

The rest is a bit specific and would require re-engineering the MaskContainer, ApplyMasksEngine and their use.

Most transition to sparseconverter was already done when fixing the COO coordinate deprecation in #1699.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [N/A] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
