### PR TITLE
Find existing deposition by concept ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       LT_RELEASE_UPLOAD_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LT_RELEASE_UPLOAD_PYPI_PASSWORD: ${{ secrets.LT_RELEASE_UPLOAD_PYPI_PASSWORD }}
       LT_RELEASE_UPLOAD_ZENODO_TOKEN: ${{ secrets.LT_RELEASE_UPLOAD_ZENODO_TOKEN }}
-      LT_RELEASE_UPLOAD_ZENODO_PARENT: ${{ secrets.LT_RELEASE_UPLOAD_ZENODO_PARENT }}
+      LT_RELEASE_UPLOAD_ZENODO_CONCEPT: ${{ secrets.LT_RELEASE_UPLOAD_ZENODO_CONCEPT }}
     steps:
       - run: sudo apt-get install -y fuse
       - uses: actions/checkout@v4

--- a/scripts/release
+++ b/scripts/release
@@ -304,7 +304,7 @@ def get_archive(tag):
         yield full_fn
 
 
-def upload_to_zenodo(verbose, parent, token):
+def upload_to_zenodo(verbose, concept, token):
     """
     Upload wheel, sdist and repo archive to zenodo. Only works if
     there is a matching GitHub release already created.
@@ -330,7 +330,7 @@ def upload_to_zenodo(verbose, parent, token):
             "python", join(HERE, "zenodo_upload"),
             "-v",
             "--url=%s" % url,
-            "--parent=%s" % parent,
+            "--concept=%s" % concept,
             "--mask-zenodo-exception",
             wheel,
             sdist,
@@ -529,11 +529,11 @@ def is_rc(ctx):
               help='Github token for creating releases')
 @click.option('--zenodo-token', type=str, show_envvar=True,
               help='Zenodo production token for final release upload')
-@click.option('--zenodo-parent', type=str, show_envvar=True,
-              help='Zenodo production parent deposition id')
+@click.option('--zenodo-concept', type=str, show_envvar=True,
+              help='Zenodo production deposition concept id')
 @click.pass_context
 def upload(ctx, dry_run, build_appimage, pypi_user, pypi_password,
-           token, zenodo_token, zenodo_parent):
+           token, zenodo_token, zenodo_concept):
     """
     prepare, build and upload to github, zenodo and pypi
     (if release candidate, to the test instance(s))
@@ -593,7 +593,7 @@ def upload(ctx, dry_run, build_appimage, pypi_user, pypi_password,
 
     if not dry_run and (is_release or is_rc):
         upload_to_zenodo(verbose=ctx.obj['verbose'],
-                         parent=zenodo_parent,
+                         concept=zenodo_concept,
                          token=zenodo_token)
 
 

--- a/scripts/zenodo_upload
+++ b/scripts/zenodo_upload
@@ -370,12 +370,12 @@ def make_data():
 
 
 @click.command()
-@click.option('--parent', default="264899")
+@click.option('--concept', default="260887")
 @click.option('--url', default='https://sandbox.zenodo.org/api/')
 @click.option('--verbose', '-v', is_flag=True)
 @click.option('--mask-zenodo-exception', is_flag=True)
 @click.argument('files', nargs=-1, required=True, type=click.File())
-def main(files, parent, url, verbose, mask_zenodo_exception):
+def main(files, concept, url, verbose, mask_zenodo_exception):
     try:
         # raise ZenodoException("Test")
         global BASE_URL
@@ -384,17 +384,34 @@ def main(files, parent, url, verbose, mask_zenodo_exception):
         global VERBOSE
         VERBOSE = verbose
 
-        try:
-            log("Creating new version of deposition %s..." % parent)
-            r = new_version(parent_id=parent)
-            prettylog(r)
-        # Above will fail for very first draft
-        except ZenodoException:
-            log("Loading initial draft of deposition %s..." % parent)
-            r = get_deposition(deposition_id=parent)
-            prettylog(r)
+        depositions = list_depositions().json()
+        log(
+            "Found the following depositions: "
+            f"{[(d['id'], d['title'], d['conceptrecid']) for d in depositions]}"
+        )
+        deposition_id = None
+        submitted = None
+        n_found = 0
 
-        deposition_id = get_latest_draft(r)
+        for deposition in depositions:
+            if deposition['conceptrecid'] == concept:
+                deposition_id = deposition['id']
+                submitted = deposition['submitted']
+                log(f"found {deposition_id} in state {deposition['state']}")
+                n_found += 1
+
+        if deposition_id is None or submitted is None:
+            raise ZenodoException("Didn't find a record matching the concept ID", concept)
+
+        if n_found != 1:
+            raise ZenodoException(f"Found {n_found} matching records, expected exactly one")
+
+        if submitted:
+            log("Creating new version of deposition %s..." % deposition_id)
+            r = new_version(parent_id=deposition_id)
+            prettylog(r)
+            deposition_id = r.json()['id']
+
         log("Updating draft deposition %s..." % deposition_id)
         r = update_deposition(deposition_id=deposition_id, data=make_data())
         prettylog(r)


### PR DESCRIPTION
Unfortunately it is no longer possible to find a draft in the previous way. Instead the script now lists all depositions and matches them by concept ID to find the right one.

Closes #1645 

Note: I've already added the LT_RELEASE_UPLOAD_ZENODO_CONCEPT variable to the repo.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)


## Reviewer Checklist:

* [N/A] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
