### PR TITLE
Windows translates the error string

### DIFF
--- a/tests/server/test_dataset.py
+++ b/tests/server/test_dataset.py
@@ -92,6 +92,7 @@ async def test_load_raw_fail(base_url, http_client, local_cluster_url, default_t
         assert (
             "No such file or directory" in resp_json['msg']
             or "The system cannot find the path specified" in resp_json['msg']
+            or "WinError 3" in resp_json['msg']
         )
 
 


### PR DESCRIPTION
`FAILED tests/server/test_dataset.py::test_load_raw_fail - assert ('No such file or directory' in "[WinError 3] Das System kann den angegebenen Pfad nicht finden: '/does/not/...`

I HOPE that the string `WinError 3` is present consistently.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [x] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases
* [N/A] I have included the [rebuilt production build of the client](https://libertem.github.io/LiberTEM/contributing.html?#building-the-client) (only if changes were made to the GUI)

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-data` passed
* [x] Only import code that is compatible with MIT license

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
