### PR TITLE
Add copy/dtype kwargs to `__array__` impls

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,4 @@ asyncio_mode = auto
 filterwarnings =
     error:coords should be an ndarray:DeprecationWarning
     error:overflow encountered in scalar negative:RuntimeWarning
+    error:__array__ implementation doesn't accept a copy keyword:DeprecationWarning

--- a/src/libertem/common/analysis.py
+++ b/src/libertem/common/analysis.py
@@ -50,8 +50,8 @@ class AnalysisResult:
     def __repr__(self):
         return "<AnalysisResult: %s>" % self.key
 
-    def __array__(self):
-        return np.array(self.raw_data)
+    def __array__(self, copy=None, dtype=None):
+        return np.array(self.raw_data, copy=copy, dtype=dtype)
 
     def get_image(self, save_kwargs: Optional[dict] = None) -> BytesIO:
         from libertem.common.viz import encode_image

--- a/src/libertem/common/analysis.py
+++ b/src/libertem/common/analysis.py
@@ -5,6 +5,8 @@ from typing import (
 
 import numpy as np
 
+from .compat import copy_if_needed
+
 
 class AnalysisResult:
     """
@@ -50,7 +52,7 @@ class AnalysisResult:
     def __repr__(self):
         return "<AnalysisResult: %s>" % self.key
 
-    def __array__(self, copy=None, dtype=None):
+    def __array__(self, copy=copy_if_needed, dtype=None):
         return np.array(self.raw_data, copy=copy, dtype=dtype)
 
     def get_image(self, save_kwargs: Optional[dict] = None) -> BytesIO:

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -658,11 +658,11 @@ class BufferWrapper:
         """
         return self._where
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         """
         returns the "wrapped"/reshaped array, see above
         """
-        return self.data
+        return np.array(self.data, copy=copy, dtype=dtype)
 
     def allocate(self, lib=None):
         """

--- a/src/libertem/common/buffers.py
+++ b/src/libertem/common/buffers.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from libertem.common.math import prod, count_nonzero, flat_nonzero
 from libertem.common.slice import Slice, Shape
+from libertem.common.compat import copy_if_needed
 from .backend import get_use_cuda
 
 if TYPE_CHECKING:
@@ -658,7 +659,7 @@ class BufferWrapper:
         """
         return self._where
 
-    def __array__(self, dtype=None, copy=None):
+    def __array__(self, dtype=None, copy=copy_if_needed):
         """
         returns the "wrapped"/reshaped array, see above
         """

--- a/src/libertem/common/compat.py
+++ b/src/libertem/common/compat.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+import numpy as np
+
+# stolen from scipy:
+copy_if_needed: Optional[bool]
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    copy_if_needed = None
+elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
+    copy_if_needed = False
+else:
+    # 2.0.0 dev versions, handle cases where copy may or may not exist
+    try:
+        np.array([1]).__array__(copy=None)  # type: ignore[call-overload]
+        copy_if_needed = None
+    except TypeError:
+        copy_if_needed = False

--- a/src/libertem/executor/utils/dask_buffer.py
+++ b/src/libertem/executor/utils/dask_buffer.py
@@ -4,6 +4,7 @@ import numpy as np
 from ...common.math import prod
 from ...common.slice import Slice
 from ...common.buffers import BufferWrapper
+from ...common.compat import copy_if_needed
 from .dask_inplace import DaskInplaceWrapper
 
 
@@ -186,7 +187,7 @@ class DaskResultBufferWrapper(DaskPreallocBufferWrapper):
         result._valid_mask = buffer._valid_mask
         return result
 
-    def __array__(self, copy=None, dtype=None):
+    def __array__(self, copy=copy_if_needed, dtype=None):
         return super().__array__(copy=copy, dtype=dtype)
 
     @property

--- a/src/libertem/executor/utils/dask_buffer.py
+++ b/src/libertem/executor/utils/dask_buffer.py
@@ -186,8 +186,8 @@ class DaskResultBufferWrapper(DaskPreallocBufferWrapper):
         result._valid_mask = buffer._valid_mask
         return result
 
-    def __array__(self):
-        return super().__array__()
+    def __array__(self, copy=None, dtype=None):
+        return super().__array__(copy=copy, dtype=dtype)
 
     @property
     def raw_data(self):


### PR DESCRIPTION
See https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-data` passed
* [ ] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
