### PR TITLE
Increase timeout for `test_libertem_server_cli_startup`

### DIFF
--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -69,8 +69,8 @@ async def test_libertem_server_cli_startup(http_client):
             if p.returncode is None:
                 p.send_signal(CTRL_C)
 
-            # wait for the process to stop, but max. 1 second:
-            ret = await asyncio.wait_for(p.wait(), 1)
+            # wait for the process to stop, but max. 30 second:
+            ret = await asyncio.wait_for(p.wait(), 30)
 
             # in unix, minus signal number is returned if the process was killed:
             assert ret in (0, -CTRL_C)


### PR DESCRIPTION
Usually (in the last 14? months) the process dies inside a one-second window, but it now happened once that the deadline was missed, so increase the timeout to 30 seconds. If the CI runner is slow, we can't do much, it's just important that we eventually fail if the process doesn't die here.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
