### PR TITLE
Remove pins for NumPy and pint

### DIFF
--- a/tests/io/datasets/test_blo.py
+++ b/tests/io/datasets/test_blo.py
@@ -19,12 +19,8 @@ from libertem.udf.raw import PickUDF
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    # FIXME: rsciio/pint is not numpy2 compatible yet
-    if int(np.version.version.split('.')[0]) < 2:
-        import rsciio
-        import rsciio.blockfile
-    else:
-        rsciio = None
+    import rsciio
+    import rsciio.blockfile
 except ModuleNotFoundError:
     rsciio = None
 

--- a/tests/io/datasets/test_dm.py
+++ b/tests/io/datasets/test_dm.py
@@ -18,11 +18,7 @@ from libertem.io.dataset.base import (
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    # FIXME: rsciio/pint is not numpy2 compatible yet
-    if int(np.version.version.split('.')[0]) < 2:
-        import hyperspy.api as hs
-    else:
-        hs = None
+    import hyperspy.api as hs
 except ModuleNotFoundError:
     hs = None
 

--- a/tests/io/datasets/test_mib.py
+++ b/tests/io/datasets/test_mib.py
@@ -23,11 +23,7 @@ from libertem.io.dataset.base import (
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    # FIXME: rsciio/pint is not numpy2 compatible yet
-    if int(np.version.version.split('.')[0]) < 2:
-        import rsciio
-    else:
-        rsciio = None
+    import rsciio
 except ModuleNotFoundError:
     rsciio = None
 

--- a/tests/io/datasets/test_ser.py
+++ b/tests/io/datasets/test_ser.py
@@ -13,11 +13,7 @@ from libertem.common.buffers import reshaped_view
 from utils import dataset_correction_verification, get_testdata_path, ValidationUDF, roi_as_sparse
 
 try:
-    # FIXME: rsciio/pint is not numpy2 compatible yet
-    if int(np.version.version.split('.')[0]) < 2:
-        import hyperspy.api as hs
-    else:
-        hs = None
+    import hyperspy.api as hs
 except ModuleNotFoundError:
     hs = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,7 @@ deps=
     py{311}-data: numba>=0.57
     py{312}-data: numba>=0.59
     py{313}-data: numba>=0.61
+    numpy<2;python_version < '3.10'
     hyperspy
     ipywidgets
     pyxem>=0.17

--- a/tox.ini
+++ b/tox.ini
@@ -69,13 +69,11 @@ deps=
     py{312}-data: numba>=0.59
     py{313}-data: numba>=0.61
     hyperspy
-    py{311,312,313}-data,py{311,312,313}-data-cuda{101,102,110,11x,12x}: orix
     stemtool
     mrcfile
-    py{311,312,313}-data,py{311,312,313}-data-cuda{101,102,110,11x,12x}: rosettasciio!=0.8.0
+    rosettasciio!=0.8.0
     pims
     scikit-image
-    pint<0.20
     py{39,310,311,312,313}-data-cuda101: cupy-cuda101
     py{39,310,311,312,313}-data-cuda102: cupy-cuda102
     py{39,310,311,312,313}-data-cuda110: cupy-cuda110
@@ -91,7 +89,6 @@ commands=
     pytest --durations=10 --cov=libertem --cov-report=term --cov-report=html --cov-report=xml --cov-config=pyproject.toml --junitxml=junit.xml tests/analysis/test_analysis_com.py tests/io/datasets tests/executor/test_functional.py {posargs}
 
 [testenv:notebooks,notebooks-cuda{101,102,110,11x,12x}]
-# need to constrain package deps, as we support numpy 2.x, but pint on Python 3.9 doesn't
 constrain_package_deps=true
 deps=
     -rtest_requirements.txt
@@ -108,8 +105,6 @@ deps=
     pyxem>=0.17
     rosettasciio!=0.8.0
     scikit-image
-    pint<0.20
-    numpy<2
     notebooks-cuda101: cupy-cuda101
     notebooks-cuda102: cupy-cuda102
     notebooks-cuda110: cupy-cuda110
@@ -200,7 +195,6 @@ commands=
     # cat docs/build/html/output.txt
 deps=
     setuptools
-    numpy<2
     -rdocs_requirements.txt
 skipsdist=True
 whitelist_externals=


### PR DESCRIPTION
It seems upstream has sorted this out?

Refs https://github.com/LiberTEM/LiberTEM/issues/1705#issuecomment-2915508963

Run CI pipeline to verify

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
