### PR TITLE
Try to make the scatter tests more robust

### DIFF
--- a/src/libertem/executor/concurrent.py
+++ b/src/libertem/executor/concurrent.py
@@ -119,6 +119,7 @@ class ConcurrentJobExecutor(BaseJobExecutor):
             self._futures[cancel_id].append(future)
 
         with task_comm_handler.monitor(msg_queue):
+            as_completed = None
             try:
                 as_completed = concurrent.futures.as_completed(self._futures[cancel_id])
                 for future in as_completed:
@@ -132,6 +133,8 @@ class ConcurrentJobExecutor(BaseJobExecutor):
             finally:
                 if cancel_id in self._futures:
                     del self._futures[cancel_id]
+                if as_completed is not None:
+                    as_completed.close()
 
     def cancel(self, cancel_id):
         if cancel_id in self._futures:


### PR DESCRIPTION
They were flaky in some of the recent runs, and this PR hopefully resolves that.

* Don't delay the first two tasks, such that it's highly likely they return after the first `handle_task` call, meaning something is yielded and the test code as a change to submit the parameter changes early
* Terminate the test case as soon as the condition is hit, meaning we can add many more tasks without a performance hit in the common case, and in other cases, we make it more likely the test case succeeds, even if it takes a bit longer
* Fix the concurrent executor to actually support being cancelled in the middle of `run_tasks`

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
