### PR TITLE
Include inverese operation to decompose transformation matrix

### DIFF
--- a/src/libertem/corrections/coordinates.py
+++ b/src/libertem/corrections/coordinates.py
@@ -52,3 +52,41 @@ def identity():
     .. versionadded:: 0.6.0
     '''
     return np.eye(2)
+
+
+def scale_rotate_flip_y(mat: np.ndarray):
+    '''
+    Deconstruct a matrix generated with scale() @ rotate() @ flip_y()
+    into the individual parameters
+    '''
+    scale_y = np.linalg.norm(mat[:, 0])
+    scale_x = np.linalg.norm(mat[:, 1])
+    if not np.allclose(scale_y, scale_x):
+        raise ValueError(f'y scale {scale_y} and x scale {scale_x} are different.')
+
+    scan_rot_flip = mat / scale_y
+    # 2D cross product
+    flip_factor = (
+        scan_rot_flip[0, 0] * scan_rot_flip[1, 1]
+        - scan_rot_flip[0, 1] * scan_rot_flip[1, 0]
+    )
+    # Make sure no scale or shear left
+    if not np.allclose(np.abs(flip_factor), 1.):
+        raise ValueError(
+            f'Contains shear: flip factor (2D cross product) is {flip_factor}.'
+        )
+    flip_y = bool(flip_factor < 0)
+    # undo flip_y
+    rot = scan_rot_flip.copy()
+    rot[:, 0] *= flip_factor
+
+    angle1 = np.arctan2(-rot[1, 0], rot[0, 0])
+    angle2 = np.arctan2(rot[0, 1], rot[1, 1])
+
+    # So far not reached in tests since inconsistencies are caught as shear before
+    if not np.allclose((np.sin(angle1), np.cos(angle1)), (np.sin(angle2), np.cos(angle2))):
+        raise ValueError(
+            f'Rotation angle 1 {angle1} and rotation angle 2 {angle2} are inconsistent.'
+        )
+
+    return (scale_y, angle1, flip_y)

--- a/tests/corrections/test_coordinates.py
+++ b/tests/corrections/test_coordinates.py
@@ -1,6 +1,8 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
+import pytest
+
 import libertem.corrections.coordinates as c
 from libertem.utils import rotate_deg
 
@@ -66,3 +68,58 @@ def test_chain():
     # Counter test: Make sure test is specific
     assert not np.allclose(r_y2, r_ywrong)
     assert not np.allclose(r_x2, r_xwrong)
+
+
+@pytest.mark.parametrize(
+    'scale', (-11, 0.023, 1, 17)
+)
+@pytest.mark.parametrize(
+    'rotate', (-23, -2*np.pi, -np.pi, 0, np.pi, 2*np.pi, 0.1234, -0.2345)
+)
+@pytest.mark.parametrize(
+    'flip_y', (False, True)
+)
+def test_deconstruct(scale, rotate, flip_y):
+    do_flip = c.flip_y() if flip_y else c.identity()
+    mat = c.scale(scale) @ c.rotate(rotate) @ do_flip
+    # A negative scale corresponds to a 180 degree rotation
+    if scale < 0:
+        rotate += np.pi
+        scale = np.abs(scale)
+
+    res_scale, res_rotate, res_flip = c.scale_rotate_flip_y(mat)
+    assert_allclose(res_scale, scale)
+    # Compare sinus and cosinus of angle instead of angle itself to avoid impact
+    # of numerical precision etc at the wrap-around points between negative and
+    # positive side
+    assert_allclose(np.sin(rotate), np.sin(res_rotate), atol=1e-7)
+    assert_allclose(np.cos(rotate), np.cos(res_rotate), atol=1e-7)
+    assert res_flip == flip_y
+
+
+@pytest.mark.parametrize(
+    'scale', (-11, 0.023, 1, 17)
+)
+@pytest.mark.parametrize(
+    'flip_y', (False, True)
+)
+def test_bad_rotate(scale, flip_y):
+    bad_rotate = np.array(((np.cos(0.123), np.sin(0.234)), (-np.sin(0.123), np.cos(0.234))))
+    do_flip = c.flip_y() if flip_y else c.identity()
+    mat = c.scale(scale) @ bad_rotate @ do_flip
+    with pytest.raises(ValueError, match='shear'):
+        res_scale, res_rotate, res_flip = c.scale_rotate_flip_y(mat)
+
+
+@pytest.mark.parametrize(
+    'rotate', (-23, -2*np.pi, -np.pi, 0, np.pi, 2*np.pi, 0.1234, -0.2345)
+)
+@pytest.mark.parametrize(
+    'flip_y', (False, True)
+)
+def test_bad_scale(rotate, flip_y):
+    bad_scale = np.array(((2, 0), (0, 3)))
+    do_flip = c.flip_y() if flip_y else c.identity()
+    mat = bad_scale @ c.rotate(rotate) @ do_flip
+    with pytest.raises(ValueError, match='scale'):
+        res_scale, res_rotate, res_flip = c.scale_rotate_flip_y(mat)


### PR DESCRIPTION
Invert a combination of scale, rotation and flip. Throw errors if the matrix contains other transformation such as non-uniform scale or shear.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases
* [ ] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [ ] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
