### PR TITLE
Bandaid for weird test failure; hopefully fix tox env name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,30 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-14]
+        python:
+          - version: "3.9"
+            toxenv: py39
+          - version: "3.10"
+            toxenv: py310
+          - version: "3.11"
+            toxenv: py311
+          - version: "3.12"
+            toxenv: py312
+          - version: "3.13"
+            toxenv: py313
         exclude:
           - os: macos-14
-            python_version: "3.9"
+            python:
+              version: "3.9"
+              toxenv: py39
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Choose Python version ${{ matrix.python_version }}
+      - name: Choose Python version ${{ matrix.python.version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '${{ matrix.python_version }}'
+          python-version: '${{ matrix.python.version }}'
           cache: 'pip'
       - run: |
            [[ "${{ matrix.os }}" = "ubuntu-latest" ]] && sudo apt-get install -y libcap-dev || true
@@ -36,7 +48,7 @@ jobs:
       - name: install tox (with uv)
         run: python3 -m pip install tox tox-uv
       - name: run tox
-        run: tox -e 'py${{ matrix.python_version }}'
+        run: tox -e '${{ matrix.python.toxenv }}'
       - name: submit code coverage
         uses: codecov/codecov-action@v5
         env:

--- a/.github/workflows/thorough.yml
+++ b/.github/workflows/thorough.yml
@@ -10,16 +10,30 @@ jobs:
       matrix:
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-14]
+        python:
+          - version: "3.9"
+            toxenv: py39
+          - version: "3.10"
+            toxenv: py310
+          - version: "3.11"
+            toxenv: py311
+          - version: "3.12"
+            toxenv: py312
+          - version: "3.13"
+            toxenv: py313
         exclude:
           - os: macos-14
-            python_version: "3.9"
+            python:
+              version: "3.9"
+              toxenv: py39
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Choose Python version ${{ matrix.python_version }}
+      - name: Choose Python version ${{ matrix.python.version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '${{ matrix.python_version }}'
+          python-version: '${{ matrix.python.version }}'
           cache: 'pip'
       - run: |
            [[ "${{ matrix.os }}" = "ubuntu-latest" ]] && sudo apt-get install -y libcap-dev || true
@@ -27,4 +41,4 @@ jobs:
       - name: install tox (with uv)
         run: python3 -m pip install tox tox-uv
       - name: run tox
-        run: tox -e 'py${{ matrix.python_version }}' -- tests/ -m "not dist"
+        run: tox -e '${{ matrix.python.toxenv }}' -- tests/ -m "not dist"

--- a/conftest.py
+++ b/conftest.py
@@ -1029,8 +1029,7 @@ if sys.platform.startswith("win"):
                 return WindowsSelectorEventLoopPolicy()
 
 
-@pytest.fixture(scope='session')
-def local_cluster_url():
+def _local_cluster_url():
     """
     Shared dask cluster, can be used repeatedly by different executors.
 
@@ -1066,6 +1065,10 @@ def local_cluster_url():
             client.close()
 
         yield 'tcp://localhost:%d' % cluster_port
+
+
+local_cluster_url = pytest.fixture(scope='session')(_local_cluster_url)
+local_cluster_url_per_module = pytest.fixture(scope='module')(_local_cluster_url)
 
 
 @pytest.fixture(scope='function')

--- a/tests/server/test_startup.py
+++ b/tests/server/test_startup.py
@@ -126,10 +126,27 @@ async def test_cluster_connect_error(base_url, http_client, default_token):
         assert_msg(conn_resp, 'CLUSTER_CONN_ERROR', status='error')
 
 
+# FIXME: This runs with a fresh local cluster URL because of elusive test
+# failures under particular conditions:
+# * Coverage being collected
+# * Python 3.13
+# * "Some" tests ran before, for example:
+# pytest --cov=libertem --cov-config=pyproject.toml -v
+# tests/server/test_browse.py tests/server/test_browse.py
+# tests/server/test_startup.py::test_start_server
+# tests/server/test_startup.py::test_get_config
+# tests/server/test_startup.py::test_conn_is_disconnected
+# tests/server/test_startup.py::test_conn_connect_local
+# tests/server/test_startup.py::test_cluster_create_error
+# tests/server/test_startup.py::test_cluster_connect_error
+# tests/server/test_startup.py::test_initial_state_empty -m 'not dist'
+
+# To be re-checked in the future if the issue persists
 @pytest.mark.asyncio
 async def test_initial_state_empty(
-    default_raw, base_url, http_client, server_port, local_cluster_url, default_token,
+    default_raw, base_url, http_client, server_port, local_cluster_url_per_module, default_token,
 ):
+    local_cluster_url = local_cluster_url_per_module
     conn_url = f"{base_url}/api/config/connection/?token={default_token}"
     conn_details = {
         'connection': {


### PR DESCRIPTION
The test failed for "thorough", see details in diff and commit message.

Also try fix for tox env name. Let's see what GitHub makes of this!

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
